### PR TITLE
Refactor exposure to have an ability share host among components

### DIFF
--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -749,10 +749,11 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 	exposedServiceName := getServerExposingServiceName(instance)
 	cheHost := ""
 	if !isOpenShift {
-		done, err := deploy.SyncIngressToCluster(
+		_, done, err := deploy.SyncIngressToCluster(
 			deployContext,
 			cheFlavor,
-			instance.Spec.Server.CheHost,
+			instance.Spec.K8s.IngressDomain,
+			"",
 			exposedServiceName,
 			8080,
 			deployContext.CheCluster.Spec.Server.CheServerIngress,
@@ -786,6 +787,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 			deployContext,
 			cheFlavor,
 			customHost,
+			"",
 			exposedServiceName,
 			8080,
 			deployContext.CheCluster.Spec.Server.CheServerRoute,
@@ -829,7 +831,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 		}
 	}
 
-	provisioned, err = devfile_registry.SyncDevfileRegistryToCluster(deployContext, cheHost)
+	provisioned, err = devfile_registry.SyncDevfileRegistryToCluster(deployContext)
 	if !tests {
 		if !provisioned {
 			if err != nil {
@@ -839,7 +841,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 		}
 	}
 
-	provisioned, err = plugin_registry.SyncPluginRegistryToCluster(deployContext, cheHost)
+	provisioned, err = plugin_registry.SyncPluginRegistryToCluster(deployContext)
 	if !tests {
 		if !provisioned {
 			if err != nil {
@@ -969,6 +971,7 @@ func getDefaultCheHost(deployContext *deploy.DeployContext) (string, error) {
 	done, err := deploy.SyncRouteToCluster(
 		deployContext,
 		cheFlavor,
+		"",
 		"",
 		getServerExposingServiceName(deployContext.CheCluster),
 		8080,

--- a/pkg/deploy/devfile-registry/devfile_registry.go
+++ b/pkg/deploy/devfile-registry/devfile_registry.go
@@ -31,16 +31,14 @@ type DevFileRegistryConfigMap struct {
 /**
  * Create devfile registry resources unless an external registry is used.
  */
-func SyncDevfileRegistryToCluster(deployContext *deploy.DeployContext, cheHost string) (bool, error) {
+func SyncDevfileRegistryToCluster(deployContext *deploy.DeployContext) (bool, error) {
 	devfileRegistryURL := deployContext.CheCluster.Spec.Server.DevfileRegistryUrl
 	if !deployContext.CheCluster.Spec.Server.ExternalDevfileRegistry {
 		endpoint, done, err := expose.Expose(
 			deployContext,
-			cheHost,
 			deploy.DevfileRegistryName,
 			deployContext.CheCluster.Spec.Server.DevfileRegistryRoute,
-			deployContext.CheCluster.Spec.Server.DevfileRegistryIngress,
-			deploy.DevfileRegistryName)
+			deployContext.CheCluster.Spec.Server.DevfileRegistryIngress)
 		if !done {
 			return false, err
 		}

--- a/pkg/deploy/gateway/gateway.go
+++ b/pkg/deploy/gateway/gateway.go
@@ -186,7 +186,7 @@ func delete(clusterAPI deploy.ClusterAPI, obj metav1.Object) error {
 // GetGatewayRouteConfig creates a config map with traefik configuration for a single new route.
 // `serviceName` is an arbitrary name identifying the configuration. This should be unique within operator. Che server only creates
 // new configuration for workspaces, so the name should not resemble any of the names created by the Che server.
-func GetGatewayRouteConfig(deployContext *deploy.DeployContext, serviceName string, pathPrefix string, priority int, internalUrl string, stripPrefix bool) corev1.ConfigMap {
+func GetGatewayRouteConfig(deployContext *deploy.DeployContext, component string, serviceName string, pathPrefix string, priority int, internalUrl string, stripPrefix bool) corev1.ConfigMap {
 	pathRewrite := pathPrefix != "/" && stripPrefix
 
 	data := `---
@@ -225,14 +225,14 @@ http:
 			Kind:       "ConfigMap",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceName,
+			Name:      component,
 			Namespace: deployContext.CheCluster.Namespace,
 			Labels: util.MergeMaps(
 				deploy.GetLabels(deployContext.CheCluster, gatewayConfigComponentName),
 				util.GetMapValue(deployContext.CheCluster.Spec.Server.SingleHostGatewayConfigMapLabels, deploy.DefaultSingleHostGatewayConfigMapLabels)),
 		},
 		Data: map[string]string{
-			serviceName + ".yml": data,
+			component + ".yml": data,
 		},
 	}
 
@@ -255,7 +255,7 @@ func DeleteGatewayRouteConfig(serviceName string, deployContext *deploy.DeployCo
 // below functions declare the desired states of the various objects required for the gateway
 
 func getGatewayServerConfigSpec(deployContext *deploy.DeployContext) corev1.ConfigMap {
-	return GetGatewayRouteConfig(deployContext, gatewayServerConfigName, "/", 1, "http://"+deploy.CheServiceName+":8080", false)
+	return GetGatewayRouteConfig(deployContext, gatewayServerConfigName, gatewayServerConfigName, "/", 1, "http://"+deploy.CheServiceName+":8080", false)
 }
 
 func getGatewayServiceAccountSpec(instance *orgv1.CheCluster) corev1.ServiceAccount {

--- a/pkg/deploy/identity-provider/deployment_keycloak.go
+++ b/pkg/deploy/identity-provider/deployment_keycloak.go
@@ -540,7 +540,7 @@ func GetSpecKeycloakDeployment(
 		if cheFlavor == "codeready" {
 			keycloakEnv = append(keycloakEnv, corev1.EnvVar{
 				Name:  "KEYCLOAK_FRONTEND_URL",
-				Value: deployContext.CheCluster.Status.KeycloakURL + "/auth",
+				Value: deployContext.CheCluster.Status.KeycloakURL,
 			})
 		}
 	}

--- a/pkg/deploy/identity-provider/identity_provider.go
+++ b/pkg/deploy/identity-provider/identity_provider.go
@@ -80,11 +80,9 @@ func syncExposure(deployContext *deploy.DeployContext) (bool, error) {
 		false: "http"})[cr.Spec.Server.TlsSupport]
 	endpoint, done, err := expose.Expose(
 		deployContext,
-		cr.Spec.Server.CheHost,
 		deploy.IdentityProviderName,
 		cr.Spec.Auth.IdentityProviderRoute,
-		cr.Spec.Auth.IdentityProviderIngress,
-		deploy.IdentityProviderName)
+		cr.Spec.Auth.IdentityProviderIngress)
 	if !done {
 		return false, err
 	}

--- a/pkg/deploy/identity-provider/identity_provider.go
+++ b/pkg/deploy/identity-provider/identity_provider.go
@@ -88,7 +88,7 @@ func syncExposure(deployContext *deploy.DeployContext) (bool, error) {
 	}
 
 	keycloakURL := protocol + "://" + endpoint
-	deployContext.InternalService.KeycloakHost = fmt.Sprintf("%s://%s.%s.svc:%d", "http", deploy.IdentityProviderName, cr.Namespace, 8080)
+	deployContext.InternalService.KeycloakHost = fmt.Sprintf("%s://%s.%s.svc:%d/auth", "http", deploy.IdentityProviderName, cr.Namespace, 8080)
 
 	if cr.Spec.Auth.IdentityProviderURL != keycloakURL {
 		cr.Spec.Auth.IdentityProviderURL = keycloakURL

--- a/pkg/deploy/ingres_test.go
+++ b/pkg/deploy/ingres_test.go
@@ -37,6 +37,7 @@ func TestIngressSpec(t *testing.T) {
 		name                  string
 		ingressName           string
 		ingressHost           string
+		ingressPath           string
 		ingressComponent      string
 		serviceName           string
 		servicePort           int
@@ -57,6 +58,7 @@ func TestIngressSpec(t *testing.T) {
 			ingressName:      "test",
 			ingressComponent: "test-component",
 			ingressHost:      "test-host",
+			ingressPath:      "",
 			serviceName:      "che",
 			servicePort:      8080,
 			ingressCustomSettings: orgv1.IngressCustomSettings{
@@ -124,9 +126,10 @@ func TestIngressSpec(t *testing.T) {
 				},
 			}
 
-			actualIngress := GetIngressSpec(deployContext,
+			_, actualIngress := GetIngressSpec(deployContext,
 				testCase.ingressName,
 				testCase.ingressHost,
+				testCase.ingressPath,
 				testCase.serviceName,
 				testCase.servicePort,
 				testCase.ingressCustomSettings,
@@ -157,12 +160,12 @@ func TestSyncIngressToCluster(t *testing.T) {
 		},
 	}
 
-	done, err := SyncIngressToCluster(deployContext, "test", "host-1", "service-1", 8080, orgv1.IngressCustomSettings{}, "component")
+	_, done, err := SyncIngressToCluster(deployContext, "test", "host-1", "", "service-1", 8080, orgv1.IngressCustomSettings{}, "component")
 	if !done || err != nil {
 		t.Fatalf("Failed to sync ingress: %v", err)
 	}
 
-	done, err = SyncIngressToCluster(deployContext, "test", "host-2", "service-2", 8080, orgv1.IngressCustomSettings{}, "component")
+	_, done, err = SyncIngressToCluster(deployContext, "test", "host-2", "", "service-2", 8080, orgv1.IngressCustomSettings{}, "component")
 	if !done || err != nil {
 		t.Fatalf("Failed to sync ingress: %v", err)
 	}

--- a/pkg/deploy/oauthclient.go
+++ b/pkg/deploy/oauthclient.go
@@ -29,7 +29,7 @@ func GetOAuthClientSpec(name string, oauthSecret string, keycloakURL string, key
 		providerName = "openshift-v4"
 	}
 
-	redirectURLSuffix := "/auth/realms/" + keycloakRealm + "/broker/" + providerName + "/endpoint"
+	redirectURLSuffix := "/realms/" + keycloakRealm + "/broker/" + providerName + "/endpoint"
 	redirectURIs := []string{
 		keycloakURL + redirectURLSuffix,
 	}

--- a/pkg/deploy/plugin-registry/plugin_registry.go
+++ b/pkg/deploy/plugin-registry/plugin_registry.go
@@ -14,6 +14,7 @@ package plugin_registry
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/eclipse-che/che-operator/pkg/deploy"
 	"github.com/eclipse-che/che-operator/pkg/deploy/expose"
@@ -31,25 +32,29 @@ type PluginRegistryConfigMap struct {
 /**
  * Create plugin registry resources unless an external registry is used.
  */
-func SyncPluginRegistryToCluster(deployContext *deploy.DeployContext, cheHost string) (bool, error) {
+func SyncPluginRegistryToCluster(deployContext *deploy.DeployContext) (bool, error) {
 	pluginRegistryURL := deployContext.CheCluster.Spec.Server.PluginRegistryUrl
 	if !deployContext.CheCluster.Spec.Server.ExternalPluginRegistry {
 		endpoint, done, err := expose.Expose(
 			deployContext,
-			cheHost,
 			deploy.PluginRegistryName,
 			deployContext.CheCluster.Spec.Server.PluginRegistryRoute,
-			deployContext.CheCluster.Spec.Server.PluginRegistryIngress,
-			deploy.PluginRegistryName)
+			deployContext.CheCluster.Spec.Server.PluginRegistryIngress)
 		if !done {
 			return false, err
 		}
 
 		if pluginRegistryURL == "" {
 			if deployContext.CheCluster.Spec.Server.TlsSupport {
-				pluginRegistryURL = "https://" + endpoint + "/v3"
+				pluginRegistryURL = "https://" + endpoint
 			} else {
-				pluginRegistryURL = "http://" + endpoint + "/v3"
+				pluginRegistryURL = "http://" + endpoint
+			}
+			// append the API version to plugin registry
+			if !strings.HasSuffix(pluginRegistryURL, "/") {
+				pluginRegistryURL = pluginRegistryURL + "/v3"
+			} else {
+				pluginRegistryURL = pluginRegistryURL + "v3"
 			}
 		}
 

--- a/pkg/deploy/route.go
+++ b/pkg/deploy/route.go
@@ -106,6 +106,7 @@ func GetRouteSpec(
 			Name:   serviceName,
 			Weight: &weight,
 		},
+		Path: path,
 		Port: &routev1.RoutePort{
 			TargetPort: targetPort,
 		},
@@ -113,10 +114,8 @@ func GetRouteSpec(
 
 	if host != "" {
 		route.Spec.Host = host
-		route.Spec.Path = path
 	} else if routeCustomSettings.Domain != "" {
 		route.Spec.Host = fmt.Sprintf(HostNameTemplate, route.ObjectMeta.Name, route.ObjectMeta.Namespace, routeCustomSettings.Domain)
-		route.Spec.Path = path
 	}
 
 	if tlsSupport {

--- a/pkg/deploy/route.go
+++ b/pkg/deploy/route.go
@@ -50,12 +50,13 @@ func SyncRouteToCluster(
 	deployContext *DeployContext,
 	name string,
 	host string,
+	path string,
 	serviceName string,
 	servicePort int32,
 	routeCustomSettings orgv1.RouteCustomSettings,
 	component string) (bool, error) {
 
-	routeSpec, err := GetRouteSpec(deployContext, name, host, serviceName, servicePort, routeCustomSettings, component)
+	routeSpec, err := GetRouteSpec(deployContext, name, host, path, serviceName, servicePort, routeCustomSettings, component)
 	if err != nil {
 		return false, err
 	}
@@ -71,6 +72,7 @@ func GetRouteSpec(
 	deployContext *DeployContext,
 	name string,
 	host string,
+	path string,
 	serviceName string,
 	servicePort int32,
 	routeCustomSettings orgv1.RouteCustomSettings,
@@ -111,8 +113,10 @@ func GetRouteSpec(
 
 	if host != "" {
 		route.Spec.Host = host
+		route.Spec.Path = path
 	} else if routeCustomSettings.Domain != "" {
 		route.Spec.Host = fmt.Sprintf(HostNameTemplate, route.ObjectMeta.Name, route.ObjectMeta.Namespace, routeCustomSettings.Domain)
+		route.Spec.Path = path
 	}
 
 	if tlsSupport {

--- a/pkg/deploy/route_test.go
+++ b/pkg/deploy/route_test.go
@@ -39,6 +39,7 @@ func TestRouteSpec(t *testing.T) {
 		name                string
 		routeName           string
 		routeHost           string
+		routePath           string
 		routeComponent      string
 		serviceName         string
 		servicePort         int32
@@ -160,6 +161,7 @@ func TestRouteSpec(t *testing.T) {
 			actualRoute, err := GetRouteSpec(deployContext,
 				testCase.routeName,
 				testCase.routeHost,
+				testCase.routePath,
 				testCase.serviceName,
 				testCase.servicePort,
 				testCase.routeCustomSettings,
@@ -194,13 +196,13 @@ func TestSyncRouteToCluster(t *testing.T) {
 		},
 	}
 
-	done, err := SyncRouteToCluster(deployContext, "test", "", "service", 80, orgv1.RouteCustomSettings{}, "test")
+	done, err := SyncRouteToCluster(deployContext, "test", "", "", "service", 80, orgv1.RouteCustomSettings{}, "test")
 	if !done || err != nil {
 		t.Fatalf("Failed to sync route: %v", err)
 	}
 
 	// sync another route
-	done, err = SyncRouteToCluster(deployContext, "test", "", "service", 90, orgv1.RouteCustomSettings{}, "test")
+	done, err = SyncRouteToCluster(deployContext, "test", "", "", "service", 90, orgv1.RouteCustomSettings{}, "test")
 	if !done || err != nil {
 		t.Fatalf("Failed to sync route: %v", err)
 	}
@@ -215,7 +217,7 @@ func TestSyncRouteToCluster(t *testing.T) {
 	}
 
 	// sync route with labels & domain
-	done, err = SyncRouteToCluster(deployContext, "test", "", "service", 90, orgv1.RouteCustomSettings{Labels: "a=b", Domain: "domain"}, "test")
+	done, err = SyncRouteToCluster(deployContext, "test", "", "", "service", 90, orgv1.RouteCustomSettings{Labels: "a=b", Domain: "domain"}, "test")
 	if !done || err != nil {
 		t.Fatalf("Failed to sync route: %v", err)
 	}

--- a/pkg/deploy/server/che_configmap.go
+++ b/pkg/deploy/server/che_configmap.go
@@ -175,7 +175,7 @@ func GetCheConfigMapData(deployContext *deploy.DeployContext) (cheEnv map[string
 	var keycloakInternalURL, pluginRegistryInternalURL, devfileRegistryInternalURL, cheInternalAPI, webSocketEndpoint, webSocketEndpointMinor string
 
 	if deployContext.CheCluster.Spec.Server.UseInternalClusterSVCNames && !deployContext.CheCluster.Spec.Auth.ExternalIdentityProvider {
-		keycloakInternalURL = deployContext.InternalService.KeycloakHost
+		keycloakInternalURL = deployContext.InternalService.KeycloakHost + "/auth"
 	} else {
 		keycloakInternalURL = keycloakURL
 	}
@@ -261,8 +261,8 @@ func GetCheConfigMapData(deployContext *deploy.DeployContext) (cheEnv map[string
 	}
 
 	if cheMultiUser == "true" {
-		data.KeycloakURL = keycloakURL + "/auth"
-		data.KeycloakInternalURL = keycloakInternalURL + "/auth"
+		data.KeycloakURL = keycloakURL
+		data.KeycloakInternalURL = keycloakInternalURL
 		data.KeycloakRealm = keycloakRealm
 		data.KeycloakClientId = keycloakClientId
 		data.DatabaseURL = "jdbc:postgresql://" + chePostgresHostName + ":" + chePostgresPort + "/" + chePostgresDb

--- a/pkg/deploy/server/che_configmap.go
+++ b/pkg/deploy/server/che_configmap.go
@@ -175,7 +175,7 @@ func GetCheConfigMapData(deployContext *deploy.DeployContext) (cheEnv map[string
 	var keycloakInternalURL, pluginRegistryInternalURL, devfileRegistryInternalURL, cheInternalAPI, webSocketEndpoint, webSocketEndpointMinor string
 
 	if deployContext.CheCluster.Spec.Server.UseInternalClusterSVCNames && !deployContext.CheCluster.Spec.Auth.ExternalIdentityProvider {
-		keycloakInternalURL = deployContext.InternalService.KeycloakHost + "/auth"
+		keycloakInternalURL = deployContext.InternalService.KeycloakHost
 	} else {
 		keycloakInternalURL = keycloakURL
 	}

--- a/pkg/deploy/server/che_configmap_test.go
+++ b/pkg/deploy/server/che_configmap_test.go
@@ -921,7 +921,7 @@ func TestShouldSetUpCorrectlyInternalIdentityProviderServiceURL(t *testing.T) {
 				},
 				Proxy: &deploy.Proxy{},
 				InternalService: deploy.InternalService{
-					KeycloakHost: "http://keycloak.eclipse-che.svc:8080",
+					KeycloakHost: "http://keycloak.eclipse-che.svc:8080/auth",
 				},
 			}
 

--- a/pkg/deploy/server/che_configmap_test.go
+++ b/pkg/deploy/server/che_configmap_test.go
@@ -816,7 +816,7 @@ func TestShouldSetUpCorrectlyInternalIdentityProviderServiceURL(t *testing.T) {
 					Auth: orgv1.CheClusterSpecAuth{
 						OpenShiftoAuth:           util.NewBoolPointer(false),
 						ExternalIdentityProvider: true,
-						IdentityProviderURL:      "http://external-keycloak",
+						IdentityProviderURL:      "http://external-keycloak/auth",
 					},
 				},
 			},
@@ -841,7 +841,7 @@ func TestShouldSetUpCorrectlyInternalIdentityProviderServiceURL(t *testing.T) {
 					Auth: orgv1.CheClusterSpecAuth{
 						OpenShiftoAuth:           util.NewBoolPointer(false),
 						ExternalIdentityProvider: true,
-						IdentityProviderURL:      "http://external-keycloak",
+						IdentityProviderURL:      "http://external-keycloak/auth",
 					},
 				},
 			},
@@ -866,7 +866,7 @@ func TestShouldSetUpCorrectlyInternalIdentityProviderServiceURL(t *testing.T) {
 					Auth: orgv1.CheClusterSpecAuth{
 						OpenShiftoAuth:           util.NewBoolPointer(false),
 						ExternalIdentityProvider: false,
-						IdentityProviderURL:      "http://keycloak",
+						IdentityProviderURL:      "http://keycloak/auth",
 					},
 				},
 				Status: orgv1.CheClusterStatus{
@@ -894,7 +894,7 @@ func TestShouldSetUpCorrectlyInternalIdentityProviderServiceURL(t *testing.T) {
 					Auth: orgv1.CheClusterSpecAuth{
 						OpenShiftoAuth:           util.NewBoolPointer(false),
 						ExternalIdentityProvider: false,
-						IdentityProviderURL:      "http://keycloak",
+						IdentityProviderURL:      "http://keycloak/auth",
 					},
 				},
 			},

--- a/pkg/deploy/tls.go
+++ b/pkg/deploy/tls.go
@@ -139,6 +139,7 @@ func GetEndpointTLSCrtChain(deployContext *DeployContext, endpointURL string) ([
 				deployContext,
 				"test",
 				"",
+				"",
 				"test",
 				8080,
 				deployContext.CheCluster.Spec.Server.CheServerRoute,
@@ -181,9 +182,10 @@ func GetEndpointTLSCrtChain(deployContext *DeployContext, endpointURL string) ([
 
 			// Create test ingress to get certificates chain.
 			// Note, it is not possible to use SyncIngressToCluster here as it may cause infinite reconcile loop.
-			ingressSpec := GetIngressSpec(
+			_, ingressSpec := GetIngressSpec(
 				deployContext,
 				"test",
+				"",
 				"",
 				"test",
 				8080,


### PR DESCRIPTION
### What does this PR do?
Refactor exposure to have an ability to share host among components.
It's needed since even in multi-host dashboard used to share Che API host and we're not going to change it for time being.
Its usage can be found at another PR where a dedicated pod for Che Dashboard is implemented: https://github.com/eclipse-che/che-operator/pull/684/commits/736efef02175397f3ffe7b0603736335eb96391d#diff-a434bd1b85e2ebded7afe3539d59f554f735b7890ad997c99d170ef0f813a4a9R56

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
It's prereq for dashboard in a separate deployment https://github.com/eclipse-che/che-operator/pull/684

### How to test this PR?
Nothing should be changed in user-facing stuff.

I tested:

**OpenShift (RHPDS):**
- multihost
- gateway singlehost

:notebook: I tested with dashboard changes but haven't retested after dropping it.
But nothing should change I believe.
**Minikube:**
- multihost
- gateway singlehost
- native singlehost


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/master/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/master/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
