### PR TITLE
Allow to trigger image build manually

### DIFF
--- a/.github/workflows/nightly-image-build.yaml
+++ b/.github/workflows/nightly-image-build.yaml
@@ -12,6 +12,9 @@
 name: Nightly Dockerimage Build
 
 on:
+  # manual trigger if required
+  workflow_dispatch
+
   schedule:
     - cron:  '0 0 * * *'
 jobs:


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Allow to trigger image build manually

