### PR TITLE
fix: Add common selector for che-dashboard

### DIFF
--- a/pkg/deploy/dashboard/dashboard.go
+++ b/pkg/deploy/dashboard/dashboard.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// DashboardComponent which is supposed to be used for the naming related objects
-	DashboardComponent = "dashboard"
+	DashboardComponent = "che-dashboard"
 )
 
 type Dashboard struct {

--- a/pkg/deploy/dashboard/dashboard_test.go
+++ b/pkg/deploy/dashboard/dashboard_test.go
@@ -60,21 +60,21 @@ func TestDashboardAll(t *testing.T) {
 
 	// check service
 	service := &corev1.Service{}
-	err = cli.Get(context.TODO(), types.NamespacedName{Name: "dashboard", Namespace: "eclipse-che"}, service)
+	err = cli.Get(context.TODO(), types.NamespacedName{Name: DashboardComponent, Namespace: "eclipse-che"}, service)
 	if err != nil {
 		t.Fatalf("Service not found: %v", err)
 	}
 
 	// check endpoint
 	route := &routev1.Route{}
-	err = cli.Get(context.TODO(), types.NamespacedName{Name: "dashboard", Namespace: "eclipse-che"}, route)
+	err = cli.Get(context.TODO(), types.NamespacedName{Name: DashboardComponent, Namespace: "eclipse-che"}, route)
 	if err != nil {
 		t.Fatalf("Route not found: %v", err)
 	}
 
 	// check deployment
 	deployment := &appsv1.Deployment{}
-	err = cli.Get(context.TODO(), types.NamespacedName{Name: "dashboard", Namespace: "eclipse-che"}, deployment)
+	err = cli.Get(context.TODO(), types.NamespacedName{Name: DashboardComponent, Namespace: "eclipse-che"}, deployment)
 	if err != nil {
 		t.Fatalf("Deployment not found: %v", err)
 	}

--- a/pkg/deploy/dashboard/deployment_dashboard.go
+++ b/pkg/deploy/dashboard/deployment_dashboard.go
@@ -24,7 +24,8 @@ import (
 
 func (p *Dashboard) getDashboardDeploymentSpec() (*appsv1.Deployment, error) {
 	terminationGracePeriodSeconds := int64(30)
-	labels := deploy.GetLabels(p.deployContext.CheCluster, DashboardComponent)
+	labels, labelsSelector := deploy.GetLabelsAndSelector(p.deployContext.CheCluster, DashboardComponent)
+
 	dashboardImageAndTag := util.GetValue(p.deployContext.CheCluster.Spec.Server.DashboardImage, deploy.DefaultDashboardImage(p.deployContext.CheCluster))
 	pullPolicy := corev1.PullPolicy(util.GetValue(p.deployContext.CheCluster.Spec.Server.DashboardImagePullPolicy, deploy.DefaultPullPolicyFromDockerImage(dashboardImageAndTag)))
 
@@ -39,7 +40,7 @@ func (p *Dashboard) getDashboardDeploymentSpec() (*appsv1.Deployment, error) {
 			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Selector: &metav1.LabelSelector{MatchLabels: labelsSelector},
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RollingUpdateDeploymentStrategyType,
 			},


### PR DESCRIPTION
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Add common labelSelector for che-dashboard like other components have. In our helm chart we are including a `component: che-dashboard` https://github.com/eclipse/che/blob/master/deploy/kubernetes/helm/che/templates/dashboard-deployment.yaml#L15

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19605

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
1. Build che-operator image and deploy with chectl: `chectl server:deploy -p minikube --installer=operator --che-operator-image=<image-builded>`
2. check the labels using: `kubectl get pod <dashboard-pod> --show-labels`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
