### PR TITLE
Stabilize devworkspace-happy-path job

### DIFF
--- a/.ci/oci-devworkspace-happy-path.sh
+++ b/.ci/oci-devworkspace-happy-path.sh
@@ -51,7 +51,7 @@ startHappyPathTest() {
   oc apply -f ${OPERATOR_REPO}/.ci/openshift-ci/happy-path-che.yaml
   # wait for the pod to start
   n=0
-  while [ $n -le 12 ]
+  while [ $n -le 48 ]
   do
     PHASE=$(oc get pod -n ${NAMESPACE} ${HAPPY_PATH_POD_NAME} \
         --template='{{ .status.phase }}')

--- a/.ci/oci-devworkspace-happy-path.sh
+++ b/.ci/oci-devworkspace-happy-path.sh
@@ -51,7 +51,7 @@ startHappyPathTest() {
   oc apply -f ${OPERATOR_REPO}/.ci/openshift-ci/happy-path-che.yaml
   # wait for the pod to start
   n=0
-  while [ $n -le 48 ]
+  while [ $n -le 120 ]
   do
     PHASE=$(oc get pod -n ${NAMESPACE} ${HAPPY_PATH_POD_NAME} \
         --template='{{ .status.phase }}')


### PR DESCRIPTION
### What does this PR do?
This PR changes waiting for **happy-path** pod in `Running` state to 4 min. Sometimes 1 min not enough for the pod to start([example](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/17107/rehearse-17107-pull-ci-eclipse-che-che-operator-master-v7-devworkspace-happy-path/1375101093381410816/artifacts/devworkspace-happy-path/devworkspace-happy-path/build-log.txt)).

