### PR TITLE
Run dashboard as separate deployment

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -81,7 +81,8 @@ jobs:
         git reset HEAD --hard
         if [[ $(find . -not -path "./vendor/*" -name '*.go' -exec goimports -l {} \;) != "" ]]
         then
-          echo "not well formatted sources are found:"
+          echo "not well organized imports are found."
+          echo "execute `find . -not -path "./vendor/*" -name '*.go' -exec goimports -l {} \;` to fix the following:"
           find . -not -path "./vendor/*" -name '*.go' -exec goimports -l {} \;
           exit 1
         fi

--- a/deploy/crds/org_v1_che_crd-v1beta1.yaml
+++ b/deploy/crds/org_v1_che_crd-v1beta1.yaml
@@ -524,6 +524,32 @@ spec:
                     ConfigMap from other CR fields, the value defined in the `customCheProperties`
                     is used instead.
                   type: object
+                dashboardCpuLimit:
+                  description: Overrides the CPU limit used in the dashboard deployment.
+                    In cores. (500m = .5 cores). Default to 500m.
+                  type: string
+                dashboardCpuRequest:
+                  description: Overrides the CPU request used in the dashboard deployment.
+                    In cores. (500m = .5 cores). Default to 100m.
+                  type: string
+                dashboardImage:
+                  description: Overrides the container image used in the dashboard
+                    deployment. This includes the image tag. Omit it or leave it empty
+                    to use the default container image provided by the Operator.
+                  type: string
+                dashboardImagePullPolicy:
+                  description: Overrides the image pull policy used in the dashboard
+                    deployment. Default value is `Always` for `nightly` or `latest`
+                    images, and `IfNotPresent` in other cases.
+                  type: string
+                dashboardMemoryLimit:
+                  description: Overrides the memory limit used in the dashboard deployment.
+                    Defaults to 256Mi.
+                  type: string
+                dashboardMemoryRequest:
+                  description: Overrides the memory request used in the dashboard
+                    deployment. Defaults to 16Mi.
+                  type: string
                 devfileRegistryCpuLimit:
                   description: Overrides the CPU limit used in the devfile registry
                     deployment. In cores. (500m = .5 cores). Default to 500m.

--- a/deploy/crds/org_v1_che_crd.yaml
+++ b/deploy/crds/org_v1_che_crd.yaml
@@ -336,7 +336,7 @@ spec:
                       it will create a default KubernetesImagePuller object to be
                       managed by the Operator. When set to `false`, the KubernetesImagePuller
                       object will be deleted, and the Operator will be uninstalled,
-                      regardless of whether a spec is provided.
+                      regardless of whether a spec is provided. 
  Note that while
                       this the Operator and its behavior is community-supported, its
                       payload may be commercially-supported for pulling commercially-supported
@@ -537,6 +537,32 @@ spec:
                       generated in `che` ConfigMap from other CR fields, the value
                       defined in the `customCheProperties` is used instead.
                     type: object
+                  dashboardCpuLimit:
+                    description: Overrides the CPU limit used in the dashboard deployment.
+                      In cores. (500m = .5 cores). Default to 500m.
+                    type: string
+                  dashboardCpuRequest:
+                    description: Overrides the CPU request used in the dashboard deployment.
+                      In cores. (500m = .5 cores). Default to 100m.
+                    type: string
+                  dashboardImage:
+                    description: Overrides the container image used in the dashboard
+                      deployment. This includes the image tag. Omit it or leave it
+                      empty to use the default container image provided by the Operator.
+                    type: string
+                  dashboardImagePullPolicy:
+                    description: Overrides the image pull policy used in the dashboard
+                      deployment. Default value is `Always` for `nightly` or `latest`
+                      images, and `IfNotPresent` in other cases.
+                    type: string
+                  dashboardMemoryLimit:
+                    description: Overrides the memory limit used in the dashboard
+                      deployment. Defaults to 256Mi.
+                    type: string
+                  dashboardMemoryRequest:
+                    description: Overrides the memory request used in the dashboard
+                      deployment. Defaults to 16Mi.
+                    type: string
                   devfileRegistryCpuLimit:
                     description: Overrides the CPU limit used in the devfile registry
                       deployment. In cores. (500m = .5 cores). Default to 500m.

--- a/deploy/crds/org_v1_che_crd.yaml
+++ b/deploy/crds/org_v1_che_crd.yaml
@@ -336,7 +336,7 @@ spec:
                       it will create a default KubernetesImagePuller object to be
                       managed by the Operator. When set to `false`, the KubernetesImagePuller
                       object will be deleted, and the Operator will be uninstalled,
-                      regardless of whether a spec is provided. 
+                      regardless of whether a spec is provided.
  Note that while
                       this the Operator and its behavior is community-supported, its
                       payload may be commercially-supported for pulling commercially-supported

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -76,13 +76,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-04-21T11:53:32Z"
+    createdAt: "2021-04-21T14:41:38Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.30.0-166.nightly
+  name: eclipse-che-preview-kubernetes.v7.30.0-168.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1113,4 +1113,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.30.0-166.nightly
+  version: 7.30.0-168.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -76,13 +76,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-04-20T09:53:09Z"
+    createdAt: "2021-04-21T11:53:32Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.30.0-164.nightly
+  name: eclipse-che-preview-kubernetes.v7.30.0-166.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -901,6 +901,8 @@ spec:
                         value: nightly
                       - name: RELATED_IMAGE_che_server
                         value: quay.io/eclipse/che-server:nightly
+                      - name: RELATED_IMAGE_dashboard
+                        value: quay.io/eclipse/che-dashboard:next
                       - name: RELATED_IMAGE_plugin_registry
                         value: quay.io/eclipse/che-plugin-registry:nightly
                       - name: RELATED_IMAGE_devfile_registry
@@ -1111,4 +1113,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.30.0-164.nightly
+  version: 7.30.0-166.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/org_v1_che_crd.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/org_v1_che_crd.yaml
@@ -336,7 +336,7 @@ spec:
                       it will create a default KubernetesImagePuller object to be
                       managed by the Operator. When set to `false`, the KubernetesImagePuller
                       object will be deleted, and the Operator will be uninstalled,
-                      regardless of whether a spec is provided.
+                      regardless of whether a spec is provided. 
  Note that while
                       this the Operator and its behavior is community-supported, its
                       payload may be commercially-supported for pulling commercially-supported
@@ -537,6 +537,32 @@ spec:
                       generated in `che` ConfigMap from other CR fields, the value
                       defined in the `customCheProperties` is used instead.
                     type: object
+                  dashboardCpuLimit:
+                    description: Overrides the CPU limit used in the dashboard deployment.
+                      In cores. (500m = .5 cores). Default to 500m.
+                    type: string
+                  dashboardCpuRequest:
+                    description: Overrides the CPU request used in the dashboard deployment.
+                      In cores. (500m = .5 cores). Default to 100m.
+                    type: string
+                  dashboardImage:
+                    description: Overrides the container image used in the dashboard
+                      deployment. This includes the image tag. Omit it or leave it
+                      empty to use the default container image provided by the Operator.
+                    type: string
+                  dashboardImagePullPolicy:
+                    description: Overrides the image pull policy used in the dashboard
+                      deployment. Default value is `Always` for `nightly` or `latest`
+                      images, and `IfNotPresent` in other cases.
+                    type: string
+                  dashboardMemoryLimit:
+                    description: Overrides the memory limit used in the dashboard
+                      deployment. Defaults to 256Mi.
+                    type: string
+                  dashboardMemoryRequest:
+                    description: Overrides the memory request used in the dashboard
+                      deployment. Defaults to 16Mi.
+                    type: string
                   devfileRegistryCpuLimit:
                     description: Overrides the CPU limit used in the devfile registry
                       deployment. In cores. (500m = .5 cores). Default to 500m.

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/org_v1_che_crd.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/org_v1_che_crd.yaml
@@ -336,7 +336,7 @@ spec:
                       it will create a default KubernetesImagePuller object to be
                       managed by the Operator. When set to `false`, the KubernetesImagePuller
                       object will be deleted, and the Operator will be uninstalled,
-                      regardless of whether a spec is provided. 
+                      regardless of whether a spec is provided.
  Note that while
                       this the Operator and its behavior is community-supported, its
                       payload may be commercially-supported for pulling commercially-supported

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -67,13 +67,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-04-21T11:53:53Z"
+    createdAt: "2021-04-21T14:41:47Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.30.0-166.nightly
+  name: eclipse-che-preview-openshift.v7.30.0-168.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1186,4 +1186,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.30.0-166.nightly
+  version: 7.30.0-168.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -67,13 +67,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-04-20T09:53:20Z"
+    createdAt: "2021-04-21T11:53:53Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.30.0-164.nightly
+  name: eclipse-che-preview-openshift.v7.30.0-166.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -970,6 +970,8 @@ spec:
                         value: nightly
                       - name: RELATED_IMAGE_che_server
                         value: quay.io/eclipse/che-server:nightly
+                      - name: RELATED_IMAGE_dashboard
+                        value: quay.io/eclipse/che-dashboard:next
                       - name: RELATED_IMAGE_plugin_registry
                         value: quay.io/eclipse/che-plugin-registry:nightly
                       - name: RELATED_IMAGE_devfile_registry
@@ -1184,4 +1186,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.30.0-164.nightly
+  version: 7.30.0-166.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
@@ -545,6 +545,33 @@ spec:
                         be normally generated in `che` ConfigMap from other CR fields,
                         the value defined in the `customCheProperties` is used instead.
                       type: object
+                    dashboardCpuLimit:
+                      description: Overrides the CPU limit used in the dashboard deployment.
+                        In cores. (500m = .5 cores). Default to 500m.
+                      type: string
+                    dashboardCpuRequest:
+                      description: Overrides the CPU request used in the dashboard
+                        deployment. In cores. (500m = .5 cores). Default to 100m.
+                      type: string
+                    dashboardImage:
+                      description: Overrides the container image used in the dashboard
+                        deployment. This includes the image tag. Omit it or leave
+                        it empty to use the default container image provided by the
+                        Operator.
+                      type: string
+                    dashboardImagePullPolicy:
+                      description: Overrides the image pull policy used in the dashboard
+                        deployment. Default value is `Always` for `nightly` or `latest`
+                        images, and `IfNotPresent` in other cases.
+                      type: string
+                    dashboardMemoryLimit:
+                      description: Overrides the memory limit used in the dashboard
+                        deployment. Defaults to 256Mi.
+                      type: string
+                    dashboardMemoryRequest:
+                      description: Overrides the memory request used in the dashboard
+                        deployment. Defaults to 16Mi.
+                      type: string
                     devfileRegistryCpuLimit:
                       description: Overrides the CPU limit used in the devfile registry
                         deployment. In cores. (500m = .5 cores). Default to 500m.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -51,6 +51,8 @@ spec:
               value: nightly
             - name: RELATED_IMAGE_che_server
               value: quay.io/eclipse/che-server:nightly
+            - name: RELATED_IMAGE_dashboard
+              value: quay.io/eclipse/che-dashboard:next
             - name: RELATED_IMAGE_plugin_registry
               value: quay.io/eclipse/che-plugin-registry:nightly
             - name: RELATED_IMAGE_devfile_registry

--- a/make-release.sh
+++ b/make-release.sh
@@ -110,6 +110,10 @@ checkImageReferences() {
     echo "[ERROR] Unable to find Che server image with version ${RELEASE} in the $filename"; exit 1
   fi
 
+if ! grep -q "value: quay.io/eclipse/che-dashboard:$RELEASE" $filename; then
+    echo "[ERROR] Unable to find dashboard image with version ${RELEASE} in the $filename"; exit 1
+  fi
+
   if ! grep -q "value: quay.io/eclipse/che-plugin-registry:$RELEASE" $filename; then
     echo "[ERROR] Unable to find plugin registry image with version ${RELEASE} in the $filename"; exit 1
   fi

--- a/olm/release-olm-files.sh
+++ b/olm/release-olm-files.sh
@@ -85,6 +85,7 @@ do
   sed \
   -e 's/imagePullPolicy: *Always/imagePullPolicy: IfNotPresent/' \
   -e 's/"cheImageTag": *"nightly"/"cheImageTag": ""/' \
+  -e 's|quay.io/eclipse/che-dashboard:next|quay.io/eclipse/che-dashboard:${RELEASE}|' \
   -e 's|"identityProviderImage": *"quay.io/eclipse/che-keycloak:nightly"|"identityProviderImage": ""|' \
   -e 's|"devfileRegistryImage": *"quay.io/eclipse/che-devfile-registry:nightly"|"devfileRegistryImage": ""|' \
   -e 's|"pluginRegistryImage": *"quay.io/eclipse/che-plugin-registry:nightly"|"pluginRegistryImage": ""|' \

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -139,6 +139,28 @@ type CheClusterSpecServer struct {
 	// The default value is `true`.
 	// +optional
 	UseInternalClusterSVCNames bool `json:"useInternalClusterSVCNames"`
+	// Overrides the container image used in the dashboard deployment.
+	// This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
+	// +optional
+	DashboardImage string `json:"dashboardImage,omitempty"`
+	// Overrides the image pull policy used in the dashboard deployment.
+	// Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+	// +optional
+	DashboardImagePullPolicy string `json:"dashboardImagePullPolicy,omitempty"`
+	// Overrides the memory limit used in the dashboard deployment. Defaults to 256Mi.
+	// +optional
+	DashboardMemoryLimit string `json:"dashboardMemoryLimit,omitempty"`
+	// Overrides the memory request used in the dashboard deployment. Defaults to 16Mi.
+	// +optional
+	DashboardMemoryRequest string `json:"dashboardMemoryRequest,omitempty"`
+	// Overrides the CPU limit used in the dashboard deployment.
+	// In cores. (500m = .5 cores). Default to 500m.
+	// +optional
+	DashboardCpuLimit string `json:"dashboardCpuLimit,omitempty"`
+	// Overrides the CPU request used in the dashboard deployment.
+	// In cores. (500m = .5 cores). Default to 100m.
+	// +optional
+	DashboardCpuRequest string `json:"dashboardCpuRequest,omitempty"`
 	// Public URL of the devfile registry, that serves sample, ready-to-use devfiles.
 	// Set this ONLY when a use of an external devfile registry is needed. See the `externalDevfileRegistry` field.
 	// By default, this will be automatically calculated by the Operator.

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -20,6 +20,7 @@ import (
 
 	orgv1 "github.com/eclipse-che/che-operator/pkg/apis/org/v1"
 	"github.com/eclipse-che/che-operator/pkg/deploy"
+	"github.com/eclipse-che/che-operator/pkg/deploy/dashboard"
 	devworkspace "github.com/eclipse-che/che-operator/pkg/deploy/dev-workspace"
 	"github.com/eclipse-che/che-operator/pkg/deploy/devfileregistry"
 	"github.com/eclipse-che/che-operator/pkg/deploy/gateway"
@@ -801,6 +802,15 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 				return reconcile.Result{}, err
 			}
 		}
+	}
+
+	d := dashboard.NewDashboard(deployContext)
+	done, err = d.SyncAll()
+	if !done {
+		if err != nil {
+			logrus.Errorf("Error provisioning '%s' to cluster: %v", dashboard.DashboardComponent, err)
+		}
+		return reconcile.Result{}, err
 	}
 
 	// create Che ConfigMap which is synced with CR and is not supposed to be manually edited

--- a/pkg/deploy/dashboard/dashboard.go
+++ b/pkg/deploy/dashboard/dashboard.go
@@ -1,0 +1,57 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package dashboard
+
+import (
+	"github.com/eclipse-che/che-operator/pkg/deploy"
+	"github.com/eclipse-che/che-operator/pkg/deploy/expose"
+)
+
+const (
+	// DashboardComponent which is supposed to be used for the naming related objects
+	DashboardComponent = "dashboard"
+)
+
+type Dashboard struct {
+	deployContext *deploy.DeployContext
+}
+
+func NewDashboard(deployContext *deploy.DeployContext) *Dashboard {
+	return &Dashboard{
+		deployContext: deployContext,
+	}
+}
+
+func (d *Dashboard) SyncAll() (done bool, err error) {
+	// Create a new dashboard service
+	done, err = deploy.SyncServiceToCluster(d.deployContext, DashboardComponent, []string{"http"}, []int32{8080}, DashboardComponent)
+	if !done {
+		return false, err
+	}
+
+	// Expose dashboard service with route or ingress
+	_, done, err = expose.ExposeWithHostPath(d.deployContext, DashboardComponent, d.deployContext.CheCluster.Spec.Server.CheHost,
+		"/dashboard",
+		d.deployContext.CheCluster.Spec.Server.CheServerRoute,
+		d.deployContext.CheCluster.Spec.Server.CheServerIngress,
+	)
+	if !done {
+		return false, err
+	}
+
+	// Deploy dashboard
+	spec, err := d.getDashboardDeploymentSpec()
+	if err != nil {
+		return false, err
+	}
+	return deploy.SyncDeploymentSpecToCluster(d.deployContext, spec, deploy.DefaultDeploymentDiffOpts)
+}

--- a/pkg/deploy/dashboard/dashboard_deployment_test.go
+++ b/pkg/deploy/dashboard/dashboard_deployment_test.go
@@ -1,0 +1,114 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package dashboard
+
+import (
+	"os"
+
+	"github.com/eclipse-che/che-operator/pkg/util"
+
+	"github.com/eclipse-che/che-operator/pkg/deploy"
+
+	orgv1 "github.com/eclipse-che/che-operator/pkg/apis/org/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"testing"
+)
+
+func TestGetDashboardDeploymentSpec(t *testing.T) {
+	type testCase struct {
+		name          string
+		initObjects   []runtime.Object
+		memoryLimit   string
+		memoryRequest string
+		cpuRequest    string
+		cpuLimit      string
+		cheCluster    *orgv1.CheCluster
+	}
+
+	testCases := []testCase{
+		{
+			name:          "Test default limits",
+			initObjects:   []runtime.Object{},
+			memoryLimit:   deploy.DefaultDashboardMemoryLimit,
+			memoryRequest: deploy.DefaultDashboardMemoryRequest,
+			cpuLimit:      deploy.DefaultDashboardCpuLimit,
+			cpuRequest:    deploy.DefaultDashboardCpuRequest,
+			cheCluster: &orgv1.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "eclipse-che",
+				},
+			},
+		},
+		{
+			name:          "Test custom limits",
+			initObjects:   []runtime.Object{},
+			cpuLimit:      "250m",
+			cpuRequest:    "150m",
+			memoryLimit:   "250Mi",
+			memoryRequest: "150Mi",
+			cheCluster: &orgv1.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "eclipse-che",
+				},
+				Spec: orgv1.CheClusterSpec{
+					Server: orgv1.CheClusterSpecServer{
+						DashboardCpuLimit:      "250m",
+						DashboardCpuRequest:    "150m",
+						DashboardMemoryLimit:   "250Mi",
+						DashboardMemoryRequest: "150Mi",
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			logf.SetLogger(zap.LoggerTo(os.Stdout, true))
+			orgv1.SchemeBuilder.AddToScheme(scheme.Scheme)
+			testCase.initObjects = append(testCase.initObjects)
+			cli := fake.NewFakeClientWithScheme(scheme.Scheme, testCase.initObjects...)
+
+			deployContext := &deploy.DeployContext{
+				CheCluster: testCase.cheCluster,
+				ClusterAPI: deploy.ClusterAPI{
+					Client: cli,
+					Scheme: scheme.Scheme,
+				},
+				Proxy: &deploy.Proxy{},
+			}
+
+			dashboard := NewDashboard(deployContext)
+			deployment, err := dashboard.getDashboardDeploymentSpec()
+			if err != nil {
+				t.Fatalf("Failed to evaluate dashboard deployment spec: %v", err)
+			}
+
+			util.CompareResources(deployment,
+				util.TestExpectedResources{
+					MemoryLimit:   testCase.memoryLimit,
+					MemoryRequest: testCase.memoryRequest,
+					CpuRequest:    testCase.cpuRequest,
+					CpuLimit:      testCase.cpuLimit,
+				},
+				t)
+
+			util.ValidateSecurityContext(deployment, t)
+		})
+	}
+}

--- a/pkg/deploy/dashboard/dashboard_test.go
+++ b/pkg/deploy/dashboard/dashboard_test.go
@@ -1,0 +1,81 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package dashboard
+
+import (
+	"context"
+
+	"github.com/eclipse-che/che-operator/pkg/deploy"
+	"github.com/eclipse-che/che-operator/pkg/util"
+
+	orgv1 "github.com/eclipse-che/che-operator/pkg/apis/org/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"testing"
+)
+
+func TestDashboardAll(t *testing.T) {
+	cheCluster := &orgv1.CheCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "eclipse-che",
+			Name:      "eclipse-che",
+		},
+	}
+
+	orgv1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	corev1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	routev1.AddToScheme(scheme.Scheme)
+	cli := fake.NewFakeClientWithScheme(scheme.Scheme, cheCluster)
+	deployContext := &deploy.DeployContext{
+		CheCluster: cheCluster,
+		ClusterAPI: deploy.ClusterAPI{
+			Client:          cli,
+			NonCachedClient: cli,
+			Scheme:          scheme.Scheme,
+		},
+	}
+
+	util.IsOpenShift = true
+
+	dashboard := NewDashboard(deployContext)
+	done, err := dashboard.SyncAll()
+	if !done || err != nil {
+		t.Fatalf("Failed to sync Dashboard: %v", err)
+	}
+
+	// check service
+	service := &corev1.Service{}
+	err = cli.Get(context.TODO(), types.NamespacedName{Name: "dashboard", Namespace: "eclipse-che"}, service)
+	if err != nil {
+		t.Fatalf("Service not found: %v", err)
+	}
+
+	// check endpoint
+	route := &routev1.Route{}
+	err = cli.Get(context.TODO(), types.NamespacedName{Name: "dashboard", Namespace: "eclipse-che"}, route)
+	if err != nil {
+		t.Fatalf("Route not found: %v", err)
+	}
+
+	// check deployment
+	deployment := &appsv1.Deployment{}
+	err = cli.Get(context.TODO(), types.NamespacedName{Name: "dashboard", Namespace: "eclipse-che"}, deployment)
+	if err != nil {
+		t.Fatalf("Deployment not found: %v", err)
+	}
+}

--- a/pkg/deploy/dashboard/deployment_dashboard.go
+++ b/pkg/deploy/dashboard/deployment_dashboard.go
@@ -1,0 +1,145 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package dashboard
+
+import (
+	"strconv"
+
+	"github.com/eclipse-che/che-operator/pkg/deploy"
+	"github.com/eclipse-che/che-operator/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func (p *Dashboard) getDashboardDeploymentSpec() (*appsv1.Deployment, error) {
+	terminationGracePeriodSeconds := int64(30)
+	labels := deploy.GetLabels(p.deployContext.CheCluster, DashboardComponent)
+	dashboardImageAndTag := util.GetValue(p.deployContext.CheCluster.Spec.Server.DashboardImage, deploy.DefaultDashboardImage(p.deployContext.CheCluster))
+	pullPolicy := corev1.PullPolicy(util.GetValue(p.deployContext.CheCluster.Spec.Server.DashboardImagePullPolicy, deploy.DefaultPullPolicyFromDockerImage(dashboardImageAndTag)))
+
+	deployment := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DashboardComponent,
+			Namespace: p.deployContext.CheCluster.Namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "dashboard",
+							ImagePullPolicy: pullPolicy,
+							Image:           dashboardImageAndTag,
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "http",
+									ContainerPort: 8080,
+									Protocol:      "TCP",
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: util.GetResourceQuantity(
+										p.deployContext.CheCluster.Spec.Server.DashboardMemoryRequest,
+										deploy.DefaultDashboardMemoryRequest),
+									corev1.ResourceCPU: util.GetResourceQuantity(
+										p.deployContext.CheCluster.Spec.Server.DashboardCpuRequest,
+										deploy.DefaultDashboardCpuRequest),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: util.GetResourceQuantity(
+										p.deployContext.CheCluster.Spec.Server.DashboardMemoryLimit,
+										deploy.DefaultDashboardMemoryLimit),
+									corev1.ResourceCPU: util.GetResourceQuantity(
+										p.deployContext.CheCluster.Spec.Server.DashboardCpuLimit,
+										deploy.DefaultDashboardCpuLimit),
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/",
+										Port: intstr.IntOrString{
+											Type:   intstr.Int,
+											IntVal: int32(8080),
+										},
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								InitialDelaySeconds: 3,
+								FailureThreshold:    10,
+								TimeoutSeconds:      3,
+								SuccessThreshold:    1,
+								PeriodSeconds:       10,
+							},
+							LivenessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/",
+										Port: intstr.IntOrString{
+											Type:   intstr.Int,
+											IntVal: int32(8080),
+										},
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								InitialDelaySeconds: 30,
+								FailureThreshold:    10,
+								TimeoutSeconds:      3,
+								SuccessThreshold:    1,
+								PeriodSeconds:       10,
+							},
+						},
+					},
+					RestartPolicy:                 "Always",
+					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
+				},
+			},
+		},
+	}
+
+	if !util.IsOpenShift {
+		runAsUser, err := strconv.ParseInt(util.GetValue(p.deployContext.CheCluster.Spec.K8s.SecurityContextRunAsUser, deploy.DefaultSecurityContextRunAsUser), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		fsGroup, err := strconv.ParseInt(util.GetValue(p.deployContext.CheCluster.Spec.K8s.SecurityContextFsGroup, deploy.DefaultSecurityContextFsGroup), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+			RunAsUser: &runAsUser,
+			FSGroup:   &fsGroup,
+		}
+	}
+
+	return deployment, nil
+}

--- a/pkg/deploy/dashboard/init_test.go
+++ b/pkg/deploy/dashboard/init_test.go
@@ -1,0 +1,21 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package dashboard
+
+import "github.com/eclipse-che/che-operator/pkg/deploy"
+
+func init() {
+	err := deploy.InitTestDefaultsFromDeployment("../../../deploy/operator.yaml")
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -29,6 +29,7 @@ import (
 var (
 	defaultCheServerImage                      string
 	defaultCheVersion                          string
+	defaultDashboardImage                      string
 	defaultPluginRegistryImage                 string
 	defaultDevfileRegistryImage                string
 	defaultCheTLSSecretsCreationJobImage       string
@@ -117,6 +118,11 @@ const (
 	PostgresName         = "postgres"
 
 	// limits
+	DefaultDashboardMemoryLimit   = "256Mi"
+	DefaultDashboardMemoryRequest = "32Mi"
+	DefaultDashboardCpuLimit      = "500m"
+	DefaultDashboardCpuRequest    = "100m"
+
 	DefaultPluginRegistryMemoryLimit   = "256Mi"
 	DefaultPluginRegistryMemoryRequest = "32Mi"
 	DefaultPluginRegistryCpuLimit      = "500m"
@@ -160,6 +166,7 @@ func InitDefaultsFromFile(defaultsPath string) {
 
 	defaultCheVersion = util.GetDeploymentEnv(operatorDeployment, "CHE_VERSION")
 	defaultCheServerImage = util.GetDeploymentEnv(operatorDeployment, util.GetArchitectureDependentEnv("RELATED_IMAGE_che_server"))
+	defaultDashboardImage = util.GetDeploymentEnv(operatorDeployment, util.GetArchitectureDependentEnv("RELATED_IMAGE_dashboard"))
 	defaultPluginRegistryImage = util.GetDeploymentEnv(operatorDeployment, util.GetArchitectureDependentEnv("RELATED_IMAGE_plugin_registry"))
 	defaultDevfileRegistryImage = util.GetDeploymentEnv(operatorDeployment, util.GetArchitectureDependentEnv("RELATED_IMAGE_devfile_registry"))
 	defaultPvcJobsImage = util.GetDeploymentEnv(operatorDeployment, util.GetArchitectureDependentEnv("RELATED_IMAGE_pvc_jobs"))
@@ -270,6 +277,10 @@ func DefaultPvcJobsImage(cr *orgv1.CheCluster) string {
 
 func DefaultPostgresImage(cr *orgv1.CheCluster) string {
 	return patchDefaultImageName(cr, defaultPostgresImage)
+}
+
+func DefaultDashboardImage(cr *orgv1.CheCluster) string {
+	return patchDefaultImageName(cr, defaultDashboardImage)
 }
 
 func DefaultKeycloakImage(cr *orgv1.CheCluster) string {
@@ -398,6 +409,7 @@ func getOrganizationFromImage(image string) string {
 func InitDefaultsFromEnv() {
 	defaultCheVersion = getDefaultFromEnv("CHE_VERSION")
 	defaultCheServerImage = getDefaultFromEnv(util.GetArchitectureDependentEnv("RELATED_IMAGE_che_server"))
+	defaultDashboardImage = getDefaultFromEnv(util.GetArchitectureDependentEnv("RELATED_IMAGE_dashboard"))
 	defaultPluginRegistryImage = getDefaultFromEnv(util.GetArchitectureDependentEnv("RELATED_IMAGE_plugin_registry"))
 	defaultDevfileRegistryImage = getDefaultFromEnv(util.GetArchitectureDependentEnv("RELATED_IMAGE_devfile_registry"))
 	defaultPvcJobsImage = getDefaultFromEnv(util.GetArchitectureDependentEnv("RELATED_IMAGE_pvc_jobs"))

--- a/pkg/deploy/defaults_test.go
+++ b/pkg/deploy/defaults_test.go
@@ -26,7 +26,7 @@ func TestDefaultFromEnv(t *testing.T) {
 	cheVersionTest := os.Getenv("CHE_VERSION")
 
 	cheServerImageTest := os.Getenv(util.GetArchitectureDependentEnv("RELATED_IMAGE_che_server"))
-
+	dashboardImageTest := os.Getenv(util.GetArchitectureDependentEnv("RELATED_IMAGE_dashboard"))
 	pluginRegistryImageTest := os.Getenv(util.GetArchitectureDependentEnv("RELATED_IMAGE_plugin_registry"))
 	devfileRegistryImageTest := os.Getenv(util.GetArchitectureDependentEnv("RELATED_IMAGE_devfile_registry"))
 	pvcJobsImageTest := os.Getenv(util.GetArchitectureDependentEnv("RELATED_IMAGE_pvc_jobs"))
@@ -48,6 +48,10 @@ func TestDefaultFromEnv(t *testing.T) {
 
 	if DefaultCheServerImage(cheCluster) != cheServerImageTest {
 		t.Errorf("Expected %s but was %s", cheServerImageTest, DefaultCheServerImage(cheCluster))
+	}
+
+	if DefaultDashboardImage(cheCluster) != dashboardImageTest {
+		t.Errorf("Expected %s but was %s", dashboardImageTest, DefaultDashboardImage(cheCluster))
 	}
 
 	if DefaultPluginRegistryImage(cheCluster) != pluginRegistryImageTest {

--- a/replace-images-tags.sh
+++ b/replace-images-tags.sh
@@ -31,11 +31,13 @@ replaceImagesTags() {
   OPERATOR_YAML="${BASE_DIR}"/deploy/operator.yaml
 
   lastDefaultCheServerImage=$(yq -r ".spec.template.spec.containers[] | select(.name == \"che-operator\") | .env[] | select(.name == \"RELATED_IMAGE_che_server\") | .value" "${OPERATOR_YAML}")
+  lastDefaultDashboardImage=$(yq -r ".spec.template.spec.containers[] | select(.name == \"che-operator\") | .env[] | select(.name == \"RELATED_IMAGE_dashboard\") | .value" "${OPERATOR_YAML}")
   lastDefaultKeycloakImage=$(yq -r ".spec.template.spec.containers[] | select(.name == \"che-operator\") | .env[] | select(.name == \"RELATED_IMAGE_keycloak\") | .value" "${OPERATOR_YAML}")
   lastDefaultPluginRegistryImage=$(yq -r ".spec.template.spec.containers[] | select(.name == \"che-operator\") | .env[] | select(.name == \"RELATED_IMAGE_plugin_registry\") | .value" "${OPERATOR_YAML}")
   lastDefaultDevfileRegistryImage=$(yq -r ".spec.template.spec.containers[] | select(.name == \"che-operator\") | .env[] | select(.name == \"RELATED_IMAGE_devfile_registry\") | .value" "${OPERATOR_YAML}")
 
   CHE_SERVER_IMAGE_REALEASE=$(replaceImageTag "${lastDefaultCheServerImage}" "${RELEASE_TAG}")
+  DASHBOARD_IMAGE_REALEASE=$(replaceImageTag "${lastDefaultDashboardImage}" "${RELEASE_TAG}")
   KEYCLOAK_IMAGE_RELEASE=$(replaceImageTag "${lastDefaultKeycloakImage}" "${RELEASE_TAG}")
   PLUGIN_REGISTRY_IMAGE_RELEASE=$(replaceImageTag "${lastDefaultPluginRegistryImage}" "${RELEASE_TAG}")
   DEVFILE_REGISTRY_IMAGE_RELEASE=$(replaceImageTag "${lastDefaultDevfileRegistryImage}" "${RELEASE_TAG}")
@@ -48,6 +50,7 @@ replaceImagesTags() {
   yq -ryY "( .spec.template.spec.containers[] | select(.name == \"che-operator\") | .image ) = \"quay.io/eclipse/che-operator:${RELEASE_TAG}\"" | \
   yq -ryY "( .spec.template.spec.containers[] | select(.name == \"che-operator\").env[] | select(.name == \"CHE_VERSION\") | .value ) = \"${RELEASE_TAG}\"" | \
   yq -ryY "( .spec.template.spec.containers[] | select(.name == \"che-operator\").env[] | select(.name == \"RELATED_IMAGE_che_server\") | .value ) = \"${CHE_SERVER_IMAGE_REALEASE}\"" | \
+  yq -ryY "( .spec.template.spec.containers[] | select(.name == \"che-operator\").env[] | select(.name == \"RELATED_IMAGE_dashboard\") | .value ) = \"${DASHBOARD_IMAGE_REALEASE}\"" | \
   yq -ryY "( .spec.template.spec.containers[] | select(.name == \"che-operator\").env[] | select(.name == \"RELATED_IMAGE_keycloak\") | .value ) = \"${KEYCLOAK_IMAGE_RELEASE}\"" | \
   yq -ryY "( .spec.template.spec.containers[] | select(.name == \"che-operator\").env[] | select(.name == \"RELATED_IMAGE_plugin_registry\") | .value ) = \"${PLUGIN_REGISTRY_IMAGE_RELEASE}\"" | \
   yq -ryY "( .spec.template.spec.containers[] | select(.name == \"che-operator\").env[] | select(.name == \"RELATED_IMAGE_devfile_registry\") | .value ) = \"${DEVFILE_REGISTRY_IMAGE_RELEASE}\"" \


### PR DESCRIPTION
### What does this PR do?
It makes the Che operator run the dashboard as a separate Deployment. The same was previously done for helm charts.
The main reason why these changes were made, it's
> STEP1 - running the HTTP server that serves the dashboard in its own pod: customising the dashboard is just a matter of rebuilding the dashboard container image.
from https://github.com/eclipse/che/issues/15778#issuecomment-692535413

Now things changed and we have a plan to introduce a backend for the dashboard. So, it becomes a need.

It depends on https://github.com/eclipse-che/che-operator/pull/760


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
It's the first step for https://github.com/eclipse/che/issues/15778
It's the second step for https://github.com/eclipse/che/issues/17802
And a prerequisite for Dashboard backend (not sure if an issue exists at this point)


### How to test this PR?
Test that dashboard is run as dedicated deployment and is available on Che host.

I tested(and prepared a lot of fixes):

Minikube:
- multihost
- gateway singlehost
- native singlehost

OpenShift (RHPDS):
- multihost
- gateway singlehost

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse/che-operator/blob/master/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse/che-operator/blob/master/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
