### PR TITLE
Remove tls conditions from source code

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -35,8 +35,6 @@ spec:
     # If enabled then the certificate from `che-git-self-signed-cert` config map
     # will be propagated to the Che components and provide particular configuration for Git.
     gitSelfSignedCert: false
-    # TLS mode for Che. It is not recommended to turn this off.
-    tlsSupport: true
     # protocol+hostname of a proxy server. Automatically added as JAVA_OPTS and https(s)_proxy
     # to Che server and workspaces containers
     proxyURL: ''

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -127,10 +127,8 @@ type CheClusterSpecServer struct {
 	// configuration for Git.
 	// +optional
 	GitSelfSignedCert bool `json:"gitSelfSignedCert"`
-	// Deprecated.
-	// Instructs the operator to deploy Che in TLS mode.
-	// This is enabled by default.
-	// Disabling TLS may cause malfunction of some Che components.
+	// Deprecated. The value of this flag is ignored.
+	// Operator always deploys Che in TLS mode.
 	// +optional
 	TlsSupport bool `json:"tlsSupport"`
 	// Public URL of the Devfile registry, that serves sample, ready-to-use devfiles.
@@ -401,8 +399,8 @@ type CheClusterSpecK8SOnly struct {
 	// NB: This drives the `is kubernetes.io/ingress.class` annotation on Che-related ingresses.
 	// +optional
 	IngressClass string `json:"ingressClass,omitempty"`
-	// Name of a secret that will be used to setup ingress TLS termination if TLS is enabled.
-	// See also the `tlsSupport` field.
+	// Name of a secret that will be used to setup ingress TLS termination.
+	// By default operator will look for `che-tls` secret.
 	// +optional
 	TlsSecretName string `json:"tlsSecretName,omitempty"`
 	// FSGroup the Che pod and Workspace pods containers should run in. Defaults to `1724`.

--- a/pkg/controller/che/che_controller_test.go
+++ b/pkg/controller/che/che_controller_test.go
@@ -168,7 +168,7 @@ func TestCheController(t *testing.T) {
 	}
 
 	// update CR and make sure Che configmap has been updated
-	cheCR.Spec.Server.TlsSupport = true
+	cheCR.Spec.Server.AllowUserDefinedWorkspaceNamespaces = true
 	if err := cl.Update(context.TODO(), cheCR); err != nil {
 		t.Error("Failed to update CheCluster custom resource")
 	}

--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -157,14 +157,9 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	}
 	defaultTargetNamespace := util.GetValue(cr.Spec.Server.WorkspaceNamespaceDefault, defaultTargetNamespaceDefault)
 	namespaceAllowUserDefined := strconv.FormatBool(cr.Spec.Server.AllowUserDefinedWorkspaceNamespaces)
-	tlsSupport := cr.Spec.Server.TlsSupport
-	protocol := "http"
-	wsprotocol := "ws"
-	if tlsSupport {
-		protocol = "https"
-		wsprotocol = "wss"
-		tls = "true"
-	}
+	protocol := "https"
+	wsprotocol := "wss"
+
 	proxyJavaOpts := ""
 	proxyUser := cr.Spec.Server.ProxyUser
 	proxyPassword := cr.Spec.Server.ProxyPassword
@@ -193,7 +188,7 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 
 	ingressDomain := cr.Spec.K8s.IngressDomain
 	tlsSecretName := cr.Spec.K8s.TlsSecretName
-	if tlsSupport && tlsSecretName == "" {
+	if tlsSecretName == "" {
 		tlsSecretName = "che-tls"
 	}
 	securityContextFsGroup := util.GetValue(cr.Spec.K8s.SecurityContextFsGroup, DefaultSecurityContextFsGroup)
@@ -240,8 +235,8 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 		WorkspacePvcStorageClassName:           workspacePvcStorageClassName,
 		PvcJobsImage:                           pvcJobsImage,
 		PreCreateSubPaths:                      preCreateSubPaths,
-		TlsSupport:                             tls,
-		K8STrustCerts:                          tls,
+		TlsSupport:                             "true",
+		K8STrustCerts:                          "true",
 		CheLogLevel:                            cheLogLevel,
 		OpenShiftIdentityProvider:              openShiftIdentityProviderId,
 		JavaOpts:                               DefaultJavaOpts + " " + proxyJavaOpts,

--- a/pkg/deploy/che_configmap_test.go
+++ b/pkg/deploy/che_configmap_test.go
@@ -26,7 +26,6 @@ func TestNewCheConfigMap(t *testing.T) {
 	// and creating a CR with all spec fields pre-populated
 	cr := &orgv1.CheCluster{}
 	cr.Spec.Server.CheHost = "myhostname.com"
-	cr.Spec.Server.TlsSupport = true
 	cr.Spec.Auth.OpenShiftoAuth = true
 	cheEnv := GetConfigMapData(cr)
 	testCm, _ := GetSpecConfigMap(cr, cheEnv, ClusterAPI{})
@@ -48,7 +47,6 @@ func TestNewCheConfigMap(t *testing.T) {
 func TestConfigMapOverride(t *testing.T) {
 	cr := &orgv1.CheCluster{}
 	cr.Spec.Server.CheHost = "myhostname.com"
-	cr.Spec.Server.TlsSupport = true
 	cr.Spec.Server.CustomCheProperties = map[string]string{
 		"CHE_WORKSPACE_NO_PROXY": "myproxy.myhostname.com",
 	}

--- a/pkg/deploy/route.go
+++ b/pkg/deploy/route.go
@@ -114,7 +114,6 @@ func GetClusterRoute(name string, namespace string, client runtimeClient.Client)
 
 // GetSpecRoute returns default configuration of a route in Che namespace.
 func GetSpecRoute(checluster *orgv1.CheCluster, name string, serviceName string, port int32, clusterAPI ClusterAPI) (*routev1.Route, error) {
-	tlsSupport := checluster.Spec.Server.TlsSupport
 	labels := GetLabels(checluster, DefaultCheFlavor(checluster))
 	weight := int32(100)
 
@@ -148,11 +147,9 @@ func GetSpecRoute(checluster *orgv1.CheCluster, name string, serviceName string,
 		},
 	}
 
-	if tlsSupport {
-		route.Spec.TLS = &routev1.TLSConfig{
-			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-			Termination:                   routev1.TLSTerminationEdge,
-		}
+	route.Spec.TLS = &routev1.TLSConfig{
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+		Termination:                   routev1.TLSTerminationEdge,
 	}
 
 	err := controllerutil.SetControllerReference(checluster, route, clusterAPI.Scheme)


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Removes tls support flag from source code which makes it impossible to deploy Eclipse Che without TLS any more.
`tlsSupport` fields is still present in Che custom resource, however it is only for backward compatibility and the flag has no effect any more.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17090

### Tests
Testing was done on CRC with the folowing scenario:
1. Deploy Eclipse Che without TLS support
2. Create and start a workspace
3. Stop the workspace
4. Update operator image
5. Wait until new operator reconcile
6. Import self-signed-certificate into browser (`chectl cacert:export` helpful here)
7. Open dashboard and start the workspace
8. Open Che-Theia (welcome webview works now), build and run an embedded project via a command

