### PR TITLE
Add metrics role to the cluster role

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To deploy Che operator you can use [chectl](https://github.com/che-incubator/che
 2. Deploy Eclipse Che on a running k8s cluster:
 
 ```bash
-$ chectl deploy:deploy --installer operator -p <PLATFORM> --che-operator-image=${IMAGE_REGISTRY_HOST}/${IMAGE_REGISTRY_USER_NAME}/che-operator:nightly
+$ chectl server:deploy --installer operator -p <PLATFORM> --che-operator-image=${IMAGE_REGISTRY_HOST}/${IMAGE_REGISTRY_USER_NAME}/che-operator:nightly
 ```
 
 Where:
@@ -77,7 +77,7 @@ Where:
 > INFO: if you have changed Che operator deployment, roles, cluster roles, CRD or CR then you must use `--templates` flag to point chectl to modified Che operator templates. Copy all files from the `deploy` folder of the che-operator project into a folder `<SOME_PATH>/templates/che-operator` and use it with chectl:
 
 ```bash
-$ chectl deploy:deploy --installer operator -p <PLATFORM> --che-operator-image=${IMAGE_REGISTRY_HOST}/${IMAGE_REGISTRY_USER_NAME}/che-operator:nightly --templates <SOME_PATH>/templates
+$ chectl server:deploy --installer operator -p <PLATFORM> --che-operator-image=${IMAGE_REGISTRY_HOST}/${IMAGE_REGISTRY_USER_NAME}/che-operator:nightly --templates <SOME_PATH>/templates
 ```
 
 #### Deploy Che operator with chectl using `--installer olm` flag

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -335,6 +335,16 @@ rules:
       - list
       - watch
   - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
       - ""
     resources:
       - pods/exec

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -76,13 +76,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-04-22T07:34:35Z"
+    createdAt: "2021-04-29T08:03:21Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.30.0-170.nightly
+  name: eclipse-che-preview-kubernetes.v7.30.0-172.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -487,6 +487,16 @@ spec:
                 - list
                 - watch
             - apiGroups:
+                - metrics.k8s.io
+              resources:
+                - pods
+                - nodes
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - batch
                 - ""
               resources:
                 - pods/exec
@@ -1113,4 +1123,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.30.0-170.nightly
+  version: 7.30.0-172.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -67,13 +67,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-04-22T07:34:45Z"
+    createdAt: "2021-04-29T08:03:31Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.30.0-170.nightly
+  name: eclipse-che-preview-openshift.v7.30.0-172.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -556,6 +556,16 @@ spec:
                 - list
                 - watch
             - apiGroups:
+                - metrics.k8s.io
+              resources:
+                - pods
+                - nodes
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - batch
                 - ""
               resources:
                 - pods/exec
@@ -1186,4 +1196,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.30.0-170.nightly
+  version: 7.30.0-172.nightly

--- a/pkg/controller/che/workspace_namespace_permission.go
+++ b/pkg/controller/che/workspace_namespace_permission.go
@@ -399,6 +399,11 @@ func getWorkspacesPolicies() []rbac.PolicyRule {
 			Resources: []string{"rolebindings"},
 			Verbs:     []string{"get", "update", "create"},
 		},
+		{
+			APIGroups: []string{"metrics.k8s.io"},
+			Resources: []string{"pods", "nodes"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
 	}
 	openshiftPolicies := []rbac.PolicyRule{
 		{


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

### What does this PR do?

Adds role for **metrics.k8s.io** into cluster role to get an information from Metric server. It is need in case when workpsaces are running in different namespace than che

### Screenshot/screencast of this PR
![screenshot-nimbus-capture-2021 04 22-13_19_27](https://user-images.githubusercontent.com/1271546/115701313-54d76900-a370-11eb-8271-60d821dd87d4.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18812


### How to test this PR?


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
