### PR TITLE
Che Operator updates DWO and DWCO resources

### DIFF
--- a/.ci/cico_updates_openshift.sh
+++ b/.ci/cico_updates_openshift.sh
@@ -20,12 +20,27 @@ source "${OPERATOR_REPO}"/.github/bin/oauth-provision.sh
 #Stop execution on any error
 trap "catchFinish" EXIT SIGINT
 
+overrideDefaults() {
+  export DEV_WORKSPACE_ENABLE="true"
+}
+
 runTests() {
   "${OPERATOR_REPO}"/olm/testUpdate.sh "openshift" "stable" ${NAMESPACE}
   waitEclipseCheDeployed ${LAST_PACKAGE_VERSION}
   provisionOAuth
   startNewWorkspace
   waitWorkspaceStart
+
+  # Dev Workspace controller tests
+  waitDevWorkspaceControllerStarted
+
+  sleep 10s
+  createWorkspaceDevWorkspaceController
+  waitWorkspaceStartedDevWorkspaceController
+
+  sleep 10s
+  createWorkspaceDevWorkspaceCheOperator
+  waitWorkspaceStartedDevWorkspaceController
 }
 
 initDefaults

--- a/.ci/oci-multi-host.sh
+++ b/.ci/oci-multi-host.sh
@@ -29,7 +29,9 @@ trap "catchFinish" EXIT SIGINT
 
 overrideDefaults() {
   # CI_CHE_OPERATOR_IMAGE it is che operator image builded in openshift CI job workflow. More info about how works image dependencies in ci:https://github.com/openshift/ci-tools/blob/master/TEMPLATES.md#parameters-available-to-templates
-  export OPERATOR_IMAGE=${CI_CHE_OPERATOR_IMAGE:-"quay.io/eclipse/che-operator:nightly"}
+  export OPERATOR_IMAGE=${CI_CHE_OPERATOR_IMAGE}
+  export CHE_EXPOSURE_STRATEGY="multi-host"
+  export DEV_WORKSPACE_ENABLE="true"
 }
 
 runTests() {
@@ -41,7 +43,6 @@ runTests() {
     waitWorkspaceStart
 
     # Dev Workspace controller tests
-    deployDevWorkspaceController
     waitDevWorkspaceControllerStarted
 
     sleep 10s

--- a/.ci/oci-single-host.sh
+++ b/.ci/oci-single-host.sh
@@ -29,8 +29,9 @@ trap "catchFinish" EXIT SIGINT
 
 overrideDefaults() {
   # CI_CHE_OPERATOR_IMAGE it is che operator image builded in openshift CI job workflow. More info about how works image dependencies in ci:https://github.com/openshift/ci-tools/blob/master/TEMPLATES.md#parameters-available-to-templates
-  export OPERATOR_IMAGE=${CI_CHE_OPERATOR_IMAGE:-"quay.io/eclipse/che-operator:nightly"}
+  export OPERATOR_IMAGE=${CI_CHE_OPERATOR_IMAGE}
   export CHE_EXPOSURE_STRATEGY="single-host"
+  export DEV_WORKSPACE_ENABLE="true"
 }
 
 runTests() {
@@ -42,7 +43,6 @@ runTests() {
     waitWorkspaceStart
 
     # Dev Workspace controller tests
-    deployDevWorkspaceController
     waitDevWorkspaceControllerStarted
 
     sleep 10s

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN curl -L https://api.github.com/repos/che-incubator/devworkspace-che-operator
     mv /tmp/che-incubator-devworkspace-che-operator-*/deploy /tmp/devworkspace-che-operator/templates/
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.3-298.1618432845
+FROM registry.access.redhat.com/ubi8-minimal:8.4-200
 
 COPY --from=builder /tmp/che-operator/che-operator /usr/local/bin/che-operator
 COPY --from=builder /che-operator/templates/keycloak-provision.sh /tmp/keycloak-provision.sh

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -273,6 +273,7 @@ rules:
     verbs:
       - get
       - create
+      - update
   - apiGroups:
       - operators.coreos.com
     resources:

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -76,13 +76,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-05-12T08:55:32Z"
+    createdAt: "2021-05-18T07:00:32Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.31.0-178.nightly
+  name: eclipse-che-preview-kubernetes.v7.31.0-180.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -428,6 +428,7 @@ spec:
               verbs:
                 - get
                 - create
+                - update
             - apiGroups:
                 - operators.coreos.com
               resources:
@@ -1132,4 +1133,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.31.0-178.nightly
+  version: 7.31.0-180.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -76,13 +76,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-05-18T07:00:32Z"
+    createdAt: "2021-05-19T07:53:38Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.31.0-180.nightly
+  name: eclipse-che-preview-kubernetes.v7.31.0-182.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -921,7 +921,7 @@ spec:
                       - name: RELATED_IMAGE_che_tls_secrets_creation_job
                         value: quay.io/eclipse/che-tls-secret-creator:alpine-d1ed4ad
                       - name: RELATED_IMAGE_pvc_jobs
-                        value: registry.access.redhat.com/ubi8-minimal:8.3-298.1618432845
+                        value: registry.access.redhat.com/ubi8-minimal:8.4-200
                       - name: RELATED_IMAGE_postgres
                         value: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
                       - name: RELATED_IMAGE_keycloak
@@ -1133,4 +1133,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.31.0-180.nightly
+  version: 7.31.0-182.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -67,13 +67,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-05-12T08:55:42Z"
+    createdAt: "2021-05-18T07:00:43Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.31.0-178.nightly
+  name: eclipse-che-preview-openshift.v7.31.0-180.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -497,6 +497,7 @@ spec:
               verbs:
                 - get
                 - create
+                - update
             - apiGroups:
                 - operators.coreos.com
               resources:
@@ -1207,4 +1208,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.31.0-178.nightly
+  version: 7.31.0-180.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -67,13 +67,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-05-18T07:00:43Z"
+    createdAt: "2021-05-19T07:53:48Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.31.0-180.nightly
+  name: eclipse-che-preview-openshift.v7.31.0-182.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -988,7 +988,7 @@ spec:
                       - name: RELATED_IMAGE_devfile_registry
                         value: quay.io/eclipse/che-devfile-registry:nightly
                       - name: RELATED_IMAGE_pvc_jobs
-                        value: registry.access.redhat.com/ubi8-minimal:8.3-298.1618432845
+                        value: registry.access.redhat.com/ubi8-minimal:8.4-200
                       - name: RELATED_IMAGE_postgres
                         value: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
                       - name: RELATED_IMAGE_keycloak
@@ -1208,4 +1208,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.31.0-180.nightly
+  version: 7.31.0-182.nightly

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -60,7 +60,7 @@ spec:
             - name: RELATED_IMAGE_che_tls_secrets_creation_job
               value: quay.io/eclipse/che-tls-secret-creator:alpine-d1ed4ad
             - name: RELATED_IMAGE_pvc_jobs
-              value: registry.access.redhat.com/ubi8-minimal:8.3-298.1618432845
+              value: registry.access.redhat.com/ubi8-minimal:8.4-200
             - name: RELATED_IMAGE_postgres
               value: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
             - name: RELATED_IMAGE_keycloak

--- a/olm/olm.sh
+++ b/olm/olm.sh
@@ -458,6 +458,7 @@ applyCRCheCluster() {
   echo "[INFO] Creating Custom Resource"
   CRs=$(yq -r '.metadata.annotations["alm-examples"]' "${CSV_FILE}")
   CR=$(echo "$CRs" | yq -r ".[0]")
+  CR=$(echo "$CR" | yq -r ".spec.devWorkspace.enable = ${DEV_WORKSPACE_ENABLE:-false}")
   if [ "${platform}" == "kubernetes" ]
   then
     CR=$(echo "$CR" | yq -r ".spec.k8s.ingressDomain = \"$(minikube ip).nip.io\"")

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -112,6 +112,8 @@ const (
 	CheEclipseOrgGithubOAuthCredentials = "che.eclipse.org/github-oauth-credentials"
 	CheEclipseOrgOAuthScmServer         = "che.eclipse.org/oauth-scm-server"
 	CheEclipseOrgScmServerEndpoint      = "che.eclipse.org/scm-server-endpoint"
+	CheEclipseOrgCreatedBy              = "che.eclipse.org/created-by"
+	CheEclipseOrgHash256                = "che.eclipse.org/hash256"
 
 	// components
 	IdentityProviderName = "keycloak"

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -112,7 +112,6 @@ const (
 	CheEclipseOrgGithubOAuthCredentials = "che.eclipse.org/github-oauth-credentials"
 	CheEclipseOrgOAuthScmServer         = "che.eclipse.org/oauth-scm-server"
 	CheEclipseOrgScmServerEndpoint      = "che.eclipse.org/scm-server-endpoint"
-	CheEclipseOrgCreatedBy              = "che.eclipse.org/created-by"
 	CheEclipseOrgHash256                = "che.eclipse.org/hash256"
 
 	// components

--- a/pkg/deploy/dev-workspace/dev_workspace.go
+++ b/pkg/deploy/dev-workspace/dev_workspace.go
@@ -15,9 +15,11 @@ package devworkspace
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/eclipse-che/che-operator/pkg/deploy"
 	"github.com/eclipse-che/che-operator/pkg/util"
+	"github.com/google/go-cmp/cmp"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -27,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -81,9 +84,14 @@ var (
 	WebTerminalOperatorNamespace        = "openshift-operators"
 )
 
+type Object2Sync struct {
+	obj  metav1.Object
+	hash string
+}
+
 var (
 	// cachedObjects
-	cachedObj = make(map[string]metav1.Object)
+	cachedObj = make(map[string]*Object2Sync)
 	syncItems = []func(*deploy.DeployContext) (bool, error){
 		createDwNamespace,
 		syncDwServiceAccount,
@@ -134,18 +142,18 @@ func ReconcileDevWorkspace(deployContext *deploy.DeployContext) (bool, error) {
 		return false, err
 	}
 
-	if !devWorkspaceWebhookExists {
-		for _, syncItem := range syncItems {
-			done, err := syncItem(deployContext)
-			if !util.IsTestMode() {
-				if !done {
-					return false, err
-				}
-			}
-		}
-	} else {
+	if devWorkspaceWebhookExists {
 		if err := checkWebTerminalSubscription(deployContext); err != nil {
 			return false, err
+		}
+	}
+
+	for _, syncItem := range syncItems {
+		done, err := syncItem(deployContext)
+		if !util.IsTestMode() {
+			if !done {
+				return false, err
+			}
 		}
 	}
 
@@ -201,60 +209,60 @@ func createDwNamespace(deployContext *deploy.DeployContext) (bool, error) {
 }
 
 func syncDwServiceAccount(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceServiceAccountFile, &corev1.ServiceAccount{})
+	return readAndSyncObject(deployContext, DevWorkspaceServiceAccountFile, &corev1.ServiceAccount{})
 }
 
 func syncDwRole(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceRoleFile, &rbacv1.Role{})
+	return readAndSyncObject(deployContext, DevWorkspaceRoleFile, &rbacv1.Role{})
 }
 
 func syncDwRoleBinding(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceRoleBindingFile, &rbacv1.RoleBinding{})
+	return readAndSyncObject(deployContext, DevWorkspaceRoleBindingFile, &rbacv1.RoleBinding{})
 }
 
 func syncDwClusterRoleBinding(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceClusterRoleBindingFile, &rbacv1.ClusterRoleBinding{})
+	return readAndSyncObject(deployContext, DevWorkspaceClusterRoleBindingFile, &rbacv1.ClusterRoleBinding{})
 }
 
 func syncDwProxyClusterRoleBinding(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceProxyClusterRoleBindingFile, &rbacv1.ClusterRoleBinding{})
+	return readAndSyncObject(deployContext, DevWorkspaceProxyClusterRoleBindingFile, &rbacv1.ClusterRoleBinding{})
 }
 
 func syncDwClusterRole(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceClusterRoleFile, &rbacv1.ClusterRole{})
+	return readAndSyncObject(deployContext, DevWorkspaceClusterRoleFile, &rbacv1.ClusterRole{})
 }
 
 func syncDwProxyClusterRole(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceProxyClusterRoleFile, &rbacv1.ClusterRole{})
+	return readAndSyncObject(deployContext, DevWorkspaceProxyClusterRoleFile, &rbacv1.ClusterRole{})
 }
 
 func syncDwViewWorkspacesClusterRole(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceViewWorkspacesClusterRoleFile, &rbacv1.ClusterRole{})
+	return readAndSyncObject(deployContext, DevWorkspaceViewWorkspacesClusterRoleFile, &rbacv1.ClusterRole{})
 }
 
 func syncDwEditWorkspacesClusterRole(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceEditWorkspacesClusterRoleFile, &rbacv1.ClusterRole{})
+	return readAndSyncObject(deployContext, DevWorkspaceEditWorkspacesClusterRoleFile, &rbacv1.ClusterRole{})
 }
 
 func syncDwWorkspaceRoutingCRD(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceWorkspaceRoutingCRDFile, &apiextensionsv1.CustomResourceDefinition{})
+	return readAndSyncObject(deployContext, DevWorkspaceWorkspaceRoutingCRDFile, &apiextensionsv1.CustomResourceDefinition{})
 }
 
 func syncDwTemplatesCRD(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceTemplatesCRDFile, &apiextensionsv1.CustomResourceDefinition{})
