### PR TITLE
Update happy-path test devfile url, use builded che-operator image for Che deployment

### DIFF
--- a/.ci/oci-devworkspace-happy-path.sh
+++ b/.ci/oci-devworkspace-happy-path.sh
@@ -17,7 +17,7 @@ set -u
 
 export OPERATOR_REPO=$(dirname $(dirname $(readlink -f "$0")));
 export HAPPY_PATH_POD_NAME=happy-path-che
-export HAPPY_PATH_DEVFILE='https://github.com/l0rd/spring-petclinic/tree/devfile2'
+export HAPPY_PATH_DEVFILE='https://gist.githubusercontent.com/l0rd/71a04dd0d8c8e921b16ba2690f7d5a47/raw/d520086e148c359b18c229328824dfefcf85e5ef/spring-petclinic-devfile-v2.0.0.yaml'
 source "${OPERATOR_REPO}"/.github/bin/common.sh
 source "${OPERATOR_REPO}"/.github/bin/oauth-provision.sh
 
@@ -46,6 +46,7 @@ startHappyPathTest() {
   TS_SELENIUM_DEVWORKSPACE_URL="${ECLIPSE_CHE_URL}/#${HAPPY_PATH_DEVFILE}"
   sed -i "s@CHE_URL@${ECLIPSE_CHE_URL}@g" ${OPERATOR_REPO}/.ci/openshift-ci/happy-path-che.yaml
   sed -i "s@WORKSPACE_ROUTE@${TS_SELENIUM_DEVWORKSPACE_URL}@g" ${OPERATOR_REPO}/.ci/openshift-ci/happy-path-che.yaml
+  sed -i "s@CHE-NAMESPACE@${NAMESPACE}@g" ${OPERATOR_REPO}/.ci/openshift-ci/happy-path-che.yaml
   cat ${OPERATOR_REPO}/.ci/openshift-ci/happy-path-che.yaml
 
   oc apply -f ${OPERATOR_REPO}/.ci/openshift-ci/happy-path-che.yaml

--- a/.ci/oci-devworkspace-happy-path.sh
+++ b/.ci/oci-devworkspace-happy-path.sh
@@ -33,6 +33,8 @@ spec:
     customCheProperties:
       CHE_FACTORY_DEFAULT__PLUGINS: ""
       CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR_PLUGINS: ""
+  auth:
+    updateAdminPassword: false
 EOL
 
   cat /tmp/che-cr-patch.yaml

--- a/.ci/oci-devworkspace-happy-path.sh
+++ b/.ci/oci-devworkspace-happy-path.sh
@@ -24,6 +24,12 @@ source "${OPERATOR_REPO}"/.github/bin/oauth-provision.sh
 # Stop execution on any error
 trap "catchFinish" EXIT SIGINT
 
+overrideDefaults() {
+  # CI_CHE_OPERATOR_IMAGE it is che operator image builded in openshift CI job workflow. More info about how works image dependencies in ci:https://github.com/openshift/ci-tools/blob/master/TEMPLATES.md#parameters-available-to-templates
+  export OPERATOR_IMAGE=${CI_CHE_OPERATOR_IMAGE:-"quay.io/eclipse/che-operator:nightly"}
+  echo ${OPERATOR_IMAGE}
+}
+
 deployChe() {
   cat > /tmp/che-cr-patch.yaml <<EOL
 spec:
@@ -39,7 +45,7 @@ EOL
 
   cat /tmp/che-cr-patch.yaml
 
-  chectl server:deploy --che-operator-cr-patch-yaml=/tmp/che-cr-patch.yaml -p openshift --batch --telemetry=off --installer=operator
+  chectl server:deploy --che-operator-cr-patch-yaml=/tmp/che-cr-patch.yaml -p openshift --batch --telemetry=off --installer=operator --che-operator-image=${OPERATOR_IMAGE}
 }
 
 startHappyPathTest() {
@@ -92,5 +98,6 @@ runTest() {
 }
 
 initDefaults
+overrideDefaults
 provisionOpenShiftOAuthUser
 runTest

--- a/.ci/oci-devworkspace-happy-path.sh
+++ b/.ci/oci-devworkspace-happy-path.sh
@@ -65,7 +65,7 @@ startHappyPathTest() {
     PHASE=$(oc get pod -n ${NAMESPACE} ${HAPPY_PATH_POD_NAME} \
         --template='{{ .status.phase }}')
     if [[ ${PHASE} == "Running" ]]; then
-      echo "[INFO] Happy-path test started succesfully"
+      echo "[INFO] Happy-path test started succesfully."
       return
     fi
 
@@ -73,7 +73,7 @@ startHappyPathTest() {
     n=$(( n+1 ))
   done
 
-  echo "Failed to start happy-path test"
+  echo "[ERROR] Failed to start happy-path test."
   exit 1
 }
 
@@ -95,6 +95,13 @@ runTest() {
 
   mkdir -p ${ARTIFACTS_DIR}
   cp -r /tmp/e2e ${ARTIFACTS_DIR}
+
+  EXIT_CODE=$(oc logs -n ${NAMESPACE} ${HAPPY_PATH_POD_NAME} -c happy-path-test | grep EXIT_CODE)
+
+  if [[ ${EXIT_CODE} == "+ EXIT_CODE=1" ]]; then
+    echo "[ERROR] Happy-path test failed."
+    exit 1
+  fi
 }
 
 initDefaults

--- a/.ci/openshift-ci/happy-path-che.yaml
+++ b/.ci/openshift-ci/happy-path-che.yaml
@@ -9,7 +9,7 @@ spec:
   containers:
     # container containing the tests
     - name: happy-path-test
-      image: quay.io/eclipse/che-e2e
+      image: quay.io/eclipse/che-e2e:nightly
       imagePullPolicy: Always
       env:
         - name: TEST_SUITE
@@ -36,6 +36,8 @@ spec:
           value: 'admin'
         - name: TS_OCP_LOGIN_PAGE_PROVIDER_TITLE
           value: "htpasswd"
+        - name: DELETE_WORKSPACE_ON_FAILED_TEST
+          value: "true"
       volumeMounts:
         - name: test-run-results
           mountPath: /tmp/e2e/report/

--- a/.ci/openshift-ci/happy-path-che.yaml
+++ b/.ci/openshift-ci/happy-path-che.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: happy-path-che
-  namespace: eclipse-che
+  namespace: CHE-NAMESPACE
 spec:
   volumes:
     - name: test-run-results
@@ -23,7 +23,7 @@ spec:
         - name: TS_SELENIUM_MULTIUSER
           value: 'true'
         - name: TS_SELENIUM_LOG_LEVEL
-          value: DEBUG
+          value: TRACE
         - name: TS_SELENIUM_OCP_USERNAME
           value: 'user'
         - name: TS_SELENIUM_OCP_PASSWORD


### PR DESCRIPTION
### What does this PR do?   [](url)
1. Update **APPY_PATH_DEVFILE**  to  [devfile](https://gist.githubusercontent.com/l0rd/71a04dd0d8c8e921b16ba2690f7d5a47/raw/d520086e148c359b18c229328824dfefcf85e5ef/spring-petclinic-devfile-v2.0.0.yaml).
2. Set **TS_SELENIUM_LOG_LEVEL** to **TRACE** for more informative logs.
3. Set namespace field in `happy-path-che.yaml` file to `${NAMESPACE}` env.
4. Check `EXIT_CODE` env in happy-path-pod for checking test result(`EXIT_CODE=1` means failing).
5. Use builded che-operator image in Eclipse Che deployment(using  `--che-operator-image` option).
