### PR TITLE
Add ability to select platforms for community operator update PR

### DIFF
--- a/.github/workflows/release-community-operator-PRs.yml
+++ b/.github/workflows/release-community-operator-PRs.yml
@@ -7,6 +7,9 @@ on:
       forceflag:
         description: 'To update an existing PR, use -f or --force flag here'
         default: ''
+      platforms:
+        description: 'List platforms for which to create PRs, which could be \'openshift\', \'kubernetes\' or both
+        default: '\'kubernetes\' \'openshift\''  
   # trigger on commit to master branch of new CSVs, eg., https://github.com/eclipse/che-operator/pull/571/files
   push:
     branches: 
@@ -61,4 +64,4 @@ jobs:
           export QUAY_PASSWORD_K8S=${{ secrets.QUAY_ECLIPSE_CHE_OPERATOR_KUBERNETES_PASSWORD }}
           export QUAY_USERNAME_OS=${{ secrets.QUAY_ECLIPSE_CHE_OPERATOR_OPENSHIFT_USERNAME }}
           export QUAY_PASSWORD_OS=${{ secrets.QUAY_ECLIPSE_CHE_OPERATOR_OPENSHIFT_PASSWORD }}
-          ./make-release.sh nightly --update-nightly-olm-files --prepare-community-operators-update ${{ github.event.inputs.forceflag }}
+          ./make-release.sh nightly --update-nightly-olm-files --prepare-community-operators-update ${{ github.event.inputs.forceflag }} -p ${{ github.event.inputs.platforms }}

--- a/olm/prepare-community-operators-update.sh
+++ b/olm/prepare-community-operators-update.sh
@@ -14,6 +14,7 @@ set -e
 
 CURRENT_DIR=$(pwd)
 BASE_DIR=$(cd "$(dirname "$0")"; pwd)
+PLATFORMS="'kubernetes' 'openshift'"
 source "${BASE_DIR}/check-yq.sh"
 
 base_branch="master"
@@ -26,6 +27,7 @@ while [[ "$#" -gt 0 ]]; do
     '-u'|'--user') GITHUB_USER="$2"; shift 1;;
     '-t'|'--token') GITHUB_TOKEN="$2"; shift 1;;
     '-f'|'--force') FORCE="-f";;
+    '-p'|'--platform') PLATFORMS="$2";shift 1;;
     '-h'|'--help') usage;;
   esac
   shift 1
@@ -49,7 +51,7 @@ Options:
 "
 }
 
-for platform in 'kubernetes' 'openshift'
+for platform in $PLATFORMS
 do
   packageName="eclipse-che-preview-${platform}"
   echo


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

When generating the community operator PR update, you can now specify platforms for which to run it, which makes it possible to run just for either kubernetes, or openshift (by default it does for both platforms). Should be useful, if it needs to rerun them separately