+	return readAndSyncObject(deployContext, DevWorkspaceTemplatesCRDFile, &apiextensionsv1.CustomResourceDefinition{})
 }
 
 func syncDwCRD(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceCRDFile, &apiextensionsv1.CustomResourceDefinition{})
+	return readAndSyncObject(deployContext, DevWorkspaceCRDFile, &apiextensionsv1.CustomResourceDefinition{})
 }
 
 func syncDwConfigMap(deployContext *deploy.DeployContext) (bool, error) {
-	objectMeta, err := getK8SObject(DevWorkspaceConfigMapFile, &corev1.ConfigMap{})
+	devObject, err := readK8SObject(DevWorkspaceConfigMapFile, &corev1.ConfigMap{})
 	if err != nil {
 		return false, err
 	}
 
-	configMap := objectMeta.(*corev1.ConfigMap)
+	configMap := devObject.obj.(*corev1.ConfigMap)
 	// Remove when DevWorkspace controller should not care about DWR base host #373 https://github.com/devfile/devworkspace-operator/issues/373
 	if !util.IsOpenShift {
 		if configMap.Data == nil {
@@ -263,20 +271,20 @@ func syncDwConfigMap(deployContext *deploy.DeployContext) (bool, error) {
 		configMap.Data["devworkspace.routing.cluster_host_suffix"] = deployContext.CheCluster.Spec.K8s.IngressDomain
 	}
 
-	return deploy.CreateIfNotExists(deployContext, configMap)
+	return syncObject(deployContext, devObject)
 }
 
 func syncDwDeployment(deployContext *deploy.DeployContext) (bool, error) {
-	objectMeta, err := getK8SObject(DevWorkspaceDeploymentFile, &appsv1.Deployment{})
+	devObject, err := readK8SObject(DevWorkspaceDeploymentFile, &appsv1.Deployment{})
 	if err != nil {
 		return false, err
 	}
 
 	devworkspaceControllerImage := util.GetValue(deployContext.CheCluster.Spec.DevWorkspace.ControllerImage, deploy.DefaultDevworkspaceControllerImage(deployContext.CheCluster))
-	deploymentObject := objectMeta.(*appsv1.Deployment)
+	deploymentObject := devObject.obj.(*appsv1.Deployment)
 	deploymentObject.Spec.Template.Spec.Containers[0].Image = devworkspaceControllerImage
 
-	return deploy.CreateIfNotExists(deployContext, deploymentObject)
+	return syncObject(deployContext, devObject)
 }
 
 func createDwCheNamespace(deployContext *deploy.DeployContext) (bool, error) {
@@ -295,47 +303,47 @@ func createDwCheNamespace(deployContext *deploy.DeployContext) (bool, error) {
 }
 
 func syncDwCheServiceAccount(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceCheServiceAccountFile, &corev1.ServiceAccount{})
+	return readAndSyncObject(deployContext, DevWorkspaceCheServiceAccountFile, &corev1.ServiceAccount{})
 }
 
 func syncDwCheClusterRole(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceCheClusterRoleFile, &rbacv1.ClusterRole{})
+	return readAndSyncObject(deployContext, DevWorkspaceCheClusterRoleFile, &rbacv1.ClusterRole{})
 }
 
 func syncDwCheProxyClusterRole(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceCheProxyClusterRoleFile, &rbacv1.ClusterRole{})
+	return readAndSyncObject(deployContext, DevWorkspaceCheProxyClusterRoleFile, &rbacv1.ClusterRole{})
 }
 
 func syncDwCheMetricsClusterRole(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceCheMetricsReaderClusterRoleFile, &rbacv1.ClusterRole{})
