### PR TITLE
Remove components CRD from DevWorkspace Operator deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ $ olm/update-crd-files.sh
 or
 
 ```bash
-$ ./docker-run.sh olm/update-crd-files.sh
+$ olm/docker-run.sh olm/update-crd-files.sh
 ```
 
 > Notice: this script contains commands to make the CRD compatible with Openshift 3.
@@ -363,7 +363,7 @@ $ olm/update-nightly-bundle.sh
 or
 
 ```bash
-$ ./docker-run.sh olm/update-nightly-bundle.sh
+$ olm/docker-run.sh olm/update-nightly-bundle.sh
 ```
 
 Every changes will be included to the `deploy/olm-catalog` bundles and will override all previous changes. OLM bundle changes should be committed to the pull request.

--- a/pkg/deploy/dev-workspace/dev_workspace.go
+++ b/pkg/deploy/dev-workspace/dev_workspace.go
@@ -52,7 +52,6 @@ const (
 	DevWorkspaceProxyClusterRoleBindingFile   = DevWorkspaceTemplates + "/devworkspace-controller-proxy-rolebinding.ClusterRoleBinding.yaml"
 	DevWorkspaceWorkspaceRoutingCRDFile       = DevWorkspaceTemplates + "/devworkspaceroutings.controller.devfile.io.CustomResourceDefinition.yaml"
 	DevWorkspaceTemplatesCRDFile              = DevWorkspaceTemplates + "/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml"
-	DevWorkspaceComponentsCRDFile             = DevWorkspaceTemplates + "/components.controller.devfile.io.CustomResourceDefinition.yaml"
 	DevWorkspaceCRDFile                       = DevWorkspaceTemplates + "/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml"
 	DevWorkspaceConfigMapFile                 = DevWorkspaceTemplates + "/devworkspace-controller-configmap.ConfigMap.yaml"
 	DevWorkspaceDeploymentFile                = DevWorkspaceTemplates + "/devworkspace-controller-manager.Deployment.yaml"
@@ -89,7 +88,6 @@ var (
 		syncDwClusterRoleBinding,
 		syncDwProxyClusterRoleBinding,
 		syncDwCRD,
-		syncDwComponentsCRD,
 		syncDwTemplatesCRD,
 		syncDwWorkspaceRoutingCRD,
 		syncDwConfigMap,
@@ -235,10 +233,6 @@ func syncDwWorkspaceRoutingCRD(deployContext *deploy.DeployContext) (bool, error
 
 func syncDwTemplatesCRD(deployContext *deploy.DeployContext) (bool, error) {
 	return syncObject(deployContext, DevWorkspaceTemplatesCRDFile, &apiextensionsv1.CustomResourceDefinition{})
-}
-
-func syncDwComponentsCRD(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceComponentsCRDFile, &apiextensionsv1.CustomResourceDefinition{})
 }
 
 func syncDwCRD(deployContext *deploy.DeployContext) (bool, error) {


### PR DESCRIPTION
### What does this PR do?
PR https://github.com/devfile/devworkspace-operator/pull/336 removes the Component CRD from the DevWorkspace Operator. As a result, depending on the components file will cause issues going forward in chectl, and it should be removed.

### What issues does this PR fix or reference?
No issue created yet, but we'll see failures soon as https://github.com/devfile/devworkspace-operator/pull/336 is merged to main

### How to test this PR?
Test deploying with DWO as normal.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/master/README.md#updating-custom-resource-definition-file)
- [x] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/master/README.md#update-nightly-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
