### PR TITLE
Fix che operator single-host tests by adding devworkspace templates to chectl command

### DIFF
--- a/.github/bin/common.sh
+++ b/.github/bin/common.sh
@@ -34,7 +34,7 @@ initDefaults() {
   export OPERATOR_IMAGE="test/che-operator:test"
   export DEFAULT_DEVFILE="https://raw.githubusercontent.com/eclipse/che-devfile-registry/master/devfiles/quarkus/devfile.yaml"
   export CHE_EXPOSURE_STRATEGY="multi-host"
-
+  export DEV_WORKSPACE_CONTROLLER_VERSION="main"
   export OAUTH="false"
 
   # turn off telemetry
@@ -52,6 +52,11 @@ initOpenShiftDefaults() {
 }
 
 initLatestTemplates() {
+curl -L https://api.github.com/repos/devfile/devworkspace-operator/zipball/${DEV_WORKSPACE_CONTROLLER_VERSION} > /tmp/devworkspace-operator.zip && \
+  unzip /tmp/devworkspace-operator.zip */deploy/deployment/* -d /tmp && \
+  mkdir -p /tmp/devworkspace-operator/templates/ && \
+  mv /tmp/devfile-devworkspace-operator-*/deploy ${TEMPLATES}/devworkspace
+
   cp -rf ${OPERATOR_REPO}/deploy/* "${TEMPLATES}/che-operator"
 }
 


### PR DESCRIPTION
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
After merging: https://github.com/che-incubator/chectl/pull/1165, Some PR are failing like here: https://github.com/eclipse-che/che-operator/pull/762/checks?check_run_id=2297829370 with error:
```log
2021-04-08T20:48:19.5725009Z [20:48:19] Verify Kubernetes API...OK [title changed]
2021-04-08T20:48:19.5957906Z [20:48:19] Verify Kubernetes API...OK [completed]
2021-04-08T20:48:19.5963556Z [20:48:19] 👀  Looking for an already existing Eclipse Che instance [started]
2021-04-08T20:48:19.5967138Z [20:48:19] Verify if Eclipse Che is deployed into namespace "eclipse-che" [started]
2021-04-08T20:48:19.6036002Z [20:48:19] Verify if Eclipse Che is deployed into namespace "eclipse-che"...it is not [title changed]
2021-04-08T20:48:19.6037680Z [20:48:19] Verify if Eclipse Che is deployed into namespace "eclipse-che"...it is not [completed]
2021-04-08T20:48:19.6039202Z [20:48:19] 👀  Looking for an already existing Eclipse Che instance [completed]
2021-04-08T20:48:19.6040686Z [20:48:19] 🧪  DevWorkspace engine (experimental / technology preview) 🚨 [started]
2021-04-08T20:48:19.6043136Z [20:48:19] Create Namespace (devworkspace-controller) [started]
2021-04-08T20:48:19.6362183Z [20:48:19] Create Namespace (devworkspace-controller)...Done. [title changed]
2021-04-08T20:48:19.6364529Z [20:48:19] Create Namespace (devworkspace-controller)...Done. [completed]
2021-04-08T20:48:19.6365836Z [20:48:19] Verify cert-manager installation [started]
2021-04-08T20:48:19.6366800Z [20:48:19] Check Cert Manager deployment [started]
2021-04-08T20:48:19.6444913Z [20:48:19] Check Cert Manager deployment...not deployed [title changed]
2021-04-08T20:48:19.6445907Z [20:48:19] Check Cert Manager deployment...not deployed [completed]
2021-04-08T20:48:19.6447222Z [20:48:19] Deploy cert-manager [started]
2021-04-08T20:48:24.0206710Z [20:48:24] Deploy cert-manager...done [title changed]
2021-04-08T20:48:24.0212580Z [20:48:24] Deploy cert-manager...done [completed]
2021-04-08T20:48:24.0218303Z [20:48:24] Wait for cert-manager [started]
2021-04-08T20:48:44.6678691Z [20:48:44] Wait for cert-manager...ready [title changed]
2021-04-08T20:48:44.6679644Z [20:48:44] Wait for cert-manager...ready [completed]
2021-04-08T20:48:44.6680530Z [20:48:44] Verify cert-manager installation [completed]
2021-04-08T20:48:44.6681735Z [20:48:44] Create certificate issuer devworkspace-controller-selfsigned-issuer [started]
2021-04-08T20:48:44.6754500Z [20:48:44] Create certificate issuer devworkspace-controller-selfsigned-issuer [failed]
2021-04-08T20:48:44.6757272Z [20:48:44] → ENOENT: no such file or directory, open '/home/runner/work/che-operator/che-operator/tmp/devworkspace/deployment/kubernetes/objects/devworkspace-controller-selfsigned-issuer.Issuer.yaml'
2021-04-08T20:48:44.6759355Z [20:48:44] 🧪  DevWorkspace engine (experimental / technology preview) 🚨 [failed]
2021-04-08T20:48:44.6768836Z [20:48:44] → ENOENT: no such file or directory, open '/home/runner/work/che-operator/che-operator/tmp/devworkspace/deployment/kubernetes/objects/devworkspace-controller-selfsigned-issuer.Issuer.yaml'
2021-04-08T20:48:44.6929217Z  ›   Error: Error: ENOENT: no such file or directory, open 
2021-04-08T20:48:44.6930163Z  ›   '/home/runner/work/che-operator/che-operator/tmp/devworkspace/deployment/k
2021-04-08T20:48:44.6932528Z  ›   ubernetes/objects/devworkspace-controller-selfsigned-issuer.Issuer.yaml'
2021-04-08T20:48:44.6934666Z  ›   Command server:deploy failed. Error log: 
2021-04-08T20:48:44.6935865Z  ›   /home/runner/.cache/chectl/error.log Eclipse Che logs: 
2021-04-08T20:48:44.6936536Z  ›   /tmp/chectl-logs/1617914899431
```

We are telling chectl to use our custom templates in https://github.com/eclipse-che/che-operator/blob/master/.github/bin/common.sh#L167 and our custom templates includes only che-operator templates, here: https://github.com/eclipse-che/che-operator/blob/master/.github/bin/common.sh#L55 . In the PR I've added to latest templates devworkspace objects for openshift and kubernetes.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/master/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/master/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