+	return readAndSyncObject(deployContext, DevWorkspaceCheMetricsReaderClusterRoleFile, &rbacv1.ClusterRole{})
 }
 
 func syncDwCheLeaderRole(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceCheRoleFile, &rbacv1.Role{})
+	return readAndSyncObject(deployContext, DevWorkspaceCheRoleFile, &rbacv1.Role{})
 }
 
 func syncDwCheLeaderRoleBinding(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceCheRoleBindingFile, &rbacv1.RoleBinding{})
+	return readAndSyncObject(deployContext, DevWorkspaceCheRoleBindingFile, &rbacv1.RoleBinding{})
 }
 
 func syncDwCheProxyRoleBinding(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceCheProxyClusterRoleBindingFile, &rbacv1.ClusterRoleBinding{})
+	return readAndSyncObject(deployContext, DevWorkspaceCheProxyClusterRoleBindingFile, &rbacv1.ClusterRoleBinding{})
 }
 
 func syncDwCheRoleBinding(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceCheClusterRoleBindingFile, &rbacv1.ClusterRoleBinding{})
+	return readAndSyncObject(deployContext, DevWorkspaceCheClusterRoleBindingFile, &rbacv1.ClusterRoleBinding{})
 }
 
 func syncDwCheCRD(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceCheManagersCRDFile, &apiextensionsv1.CustomResourceDefinition{})
