### PR TITLE
Do not allow to upgrade che 7.31 or later to upgrade installation that configured with namespace strategies other than "per user"

### DIFF
--- a/deploy/crds/org_v1_che_crd-v1beta1.yaml
+++ b/deploy/crds/org_v1_che_crd-v1beta1.yaml
@@ -437,10 +437,11 @@ spec:
                     Eclipse Che in a restricted environment.
                   type: string
                 allowUserDefinedWorkspaceNamespaces:
-                  description: Defines that a user is allowed to specify a Kubernetes
-                    namespace, or an OpenShift project, which differs from the default.
-                    It's NOT RECOMMENDED to set to `true` without OpenShift OAuth
-                    configured. The OpenShift infrastructure also uses this property.
+                  description: Deprecated. The value of this flag is ignored. Defines
+                    that a user is allowed to specify a Kubernetes namespace, or an
+                    OpenShift project, which differs from the default. It's NOT RECOMMENDED
+                    to set to `true` without OpenShift OAuth configured. The OpenShift
+                    infrastructure also uses this property.
                   type: boolean
                 cheClusterRoles:
                   description: A comma-separated list of ClusterRoles that will be

--- a/deploy/crds/org_v1_che_crd.yaml
+++ b/deploy/crds/org_v1_che_crd.yaml
@@ -447,10 +447,11 @@ spec:
                       install Eclipse Che in a restricted environment.
                     type: string
                   allowUserDefinedWorkspaceNamespaces:
-                    description: Defines that a user is allowed to specify a Kubernetes
-                      namespace, or an OpenShift project, which differs from the default.
-                      It's NOT RECOMMENDED to set to `true` without OpenShift OAuth
-                      configured. The OpenShift infrastructure also uses this property.
+                    description: Deprecated. The value of this flag is ignored. Defines
+                      that a user is allowed to specify a Kubernetes namespace, or
+                      an OpenShift project, which differs from the default. It's NOT
+                      RECOMMENDED to set to `true` without OpenShift OAuth configured.
+                      The OpenShift infrastructure also uses this property.
                     type: boolean
                   cheClusterRoles:
                     description: A comma-separated list of ClusterRoles that will

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -76,13 +76,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-05-11T18:38:31Z"
+    createdAt: "2021-05-12T08:55:32Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.30.0-176.nightly
+  name: eclipse-che-preview-kubernetes.v7.31.0-178.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1132,4 +1132,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.30.0-176.nightly
+  version: 7.31.0-178.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/org_v1_che_crd.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/org_v1_che_crd.yaml
@@ -447,10 +447,11 @@ spec:
                       install Eclipse Che in a restricted environment.
                     type: string
                   allowUserDefinedWorkspaceNamespaces:
-                    description: Defines that a user is allowed to specify a Kubernetes
-                      namespace, or an OpenShift project, which differs from the default.
-                      It's NOT RECOMMENDED to set to `true` without OpenShift OAuth
-                      configured. The OpenShift infrastructure also uses this property.
+                    description: Deprecated. The value of this flag is ignored. Defines
+                      that a user is allowed to specify a Kubernetes namespace, or
+                      an OpenShift project, which differs from the default. It's NOT
+                      RECOMMENDED to set to `true` without OpenShift OAuth configured.
+                      The OpenShift infrastructure also uses this property.
                     type: boolean
                   cheClusterRoles:
                     description: A comma-separated list of ClusterRoles that will

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -67,13 +67,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-05-11T18:38:45Z"
+    createdAt: "2021-05-12T08:55:42Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.30.0-176.nightly
+  name: eclipse-che-preview-openshift.v7.31.0-178.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1207,4 +1207,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.30.0-176.nightly
+  version: 7.31.0-178.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
@@ -452,11 +452,11 @@ spec:
                         useful to install Eclipse Che in a restricted environment.
                       type: string
                     allowUserDefinedWorkspaceNamespaces:
-                      description: Defines that a user is allowed to specify a Kubernetes
-                        namespace, or an OpenShift project, which differs from the
-                        default. It's NOT RECOMMENDED to set to `true` without OpenShift
-                        OAuth configured. The OpenShift infrastructure also uses this
-                        property.
+                      description: Deprecated. The value of this flag is ignored.
+                        Defines that a user is allowed to specify a Kubernetes namespace,
+                        or an OpenShift project, which differs from the default. It's
+                        NOT RECOMMENDED to set to `true` without OpenShift OAuth configured.
+                        The OpenShift infrastructure also uses this property.
                       type: boolean
                     cheClusterRoles:
                       description: A comma-separated list of ClusterRoles that will

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -116,6 +116,7 @@ type CheClusterSpecServer struct {
 	// In that case, a new namespace will be created for each user or workspace.
 	// +optional
 	WorkspaceNamespaceDefault string `json:"workspaceNamespaceDefault,omitempty"`
+	// Deprecated. The value of this flag is ignored.
 	// Defines that a user is allowed to specify a Kubernetes namespace, or an OpenShift project, which differs from the default.
 	// It's NOT RECOMMENDED to set to `true` without OpenShift OAuth configured. The OpenShift infrastructure also uses this property.
 	// +optional

--- a/pkg/controller/che/che_controller_test.go
+++ b/pkg/controller/che/che_controller_test.go
@@ -901,9 +901,6 @@ func TestCheController(t *testing.T) {
 	if err := cl.Get(context.TODO(), types.NamespacedName{Name: "che", Namespace: cheCR.Namespace}, cm); err != nil {
 		t.Errorf("ConfigMap %s not found: %s", cm.Name, err)
 	}
-	if cm.Data["CHE_INFRA_OPENSHIFT_PROJECT"] != "" {
-		t.Errorf("ConfigMap wasn't updated properly. Extecting empty string, got: '%s'", cm.Data["CHE_INFRA_OPENSHIFT_PROJECT"])
-	}
 
 	_, isOpenshiftv4, err := util.DetectOpenShift()
 	if err != nil {
@@ -1101,30 +1098,6 @@ func TestShouldDelegatePermissionsForCheWorkspaces(t *testing.T) {
 	crWsInAnotherNs3.Spec.Server.WorkspaceNamespaceDefault = "some-test-namespace"
 
 	testCases := []testCase{
-		// {
-		// 	name:        "che-operator should delegate permission for workspaces in the same namespace with Che. WorkspaceNamespaceDefault=" + crWsInTheSameNs1.Namespace,
-		// 	initObjects: []runtime.Object{},
-		// 	clusterRole: false,
-		// 	checluster:  crWsInTheSameNs1,
-		// },
-		// {
-		// 	name:        "che-operator should delegate permission for workspaces in the same namespace with Che. WorkspaceNamespaceDefault=''",
-		// 	initObjects: []runtime.Object{},
-		// 	clusterRole: false,
-		// 	checluster:  crWsInTheSameNs2,
-		// },
-		// {
-		// 	name:        "che-operator should delegate permission for workspaces in the same namespace with Che. Property CHE_INFRA_KUBERNETES_NAMESPACE_DEFAULT=''",
-		// 	initObjects: []runtime.Object{},
-		// 	clusterRole: false,
-		// 	checluster:  crWsInTheSameNs3,
-		// },
-		// {
-		// 	name:        "che-operator should delegate permission for workspaces in the same namespace with Che. Property CHE_INFRA_KUBERNETES_NAMESPACE_DEFAULT=" + crWsInTheSameNs1.Namespace,
-		// 	initObjects: []runtime.Object{},
-		// 	clusterRole: false,
-		// 	checluster:  crWsInTheSameNs4,
-		// },
 		{
 			name:        "che-operator should delegate permission for workspaces in differ namespace than Che. WorkspaceNamespaceDefault = 'some-test-namespace'",
 			initObjects: []runtime.Object{},
@@ -1137,12 +1110,6 @@ func TestShouldDelegatePermissionsForCheWorkspaces(t *testing.T) {
 			clusterRole: true,
 			checluster:  crWsInAnotherNs2,
 		},
-		// {
-		// 	name:        "che-operator should delegate permission for workspaces in differ namespace than Che. Property CHE_INFRA_KUBERNETES_NAMESPACE_DEFAULT points to Che namespace with higher priority WorkspaceNamespaceDefault = 'some-test-namespace'.",
-		// 	initObjects: []runtime.Object{},
-		// 	clusterRole: false,
-		// 	checluster:  crWsInAnotherNs3,
-		// },
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/pkg/controller/che/che_cr_validator.go
+++ b/pkg/controller/che/che_cr_validator.go
@@ -13,8 +13,10 @@ package che
 
 import (
 	"fmt"
+	"strings"
 
 	orgv1 "github.com/eclipse-che/che-operator/pkg/apis/org/v1"
+	"github.com/eclipse-che/che-operator/pkg/util"
 )
 
 // ValidateCheCR checks Che CR configuration.
@@ -22,11 +24,18 @@ import (
 // - configurations which miss required field(s) to deploy Che
 // - self-contradictory configurations
 // - configurations with which it is impossible to deploy Che
-func ValidateCheCR(checluster *orgv1.CheCluster, isOpenshift bool) error {
-	if !isOpenshift {
+func ValidateCheCR(checluster *orgv1.CheCluster) error {
+	if !util.IsOpenShift {
 		if checluster.Spec.K8s.IngressDomain == "" {
 			return fmt.Errorf("Required field \"spec.K8s.IngressDomain\" is not set")
 		}
+	}
+
+	workspaceNamespaceDefault := util.GetWorkspaceNamespaceDefault(checluster)
+	if strings.Index(workspaceNamespaceDefault, "<username>") == -1 && strings.Index(workspaceNamespaceDefault, "<userid>") == -1 {
+		return fmt.Errorf(`Namespace strategies other than 'per user' is not supported anymore.
+ Using the <username> or <userid> placeholder is required in the 'spec.server.workspaceNamespaceDefault' field.
+ The current value is: %s`, workspaceNamespaceDefault)
 	}
 
 	return nil

--- a/pkg/controller/che/che_cr_validator.go
+++ b/pkg/controller/che/che_cr_validator.go
@@ -33,9 +33,7 @@ func ValidateCheCR(checluster *orgv1.CheCluster) error {
 
 	workspaceNamespaceDefault := util.GetWorkspaceNamespaceDefault(checluster)
 	if strings.Index(workspaceNamespaceDefault, "<username>") == -1 && strings.Index(workspaceNamespaceDefault, "<userid>") == -1 {
-		return fmt.Errorf(`Namespace strategies other than 'per user' is not supported anymore.
- Using the <username> or <userid> placeholder is required in the 'spec.server.workspaceNamespaceDefault' field.
- The current value is: %s`, workspaceNamespaceDefault)
+		return fmt.Errorf(`Namespace strategies other than 'per user' is not supported anymore. Using the <username> or <userid> placeholder is required in the 'spec.server.workspaceNamespaceDefault' field. The current value is: %s`, workspaceNamespaceDefault)
 	}
 
 	return nil

--- a/pkg/controller/che/workspace_namespace_permission.go
+++ b/pkg/controller/che/workspace_namespace_permission.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/eclipse-che/che-operator/pkg/deploy"
 	"github.com/eclipse-che/che-operator/pkg/util"
-	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -45,56 +44,12 @@ const (
 
 // Reconcile workspace permissions based on workspace strategy
 func (r *ReconcileChe) reconcileWorkspacePermissions(deployContext *deploy.DeployContext) (bool, error) {
-	// The only supported namespace strategy is `per-user`.
-	// We have to remove some permissions if user switched from others.
-	done, err := r.removeWorkspacePermissionsInSameNamespaceWithChe(deployContext)
-	if !done {
-		return false, err
-	}
-
-	// Add workspaces cluster permission finalizer to the CR if deletion timestamp is 0.
-	// Or delete workspaces cluster permission set and finalizer from CR if deletion timestamp is not 0.
-	done, err = r.delegateWorkspacePermissionsInTheDifferNamespaceThanChe(deployContext)
+	done, err := r.delegateWorkspacePermissionsInTheDifferNamespaceThanChe(deployContext)
 	if !done {
 		return false, err
 	}
 
 	done, err = r.delegateNamespaceEditorPermissions(deployContext)
-	if !done {
-		return false, err
-	}
-
-	return true, nil
-}
-
-// removeWorkspacePermissionsInSameNamespaceWithChe - removes workspaces in same namespace with Che role and rolebindings.
-func (r *ReconcileChe) removeWorkspacePermissionsInSameNamespaceWithChe(deployContext *deploy.DeployContext) (bool, error) {
-	done, err := deploy.DeleteNamespacedObject(deployContext, deploy.ExecRoleName, &rbac.Role{})
-	if !done {
-		return false, err
-	}
-
-	done, err = deploy.DeleteNamespacedObject(deployContext, ExecRoleBindingName, &rbac.RoleBinding{})
-	if !done {
-		return false, err
-	}
-
-	done, err = deploy.DeleteNamespacedObject(deployContext, deploy.ViewRoleName, &rbac.Role{})
-	if !done {
-		return false, err
-	}
-
-	done, err = deploy.DeleteNamespacedObject(deployContext, ViewRoleBindingName, &rbac.RoleBinding{})
-	if !done {
-		return false, err
-	}
-
-	done, err = deploy.DeleteNamespacedObject(deployContext, EditRoleBindingName, &rbac.RoleBinding{})
-	if !done {
-		return false, err
-	}
-
-	done, err = deploy.DeleteNamespacedObject(deployContext, CheWorkspacesServiceAccount, &corev1.ServiceAccount{})
 	if !done {
 		return false, err
 	}

--- a/pkg/controller/che/workspace_namespace_permission.go
+++ b/pkg/controller/che/workspace_namespace_permission.go
@@ -45,8 +45,8 @@ const (
 
 // Reconcile workspace permissions based on workspace strategy
 func (r *ReconcileChe) reconcileWorkspacePermissions(deployContext *deploy.DeployContext) (bool, error) {
-	// if util.IsWorkspacePermissionsInTheDifferNamespaceThanCheRequired(deployContext.CheCluster) {
-	// Delete permission set for configuration "same namespace for Che and workspaces".
+	// The only supported namespace strategy is `per-user`.
+	// We have to remove some permissions if user switched from others.
 	done, err := r.removeWorkspacePermissionsInSameNamespaceWithChe(deployContext)
 	if !done {
 		return false, err
@@ -58,18 +58,6 @@ func (r *ReconcileChe) reconcileWorkspacePermissions(deployContext *deploy.Deplo
 	if !done {
 		return false, err
 	}
-	// } else {
-	// 	// Delete workspaces cluster permission set and finalizer from CR if deletion timestamp is not 0.
-	// 	done, err := r.removeWorkspacePermissionsInTheDifferNamespaceThanChe(deployContext)
-	// 	if !done {
-	// 		return false, err
-	// 	}
-
-	// 	done, err = r.delegateWorkspacePermissionsInTheSameNamespaceWithChe(deployContext)
-	// 	if !done {
-	// 		return false, err
-	// 	}
-	// }
 
 	done, err = r.delegateNamespaceEditorPermissions(deployContext)
 	if !done {
@@ -78,54 +66,6 @@ func (r *ReconcileChe) reconcileWorkspacePermissions(deployContext *deploy.Deplo
 
 	return true, nil
 }
-
-// delegateWorkspacePermissionsInTheSameNamespaceWithChe - creates "che-workspace" service account(for Che workspaces) and
-// delegates "che-operator" SA permissions to the service accounts: "che" and "che-workspace".
-// Also this method binds "edit" default k8s clusterrole using rolebinding to "che" SA.
-// func (r *ReconcileChe) delegateWorkspacePermissionsInTheSameNamespaceWithChe(deployContext *deploy.DeployContext) (bool, error) {
-// 	// Create "che-workspace" service account.
-// 	// Che workspace components use this service account.
-// 	done, err := deploy.SyncServiceAccountToCluster(deployContext, CheWorkspacesServiceAccount)
-// 	if !done {
-// 		return false, err
-// 	}
-
-// 	// Create view role for "che-workspace" service account.
-// 	// This role used by exec terminals, tasks, metric che-theia plugin and so on.
-// 	done, err = deploy.SyncViewRoleToCluster(deployContext)
-// 	if !done {
-// 		return false, err
-// 	}
-
-// 	done, err = deploy.SyncRoleBindingToCluster(deployContext, ViewRoleBindingName, CheWorkspacesServiceAccount, deploy.ViewRoleName, "Role")
-// 	if !done {
-// 		return false, err
-// 	}
-
-// 	// Create exec role for "che-workspaces" service account.
-// 	// This role used by exec terminals, tasks and so on.
-// 	done, err = deploy.SyncExecRoleToCluster(deployContext)
-// 	if !done {
-// 		return false, err
-// 	}
-
-// 	done, err = deploy.SyncRoleBindingToCluster(deployContext, ExecRoleBindingName, CheWorkspacesServiceAccount, deploy.ExecRoleName, "Role")
-// 	if !done {
-// 		return false, err
-// 	}
-
-// 	// Bind "edit" cluster role for "che" service account.
-// 	// che-operator doesn't create "edit" role. This role is pre-created on the cluster.
-// 	// Warning: operator binds clusterrole using rolebinding(not clusterrolebinding).
-// 	// That's why "che" service account has got permissions only in the one namespace!
-// 	// So permissions are binding in "non-cluster" scope.
-// 	done, err = deploy.SyncRoleBindingToCluster(deployContext, EditRoleBindingName, CheServiceAccountName, EditClusterRoleName, "ClusterRole")
-// 	if !done {
-// 		return false, err
-// 	}
-
-// 	return true, nil
-// }
 
 // removeWorkspacePermissionsInSameNamespaceWithChe - removes workspaces in same namespace with Che role and rolebindings.
 func (r *ReconcileChe) removeWorkspacePermissionsInSameNamespaceWithChe(deployContext *deploy.DeployContext) (bool, error) {

--- a/pkg/deploy/server/che_configmap.go
+++ b/pkg/deploy/server/che_configmap.go
@@ -48,7 +48,6 @@ type CheConfigMap struct {
 	CheInfrastructureActive                string `json:"CHE_INFRASTRUCTURE_ACTIVE"`
 	CheInfraKubernetesServiceAccountName   string `json:"CHE_INFRA_KUBERNETES_SERVICE__ACCOUNT__NAME"`
 	DefaultTargetNamespace                 string `json:"CHE_INFRA_KUBERNETES_NAMESPACE_DEFAULT"`
-	NamespaceAllowUserDefined              string `json:"CHE_INFRA_KUBERNETES_NAMESPACE_ALLOW__USER__DEFINED"`
 	PvcStrategy                            string `json:"CHE_INFRA_KUBERNETES_PVC_STRATEGY"`
 	PvcClaimSize                           string `json:"CHE_INFRA_KUBERNETES_PVC_QUANTITY"`
 	PvcJobsImage                           string `json:"CHE_INFRA_KUBERNETES_PVC_JOBS_IMAGE"`
@@ -128,7 +127,6 @@ func GetCheConfigMapData(deployContext *deploy.DeployContext) (cheEnv map[string
 			openShiftIdentityProviderId = "openshift-v4"
 		}
 	}
-	namespaceAllowUserDefined := strconv.FormatBool(deployContext.CheCluster.Spec.Server.AllowUserDefinedWorkspaceNamespaces)
 	tlsSupport := deployContext.CheCluster.Spec.Server.TlsSupport
 	protocol := "http"
 	if tlsSupport {
@@ -232,7 +230,6 @@ func GetCheConfigMapData(deployContext *deploy.DeployContext) (cheEnv map[string
 		CheInfrastructureActive:                infra,
 		CheInfraKubernetesServiceAccountName:   "che-workspace",
 		DefaultTargetNamespace:                 workspaceNamespaceDefault,
-		NamespaceAllowUserDefined:              namespaceAllowUserDefined,
 		PvcStrategy:                            pvcStrategy,
 		PvcClaimSize:                           pvcClaimSize,
 		WorkspacePvcStorageClassName:           workspacePvcStorageClassName,
@@ -295,7 +292,7 @@ func GetCheConfigMapData(deployContext *deploy.DeployContext) (cheEnv map[string
 			"CHE_INFRA_KUBERNETES_INGRESS_PATH__TRANSFORM":             "%s(.*)",
 		}
 
-		// Add TLS key and server certificate to properties since user workspaces is be created in another
+		// Add TLS key and server certificate to properties since user workspaces is created in another
 		// than Che server namespace, from where the Che TLS secret is not accessable
 		if deployContext.CheCluster.Spec.K8s.TlsSecretName != "" {
 			cheTLSSecret := &corev1.Secret{}

--- a/pkg/deploy/server/deployment_che.go
+++ b/pkg/deploy/server/deployment_che.go
@@ -165,13 +165,6 @@ func GetSpecCheDeployment(deployContext *deploy.DeployContext) (*appsv1.Deployme
 		corev1.EnvVar{
 			Name:  "CM_REVISION",
 			Value: cmResourceVersions,
-		},
-		corev1.EnvVar{
-			Name: "KUBERNETES_NAMESPACE",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					APIVersion: "v1",
-					FieldPath:  "metadata.namespace"}},
 		})
 
 	cheImageAndTag := GetFullCheServerImageLink(deployContext.CheCluster)

--- a/pkg/deploy/server/deployment_che.go
+++ b/pkg/deploy/server/deployment_che.go
@@ -165,6 +165,13 @@ func GetSpecCheDeployment(deployContext *deploy.DeployContext) (*appsv1.Deployme
 		corev1.EnvVar{
 			Name:  "CM_REVISION",
 			Value: cmResourceVersions,
+		},
+		corev1.EnvVar{
+			Name: "KUBERNETES_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "metadata.namespace"}},
 		})
 
 	cheImageAndTag := GetFullCheServerImageLink(deployContext.CheCluster)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -371,22 +371,12 @@ func NewBoolPointer(value bool) *bool {
 
 // IsOAuthEnabled returns true when oAuth is enable for CheCluster resource, otherwise false.
 func IsOAuthEnabled(c *orgv1.CheCluster) bool {
-	return c.Spec.Auth.OpenShiftoAuth != nil && *c.Spec.Auth.OpenShiftoAuth
+	return IsOpenShift && c.Spec.Auth.OpenShiftoAuth != nil && *c.Spec.Auth.OpenShiftoAuth
 }
 
 // IsInitialOpenShiftOAuthUserEnabled returns true when initial Openshift oAuth user is enabled for CheCluster resource, otherwise false.
 func IsInitialOpenShiftOAuthUserEnabled(c *orgv1.CheCluster) bool {
 	return c.Spec.Auth.InitialOpenShiftOAuthUser != nil && *c.Spec.Auth.InitialOpenShiftOAuthUser
-}
-
-// IsWorkspaceInDifferentNamespaceThanChe return true when Che workspaces will be executed
-// in the different namespace with Che otherwise returns false.
-func IsWorkspaceInDifferentNamespaceThanChe(cr *orgv1.CheCluster) bool {
-	return GetWorkspaceNamespaceDefault(cr) != cr.Namespace
-}
-
-func IsWorkspacePermissionsInTheDifferNamespaceThanCheRequired(cr *orgv1.CheCluster) bool {
-	return !IsOAuthEnabled(cr) && IsWorkspaceInDifferentNamespaceThanChe(cr)
 }
 
 // GetWorkspaceNamespaceDefault - returns workspace namespace default strategy, which points on the namespaces used for workspaces execution.


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
- Do not allow to upgrade che 7.31 or later to upgrade installation that configured with namespace strategies other than "per user"
- Operator delegates permissions that are needed to start a workspace in a dedicated namespace
- Previous permissions (that are needed to start a workspace in the same namespace) are not removed to allow to start previously created workspaces

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19537

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

@abazko: Manually checked updates to `per-user`  namespace strategy. New and previously workspaces are started on both k8s and OpenShift clusters.
