### PR TITLE
Include additional cluster-wide trusted CA into Che

### DIFF
--- a/pkg/controller/che/proxy.go
+++ b/pkg/controller/che/proxy.go
@@ -51,16 +51,10 @@ func (r *ReconcileChe) getProxyConfiguration(checluster *orgv1.CheCluster) (*dep
 			// Add cluster-wide trusted CA certs, if any
 			cheClusterProxyConf.TrustedCAMapName = clusterWideProxyConf.TrustedCAMapName
 			return cheClusterProxyConf, nil
-		} else if clusterWideProxyConf.HttpProxy != "" {
+		} else {
 			clusterWideProxyConf.NoProxy = deploy.MergeNonProxy(clusterWideProxyConf.NoProxy, cheClusterProxyConf.NoProxy)
 			return clusterWideProxyConf, nil
 		}
-
-		// Proxy isn't configured
-		// However add cluster-wide trusted CA certificates, if any, to Che
-		return &deploy.Proxy{
-			TrustedCAMapName: clusterWideProxyConf.TrustedCAMapName,
-		}, nil
 	}
 
 	// OpenShift 3.x and k8s

--- a/pkg/controller/che/proxy.go
+++ b/pkg/controller/che/proxy.go
@@ -48,10 +48,8 @@ func (r *ReconcileChe) getProxyConfiguration(checluster *orgv1.CheCluster) (*dep
 			} else {
 				cheClusterProxyConf.NoProxy = deploy.MergeNonProxy(cheClusterProxyConf.NoProxy, ".svc")
 			}
-			// Add cluster-wide trusted CA certs
-			if clusterWideProxyConf.TrustedCAMapName != "" {
-				cheClusterProxyConf.TrustedCAMapName = clusterWideProxyConf.TrustedCAMapName
-			}
+			// Add cluster-wide trusted CA certs, if any
+			cheClusterProxyConf.TrustedCAMapName = clusterWideProxyConf.TrustedCAMapName
 			return cheClusterProxyConf, nil
 		} else if clusterWideProxyConf.HttpProxy != "" {
 			clusterWideProxyConf.NoProxy = deploy.MergeNonProxy(clusterWideProxyConf.NoProxy, cheClusterProxyConf.NoProxy)

--- a/pkg/controller/che/proxy.go
+++ b/pkg/controller/che/proxy.go
@@ -48,14 +48,21 @@ func (r *ReconcileChe) getProxyConfiguration(checluster *orgv1.CheCluster) (*dep
 			} else {
 				cheClusterProxyConf.NoProxy = deploy.MergeNonProxy(cheClusterProxyConf.NoProxy, ".svc")
 			}
+			// Add cluster-wide trusted CA certs
+			if clusterWideProxyConf.TrustedCAMapName != "" {
+				cheClusterProxyConf.TrustedCAMapName = clusterWideProxyConf.TrustedCAMapName
+			}
 			return cheClusterProxyConf, nil
 		} else if clusterWideProxyConf.HttpProxy != "" {
 			clusterWideProxyConf.NoProxy = deploy.MergeNonProxy(clusterWideProxyConf.NoProxy, cheClusterProxyConf.NoProxy)
 			return clusterWideProxyConf, nil
 		}
 
-		// proxy isn't configured
-		return &deploy.Proxy{}, nil
+		// Proxy isn't configured
+		// However add cluster-wide trusted CA certificates, if any, to Che
+		return &deploy.Proxy{
+			TrustedCAMapName: clusterWideProxyConf.TrustedCAMapName,
+		}, nil
 	}
 
 	// OpenShift 3.x and k8s

--- a/pkg/controller/che/proxy_test.go
+++ b/pkg/controller/che/proxy_test.go
@@ -142,6 +142,11 @@ func TestReadProxyConfiguration(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster",
 				},
+				Spec: configv1.ProxySpec{
+					TrustedCA: configv1.ConfigMapNameReference{
+						Name: "additional-cluster-ca-bundle",
+					},
+				},
 				Status: configv1.ProxyStatus{
 					HTTPProxy:  "http://proxy:3128",
 					HTTPSProxy: "http://proxy:3128",
@@ -169,7 +174,30 @@ func TestReadProxyConfiguration(t *testing.T) {
 				HttpsHost:        "proxy",
 				HttpsPort:        "3128",
 				NoProxy:          "host1",
-				TrustedCAMapName: "",
+				TrustedCAMapName: "additional-cluster-ca-bundle",
+			},
+		},
+		{
+			name:             "Test cluster wide proxy is not configured, but cluster wide CA certs added, OpenShift 4.x",
+			openShiftVersion: "4",
+			clusterProxy: &configv1.Proxy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: configv1.ProxySpec{
+					TrustedCA: configv1.ConfigMapNameReference{
+						Name: "additional-cluster-ca-bundle",
+					},
+				},
+			},
+			cheCluster: &orgv1.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "eclipse-che",
+				},
+			},
+			initObjects: []runtime.Object{},
+			expectedProxyConf: &deploy.Proxy{
+				TrustedCAMapName: "additional-cluster-ca-bundle",
 			},
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Includes CA certificates configured in `proxy/cluster` into list of trusted by Che certificates even if no proxy configuration added.


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17938

### How to test this PR?
1. Configure Openshift router with a custom certificate chain
2. Add all the CA certificates from the chain into `proxy/cluster` (excluding server one).
3. Deploy Che using operator from this branch
4. Start a workspace, ensure everything works as expected


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse/che-operator/blob/master/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse/che-operator/blob/master/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