+	return readAndSyncObject(deployContext, DevWorkspaceCheManagersCRDFile, &apiextensionsv1.CustomResourceDefinition{})
 }
 
 func syncDwCheConfigMap(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceCheConfigMapFile, &corev1.ConfigMap{})
+	return readAndSyncObject(deployContext, DevWorkspaceCheConfigMapFile, &corev1.ConfigMap{})
 }
 
 func syncDwCheMetricsService(deployContext *deploy.DeployContext) (bool, error) {
-	return syncObject(deployContext, DevWorkspaceCheMetricsServiceFile, &corev1.Service{})
+	return readAndSyncObject(deployContext, DevWorkspaceCheMetricsServiceFile, &corev1.Service{})
 }
 
 func synDwCheCR(deployContext *deploy.DeployContext) (bool, error) {
@@ -383,34 +391,84 @@ func synDwCheCR(deployContext *deploy.DeployContext) (bool, error) {
 }
 
 func synDwCheDeployment(deployContext *deploy.DeployContext) (bool, error) {
-	objectMeta, err := getK8SObject(DevWorkspaceCheDeploymentFile, &appsv1.Deployment{})
+	devObject, err := readK8SObject(DevWorkspaceCheDeploymentFile, &appsv1.Deployment{})
 	if err != nil {
 		return false, err
 	}
 
 	devworkspaceCheOperatorImage := deploy.DefaultDevworkspaceCheOperatorImage(deployContext.CheCluster)
-	deploymentObject := objectMeta.(*appsv1.Deployment)
+	deploymentObject := devObject.obj.(*appsv1.Deployment)
 	deploymentObject.Spec.Template.Spec.Containers[0].Image = devworkspaceCheOperatorImage
 
-	return deploy.CreateIfNotExists(deployContext, deploymentObject)
+	return syncObject(deployContext, devObject)
 }
 
-func syncObject(deployContext *deploy.DeployContext, yamlFile string, obj interface{}) (bool, error) {
-	objectMeta, err := getK8SObject(yamlFile, obj)
+func readAndSyncObject(deployContext *deploy.DeployContext, yamlFile string, obj interface{}) (bool, error) {
+	obj2sync, err := readK8SObject(yamlFile, obj)
 	if err != nil {
 		return false, err
 	}
 
-	return deploy.CreateIfNotExists(deployContext, objectMeta)
+	return syncObject(deployContext, obj2sync)
 }
 
-func getK8SObject(yamlFile string, obj interface{}) (metav1.Object, error) {
+func syncObject(deployContext *deploy.DeployContext, obj2sync *Object2Sync) (bool, error) {
+	runtimeObject, ok := obj2sync.obj.(runtime.Object)
+	if !ok {
+		return false, fmt.Errorf("object %T is not a runtime.Object. Cannot sync it", runtimeObject)
+	}
+
+	actual := runtimeObject.DeepCopyObject()
+	key := types.NamespacedName{Namespace: obj2sync.obj.GetNamespace(), Name: obj2sync.obj.GetName()}
+	exists, err := deploy.Get(deployContext, key, actual.(metav1.Object))
+	if err != nil {
+		return false, err
+	}
+
+	cheFlavor := deploy.DefaultCheFlavor(deployContext.CheCluster)
+	createdBy := cheFlavor + "-operator"
+
+	if !exists ||
+		(actual.(metav1.Object).GetAnnotations()[deploy.CheEclipseOrgCreatedBy] == createdBy &&
+			actual.(metav1.Object).GetAnnotations()[deploy.CheEclipseOrgHash256] != obj2sync.hash) {
+
+		setAnnotations(deployContext, obj2sync)
+		return deploy.Sync(deployContext, obj2sync.obj, cmp.Options{})
+	}
+
+	return true, nil
+}
+
+func setAnnotations(deployContext *deploy.DeployContext, obj2sync *Object2Sync) {
+	cheFlavor := deploy.DefaultCheFlavor(deployContext.CheCluster)
+	createdBy := cheFlavor + "-operator"
+
+	annotations := obj2sync.obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	annotations[deploy.CheEclipseOrgCreatedBy] = createdBy
+	annotations[deploy.CheEclipseOrgHash256] = obj2sync.hash
+	obj2sync.obj.SetAnnotations(annotations)
+}
+
+func readK8SObject(yamlFile string, obj interface{}) (*Object2Sync, error) {
 	_, exists := cachedObj[yamlFile]
 	if !exists {
 		if err := util.ReadObject(yamlFile, obj); err != nil {
 			return nil, err
 		}
-		cachedObj[yamlFile] = obj.(metav1.Object)
+
+		hash, err := util.ComputeHash256(yamlFile)
+		if err != nil {
+			return nil, err
+		}
+
+		cachedObj[yamlFile] = &Object2Sync{
+			obj.(metav1.Object),
+			hash,
+		}
 	}
 
 	return cachedObj[yamlFile], nil

--- a/pkg/deploy/dev-workspace/dev_workspace.go
+++ b/pkg/deploy/dev-workspace/dev_workspace.go
@@ -20,7 +20,6 @@ import (
 	orgv1 "github.com/eclipse-che/che-operator/pkg/apis/org/v1"
 	"github.com/eclipse-che/che-operator/pkg/deploy"
 	"github.com/eclipse-che/che-operator/pkg/util"
-	"github.com/google/go-cmp/cmp"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -438,7 +437,7 @@ func syncObject(deployContext *deploy.DeployContext, obj2sync *Object2Sync) (boo
 			(actual.(metav1.Object).GetAnnotations()[deploy.CheEclipseOrgNamespace] == deployContext.CheCluster.Namespace || isOnlyOneOperatorManagesDWResources)) {
 
 		setAnnotations(deployContext, obj2sync)
-		return deploy.Sync(deployContext, obj2sync.obj, cmp.Options{})
+		return deploy.Sync(deployContext, obj2sync.obj)
 	}
 
 	return true, nil

--- a/pkg/deploy/dev-workspace/dev_workspace_test.go
+++ b/pkg/deploy/dev-workspace/dev_workspace_test.go
@@ -19,55 +19,42 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/util"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakeDiscovery "k8s.io/client-go/discovery/fake"
-	fakeclientset "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"testing"
 )
 
 func TestReconcileDevWorkspace(t *testing.T) {
-	scheme := scheme.Scheme
-	orgv1.SchemeBuilder.AddToScheme(scheme)
-	scheme.AddKnownTypes(operatorsv1alpha1.SchemeGroupVersion, &operatorsv1alpha1.Subscription{})
+	cheCluster := &orgv1.CheCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "eclipse-che",
+		},
+		Spec: orgv1.CheClusterSpec{
+			DevWorkspace: orgv1.CheClusterSpecDevWorkspace{
+				Enable: true,
+			},
+			Auth: orgv1.CheClusterSpecAuth{
+				OpenShiftoAuth: util.NewBoolPointer(true),
+			},
+			Server: orgv1.CheClusterSpecServer{
+				ServerExposureStrategy: "single-host",
+			},
+		},
+	}
 
-	cli := fake.NewFakeClientWithScheme(scheme)
-	clientSet := fakeclientset.NewSimpleClientset()
-	fakeDiscovery, _ := clientSet.Discovery().(*fakeDiscovery.FakeDiscovery)
-	fakeDiscovery.Fake.Resources = []*metav1.APIResourceList{
+	deployContext := deploy.GetTestDeployContext(cheCluster, []runtime.Object{})
+	deployContext.ClusterAPI.Scheme.AddKnownTypes(operatorsv1alpha1.SchemeGroupVersion, &operatorsv1alpha1.Subscription{})
+	deployContext.ClusterAPI.DiscoveryClient.(*fakeDiscovery.FakeDiscovery).Fake.Resources = []*metav1.APIResourceList{
 		{
 			APIResources: []metav1.APIResource{
 				{Name: CheManagerResourcename},
 			},
-		},
-	}
-	deployContext := &deploy.DeployContext{
-		CheCluster: &orgv1.CheCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "eclipse-che",
-			},
-			Spec: orgv1.CheClusterSpec{
-				DevWorkspace: orgv1.CheClusterSpecDevWorkspace{
-					Enable: true,
-				},
-				Auth: orgv1.CheClusterSpecAuth{
-					OpenShiftoAuth: util.NewBoolPointer(true),
-				},
-				Server: orgv1.CheClusterSpecServer{
-					ServerExposureStrategy: "single-host",
-				},
-			},
-		},
-		ClusterAPI: deploy.ClusterAPI{
-			Client:          cli,
-			NonCachedClient: cli,
-			Scheme:          scheme,
-			DiscoveryClient: fakeDiscovery,
 		},
 	}
 
@@ -85,7 +72,7 @@ func TestReconcileDevWorkspace(t *testing.T) {
 	t.Run("defaultCheManagerDeployed", func(t *testing.T) {
 		obj := &unstructured.Unstructured{}
 		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "che.eclipse.org", Version: "v1alpha1", Kind: "CheManager"})
-		err := cli.Get(context.TODO(), client.ObjectKey{Name: "devworkspace-che", Namespace: DevWorkspaceCheNamespace}, obj)
+		err := deployContext.ClusterAPI.Client.Get(context.TODO(), client.ObjectKey{Name: "devworkspace-che", Namespace: DevWorkspaceCheNamespace}, obj)
 		if err != nil {
 			t.Fatalf("Should have found a CheManager with default config but got an error: %s", err)
 		}
@@ -97,6 +84,22 @@ func TestReconcileDevWorkspace(t *testing.T) {
 }
 
 func TestReconcileDevWorkspaceShouldThrowErrorIfWebTerminalSubscriptionExists(t *testing.T) {
+	cheCluster := &orgv1.CheCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "eclipse-che",
+		},
+		Spec: orgv1.CheClusterSpec{
+			DevWorkspace: orgv1.CheClusterSpecDevWorkspace{
+				Enable: true,
+			},
+			Auth: orgv1.CheClusterSpecAuth{
+				OpenShiftoAuth: util.NewBoolPointer(true),
+			},
+			Server: orgv1.CheClusterSpecServer{
+				ServerExposureStrategy: "single-host",
+			},
+		},
+	}
 	subscription := &operatorsv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      WebTerminalOperatorSubscriptionName,
@@ -104,51 +107,20 @@ func TestReconcileDevWorkspaceShouldThrowErrorIfWebTerminalSubscriptionExists(t 
 		},
 		Spec: &operatorsv1alpha1.SubscriptionSpec{},
 	}
-
-	webhook := admissionregistrationv1.MutatingWebhookConfiguration{
+	webhook := &admissionregistrationv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: DevWorkspaceWebhookName,
 		},
 	}
 
-	scheme := scheme.Scheme
-	orgv1.SchemeBuilder.AddToScheme(scheme)
-	scheme.AddKnownTypes(operatorsv1alpha1.SchemeGroupVersion, &operatorsv1alpha1.Subscription{})
-	scheme.AddKnownTypes(admissionregistrationv1.SchemeGroupVersion, &admissionregistrationv1.MutatingWebhookConfiguration{})
-
-	cli := fake.NewFakeClientWithScheme(scheme, subscription, &webhook)
-	clientSet := fakeclientset.NewSimpleClientset()
-	fakeDiscovery, _ := clientSet.Discovery().(*fakeDiscovery.FakeDiscovery)
-	fakeDiscovery.Fake.Resources = []*metav1.APIResourceList{
+	deployContext := deploy.GetTestDeployContext(cheCluster, []runtime.Object{subscription, webhook})
+	deployContext.ClusterAPI.Scheme.AddKnownTypes(operatorsv1alpha1.SchemeGroupVersion, &operatorsv1alpha1.Subscription{})
+	deployContext.ClusterAPI.Scheme.AddKnownTypes(admissionregistrationv1.SchemeGroupVersion, &admissionregistrationv1.MutatingWebhookConfiguration{})
+	deployContext.ClusterAPI.DiscoveryClient.(*fakeDiscovery.FakeDiscovery).Fake.Resources = []*metav1.APIResourceList{
 		{
 			APIResources: []metav1.APIResource{
 				{Name: SubscriptionResourceName},
 			},
-		},
-	}
-
-	deployContext := &deploy.DeployContext{
-		CheCluster: &orgv1.CheCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "eclipse-che",
-			},
-			Spec: orgv1.CheClusterSpec{
-				DevWorkspace: orgv1.CheClusterSpecDevWorkspace{
-					Enable: true,
-				},
-				Auth: orgv1.CheClusterSpecAuth{
-					OpenShiftoAuth: util.NewBoolPointer(true),
-				},
-				Server: orgv1.CheClusterSpecServer{
-					ServerExposureStrategy: "single-host",
-				},
-			},
-		},
-		ClusterAPI: deploy.ClusterAPI{
-			Client:          cli,
-			NonCachedClient: cli,
-			Scheme:          scheme,
-			DiscoveryClient: fakeDiscovery,
 		},
 	}
 
@@ -157,5 +129,157 @@ func TestReconcileDevWorkspaceShouldThrowErrorIfWebTerminalSubscriptionExists(t 
 
 	if err == nil || err.Error() != "A non matching version of the Dev Workspace operator is already installed" {
 		t.Fatalf("Error should be thrown")
+	}
+}
+
+func TestShouldSyncObject(t *testing.T) {
+	deployContext := deploy.GetTestDeployContext(nil, []runtime.Object{})
+
+	testObject := deploy.GetConfigMapSpec(deployContext, "test", map[string]string{}, "test")
+	obj2sync := &Object2Sync{
+		obj:  testObject,
+		hash256: "hash1",
+	}
+
+	done, err := syncObject(deployContext, obj2sync)
+	if err != nil {
+		t.Fatalf("Failed to sync object: %v", err)
+	} else if !done {
+		t.Fatalf("Object is not synced.")
+	}
+
+	actual := &corev1.ConfigMap{}
+	exists, err := deploy.GetNamespacedObject(deployContext, "test", actual)
+	if err != nil {
+		t.Fatalf("Failed to get object: %v", err)
+	} else if !exists {
+		t.Fatalf("Object not found")
+	}
+
+	if actual.GetAnnotations()[deploy.CheEclipseOrgHash256] != obj2sync.hash256 {
+		t.Fatalf("Invalid hash")
+	}
+	if actual.GetAnnotations()[deploy.CheEclipseOrgCreatedBy] != getCreatedBy(deployContext) {
+		t.Fatalf("Invalid created-by")
+	}
+}
+
+func TestShouldSyncObjectIfHashIsNotEqual(t *testing.T) {
+	deployContext := deploy.GetTestDeployContext(nil, []runtime.Object{})
+
+	initialObject := deploy.GetConfigMapSpec(deployContext, "test", map[string]string{"a": "b"}, "test")
+	initialObject.SetAnnotations(map[string]string{
+		deploy.CheEclipseOrgHash256:   "hash1",
+		deploy.CheEclipseOrgCreatedBy: getCreatedBy(deployContext),
+	})
+	deploy.Create(deployContext, initialObject)
+
+	testObject := deploy.GetConfigMapSpec(deployContext, "test", map[string]string{"a": "c"}, "test")
+	obj2sync := &Object2Sync{
+		obj:  testObject,
+		hash256: "hash2",
+	}
+
+	done, err := syncObject(deployContext, obj2sync)
+	if err != nil {
+		t.Fatalf("Failed to sync object: %v", err)
+	} else if done {
+		t.Fatalf("Object is updated, another sync is required.")
+	}
+
+	done, err = syncObject(deployContext, obj2sync)
+	if err != nil {
+		t.Fatalf("Failed to sync object: %v", err)
+	} else if !done {
+		t.Fatalf("Object is not synced.")
+	}
+
+	actual := &corev1.ConfigMap{}
+	exists, err := deploy.GetNamespacedObject(deployContext, "test", actual)
+	if err != nil {
+		t.Fatalf("Failed to get object: %v", err)
+	} else if !exists {
+		t.Fatalf("Object not found")
+	}
+
+	if actual.GetAnnotations()[deploy.CheEclipseOrgHash256] != obj2sync.hash256 {
+		t.Fatalf("Invalid hash")
+	}
+	if actual.GetAnnotations()[deploy.CheEclipseOrgCreatedBy] != getCreatedBy(deployContext) {
+		t.Fatalf("Invalid created-by")
+	}
+	if actual.Data["a"] == "b" {
+		t.Fatalf("Object is not updated.")
+	}
+}
+
+func TestShouldNotSyncObjectIfHashIsEqual(t *testing.T) {
+	deployContext := deploy.GetTestDeployContext(nil, []runtime.Object{})
+
+	initialObject := deploy.GetConfigMapSpec(deployContext, "test", map[string]string{"a": "b"}, "test")
+	initialObject.SetAnnotations(map[string]string{
+		deploy.CheEclipseOrgHash256:   "hash1",
+		deploy.CheEclipseOrgCreatedBy: getCreatedBy(deployContext),
+	})
+	deploy.Create(deployContext, initialObject)
+
+	testObject := deploy.GetConfigMapSpec(deployContext, "test", map[string]string{"a": "c"}, "test")
+	obj2sync := &Object2Sync{
+		obj:  testObject,
+		hash256: "hash1",
+	}
+
+	done, err := syncObject(deployContext, obj2sync)
+	if err != nil {
+		t.Fatalf("Failed to sync object: %v", err)
+	} else if !done {
+		t.Fatalf("Object is not synced.")
+	}
+
+	actual := &corev1.ConfigMap{}
+	exists, err := deploy.GetNamespacedObject(deployContext, "test", actual)
+	if err != nil {
+		t.Fatalf("Failed to get object: %v", err)
+	} else if !exists {
+		t.Fatalf("Object not found")
+	}
+
+	if actual.Data["a"] != "b" {
+		t.Fatalf("Object is not supposed to be updated.")
+	}
+}
+
+func TestShouldNotSyncObjectIfCreatedByIsDifferent(t *testing.T) {
+	deployContext := deploy.GetTestDeployContext(nil, []runtime.Object{})
+
+	initialObject := deploy.GetConfigMapSpec(deployContext, "test", map[string]string{"a": "b"}, "test")
+	initialObject.SetAnnotations(map[string]string{
+		deploy.CheEclipseOrgHash256: "hash1",
+	})
+	deploy.Create(deployContext, initialObject)
+
+	testObject := deploy.GetConfigMapSpec(deployContext, "test", map[string]string{"a": "c"}, "test")
+	obj2sync := &Object2Sync{
+		obj:  testObject,
+		hash256: "hash1",
+	}
+
+	done, err := syncObject(deployContext, obj2sync)
+	if err != nil {
+		t.Fatalf("Failed to sync object: %v", err)
+	} else if !done {
+		t.Fatalf("Object is not synced.")
+	}
+
+	actual := &corev1.ConfigMap{}
+	exists, err := deploy.GetNamespacedObject(deployContext, "test", actual)
+	if err != nil {
+		t.Fatalf("Failed to get object: %v", err)
+	} else if !exists {
+		t.Fatalf("Object not found")
+	}
+
+	if actual.Data["a"] != "b" {
+		t.Fatalf("Object is not supposed to be updated.")
 	}
 }

--- a/pkg/deploy/dev-workspace/dev_workspace_test.go
+++ b/pkg/deploy/dev-workspace/dev_workspace_test.go
@@ -137,7 +137,7 @@ func TestShouldSyncObject(t *testing.T) {
 
 	testObject := deploy.GetConfigMapSpec(deployContext, "test", map[string]string{}, "test")
 	obj2sync := &Object2Sync{
-		obj:  testObject,
+		obj:     testObject,
 		hash256: "hash1",
 	}
 
@@ -176,7 +176,7 @@ func TestShouldSyncObjectIfHashIsNotEqual(t *testing.T) {
 
 	testObject := deploy.GetConfigMapSpec(deployContext, "test", map[string]string{"a": "c"}, "test")
 	obj2sync := &Object2Sync{
-		obj:  testObject,
+		obj:     testObject,
 		hash256: "hash2",
 	}
 
@@ -225,7 +225,7 @@ func TestShouldNotSyncObjectIfHashIsEqual(t *testing.T) {
 
 	testObject := deploy.GetConfigMapSpec(deployContext, "test", map[string]string{"a": "c"}, "test")
 	obj2sync := &Object2Sync{
-		obj:  testObject,
+		obj:     testObject,
 		hash256: "hash1",
 	}
 
@@ -260,7 +260,7 @@ func TestShouldNotSyncObjectIfCreatedByIsDifferent(t *testing.T) {
 
 	testObject := deploy.GetConfigMapSpec(deployContext, "test", map[string]string{"a": "c"}, "test")
 	obj2sync := &Object2Sync{
-		obj:  testObject,
+		obj:     testObject,
 		hash256: "hash1",
 	}
 

--- a/pkg/deploy/test_util.go
+++ b/pkg/deploy/test_util.go
@@ -1,0 +1,56 @@
+//
+// Copyright (c) 2012-2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package deploy
+
+import (
+	orgv1 "github.com/eclipse-che/che-operator/pkg/apis/org/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeDiscovery "k8s.io/client-go/discovery/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// Initialize DeployContext for tests
+func GetTestDeployContext(cheCluster *orgv1.CheCluster, initObjs []runtime.Object) *DeployContext {
+	if cheCluster == nil {
+		// use a default checluster
+		cheCluster = &orgv1.CheCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "eclipse-che",
+				Namespace: "eclipse-che",
+			},
+		}
+	}
+
+	scheme := scheme.Scheme
+	orgv1.SchemeBuilder.AddToScheme(scheme)
+	scheme.AddKnownTypes(operatorsv1alpha1.SchemeGroupVersion, &operatorsv1alpha1.Subscription{})
+
+	initObjs = append(initObjs, cheCluster)
+	cli := fake.NewFakeClientWithScheme(scheme, initObjs...)
+	clientSet := fakeclientset.NewSimpleClientset()
+	fakeDiscovery, _ := clientSet.Discovery().(*fakeDiscovery.FakeDiscovery)
+
+	return &DeployContext{
+		CheCluster: cheCluster,
+		ClusterAPI: ClusterAPI{
+			Client:          cli,
+			NonCachedClient: cli,
+			Scheme:          scheme,
+			DiscoveryClient: fakeDiscovery,
+		},
+		Proxy: &Proxy{},
+	}
+}

--- a/pkg/util/test_util.go
+++ b/pkg/util/test_util.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2012-2019 Red Hat, Inc.
+// Copyright (c) 2019-2021 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -14,7 +14,9 @@ package util
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -430,6 +432,18 @@ func ReadObject(yamlFile string, obj interface{}) error {
 	}
 
 	return nil
+}
+
+func ComputeHash256(yamlFile string) (string, error) {
+	data, err := ioutil.ReadFile(yamlFile)
+	if err != nil {
+		return "", err
+	}
+
+	hasher := sha256.New()
+	hasher.Write(data)
+	sha := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+	return sha, nil
 }
 
 func ReloadCheCluster(client client.Client, cheCluster *orgv1.CheCluster) error {


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
- Che Operator sets annotations DWO and DWCO resources
- Che Operator syncs DWO and DWCO resources by updating them if hashes are different 
- Add DWO and DWCO tests for OCP

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Che Operator does not update DWO and DWCO resources https://github.com/eclipse/che/issues/19664

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
1. Run OCP cluster
2. Update ./local-debug.sh [1] by setting some old version of DWO and DWCO, for instance 
```
DEV_WORKSPACE_CONTROLLER_VERSION="v0.2.1"
DEV_WORKSPACE_CHE_OPERATOR_VERSION="v7.28.0"
```
3. Update CR [2] to turn off OAuth (spec.auth.openShiftoAuth: false)
4. Update CR [2] to turn on DevWorkspace (spec.devWorkspace.enable: true)
5. Run `./local-debug.sh`, wait until everything is deployed
6. Stop `./loca-debug.sh` and update DWO and DWCO, for instance:
```
DEV_WORKSPACE_CONTROLLER_VERSION="main"
DEV_WORKSPACE_CHE_OPERATOR_VERSION="main"
```
7. Run `./local-debug.sh`, wait until DWO and DWCO resources are updated. You can see that in the logs.
8. Check `devworkspace-che` and `devworkspace-controller` workspaces that all pods are running
9. Create workspaces and check that all pods are running.
```
oc apply -f https://raw.githubusercontent.com/che-incubator/devworkspace-che-operator/main/samples/flattened_theia-nodejs.yaml -n eclipse-che
oc apply -f https://raw.githubusercontent.com/devfile/devworkspace-operator/main/samples/flattened_theia-next.yaml -n eclipse-che
```

[1]  https://github.com/eclipse-che/che-operator/blob/main/local-debug.sh#L21-L22
[2] https://github.com/eclipse-che/che-operator/blob/main/deploy/crds/org_v1_che_cr.yaml

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
