### PR TITLE
Remove devworkspace start in single-host in minikube

### DIFF
--- a/.github/bin/common.sh
+++ b/.github/bin/common.sh
@@ -32,7 +32,7 @@ initDefaults() {
   export ARTIFACTS_DIR=${ARTIFACT_DIR:-"/tmp/artifacts-che"}
   export TEMPLATES=${OPERATOR_REPO}/tmp
   export OPERATOR_IMAGE="test/che-operator:test"
-  export DEFAULT_DEVFILE="https://raw.githubusercontent.com/eclipse/che-devfile-registry/master/devfiles/quarkus/devfile.yaml"
+  export DEFAULT_DEVFILE="https://raw.githubusercontent.com/eclipse-che/che-devfile-registry/master/devfiles/go/devfile.yaml"
   export CHE_EXPOSURE_STRATEGY="multi-host"
   export OPENSHIFT_NIGHTLY_CSV_FILE="${OPERATOR_REPO}/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml"
   export DEV_WORKSPACE_CONTROLLER_VERSION="main"
@@ -90,20 +90,20 @@ initStableTemplates() {
 
 # Utility to wait for a workspace to be started after workspace:create.
 waitWorkspaceStart() {
-  login
-
-  set +e
   export x=0
   while [ $x -le 180 ]
   do
-    chectl workspace:list --chenamespace=${NAMESPACE}
-    workspaceList=$(chectl workspace:list --chenamespace=${NAMESPACE})
-    workspaceStatus=$(echo "$workspaceList" | grep RUNNING | awk '{ print $4} ')
+    login
 
-    if [ "${workspaceStatus:-NOT_RUNNING}" == "RUNNING" ]
-    then
+    chectl workspace:list --chenamespace=${NAMESPACE}
+    workspaceStatus=$(chectl workspace:list --chenamespace=${NAMESPACE} | tail -1 | awk '{ print $4} ')
+
+    if [ "${workspaceStatus}" == "RUNNING" ]; then
       echo "[INFO] Workspace started successfully"
       break
+    elif [ "${workspaceStatus}" == "STOPPED" ]; then
+      echo "[ERROR] Workspace failed to start"
+      exit 1
     fi
     sleep 10
     x=$(( x+1 ))
@@ -331,7 +331,7 @@ function provisionOpenShiftOAuthUser() {
 }
 
 login() {
-  local oauth=$(oc get checluster eclipse-che -n $NAMESPACE -o json | jq -r '.spec.auth.openShiftoAuth')
+  local oauth=$(kubect get checluster eclipse-che -n $NAMESPACE -o json | jq -r '.spec.auth.openShiftoAuth')
   if [[ ${oauth} == "true" ]]; then
     # log in using OpenShift token
     chectl auth:login --chenamespace=${NAMESPACE}

--- a/.github/bin/common.sh
+++ b/.github/bin/common.sh
@@ -331,7 +331,7 @@ function provisionOpenShiftOAuthUser() {
 }
 
 login() {
-  local oauth=$(kubect get checluster eclipse-che -n $NAMESPACE -o json | jq -r '.spec.auth.openShiftoAuth')
+  local oauth=$(kubectl get checluster eclipse-che -n $NAMESPACE -o json | jq -r '.spec.auth.openShiftoAuth')
   if [[ ${oauth} == "true" ]]; then
     # log in using OpenShift token
     chectl auth:login --chenamespace=${NAMESPACE}

--- a/.github/bin/minikube/test-operator-singlehost-gateway.sh
+++ b/.github/bin/minikube/test-operator-singlehost-gateway.sh
@@ -17,7 +17,6 @@ set -u
 # Get absolute path for root repo directory from github actions context: https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions
 export OPERATOR_REPO="${GITHUB_WORKSPACE}"
 source "${OPERATOR_REPO}"/.github/bin/common.sh
-source "${OPERATOR_REPO}/olm/olm.sh"
 
 # Stop execution on any error
 trap "catchFinish" EXIT SIGINT
@@ -26,7 +25,6 @@ prepareTemplates() {
   disableUpdateAdminPassword ${TEMPLATES}
   setCustomOperatorImage ${TEMPLATES} ${OPERATOR_IMAGE}
   setServerExposureStrategy ${TEMPLATES} "single-host"
-  enableDevWorkspace ${TEMPLATES} true
   setSingleHostExposureType ${TEMPLATES} "gateway"
   setIngressDomain ${TEMPLATES} "$(minikube ip).nip.io"
 }
@@ -38,9 +36,7 @@ runTest() {
 }
 
 initDefaults
-installOperatorMarketPlace
 initLatestTemplates
 prepareTemplates
-buildCheOperatorImage
 copyCheOperatorImageToMinikube
 runTest

--- a/.github/bin/minikube/test-operator-singlehost-gateway.sh
+++ b/.github/bin/minikube/test-operator-singlehost-gateway.sh
@@ -38,5 +38,6 @@ runTest() {
 initDefaults
 initLatestTemplates
 prepareTemplates
+buildCheOperatorImage
 copyCheOperatorImageToMinikube
 runTest

--- a/.github/bin/minikube/test-operator-singlehost-native.sh
+++ b/.github/bin/minikube/test-operator-singlehost-native.sh
@@ -16,7 +16,6 @@ set -x
 # Get absolute path for root repo directory from github actions context: https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions
 export OPERATOR_REPO="${GITHUB_WORKSPACE}"
 source "${OPERATOR_REPO}"/.github/bin/common.sh
-source "${OPERATOR_REPO}/olm/olm.sh"
 
 # Stop execution on any error
 trap "catchFinish" EXIT SIGINT
@@ -25,7 +24,6 @@ prepareTemplates() {
   disableUpdateAdminPassword ${TEMPLATES}
   setCustomOperatorImage ${TEMPLATES} ${OPERATOR_IMAGE}
   setServerExposureStrategy ${TEMPLATES} "single-host"
-  enableDevWorkspace ${TEMPLATES} true
   setSingleHostExposureType ${TEMPLATES} "native"
   setIngressDomain ${TEMPLATES} "$(minikube ip).nip.io"
 }
@@ -37,9 +35,7 @@ runTest() {
 }
 
 initDefaults
-installOperatorMarketPlace
 initLatestTemplates
 prepareTemplates
-buildCheOperatorImage
 copyCheOperatorImageToMinikube
 runTest

--- a/.github/bin/minikube/test-operator-singlehost-native.sh
+++ b/.github/bin/minikube/test-operator-singlehost-native.sh
@@ -37,5 +37,6 @@ runTest() {
 initDefaults
 initLatestTemplates
 prepareTemplates
+buildCheOperatorImage
 copyCheOperatorImageToMinikube
 runTest

--- a/.github/workflows/minikube-operator-singlehost.yaml
+++ b/.github/workflows/minikube-operator-singlehost.yaml
@@ -14,32 +14,16 @@ on: pull_request
 jobs:
   minikube-gateway:
     name: Testing latest changes (single-host/gateway)
-    runs-on: macos-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
-    - name: Build Che operator image
-      run: |
-        export OPERATOR_IMAGE=test/che-operator:test
-        # coreutils provides a readlink that supports `-f`
-        brew install coreutils docker docker-machine
-        mkdir -p ~/.docker/machine/cache/
-        sudo curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
-        docker-machine --github-api-token="${{ secrets.GITHUB_TOKEN }}" create --driver virtualbox default
-        eval "$(docker-machine env default)"
-        export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
-        docker build -t "${OPERATOR_IMAGE}" -f Dockerfile . && docker save "${OPERATOR_IMAGE}" > /tmp/operator.tar
-        docker-machine stop
+    - name: Install yq
+      run: sudo pip install yq
     - name: Provision Minikube cluster
       run: |
-        curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-amd64
-        sudo install minikube-darwin-amd64 /usr/local/bin/minikube
-        minikube start --memory=10000 --cpus=2
-    - name: Install kubectl
-      run: |
-        curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl"
-        chmod +x ./kubectl
-        sudo mv ./kubectl /usr/local/bin/kubectl
-        kubectl version --client
+        curl -LO https://storage.googleapis.com/minikube/releases/v1.18.1/minikube-linux-amd64
+        sudo install minikube-linux-amd64 /usr/local/bin/minikube
+        minikube start --memory=6000mb
     - name: Enable minikube addons
       run: |
         minikube addons enable ingress
@@ -47,11 +31,8 @@ jobs:
         /bin/bash olm/minikube-registry-addon.sh &
     - name: Install chectl
       run: bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next
-    - name: Install jq
-      run: brew install python-yq
     - name: Run tests
-      run: |
-        /bin/bash .github/bin/minikube/test-operator-singlehost-gateway.sh
+      run: /bin/bash .github/bin/minikube/test-operator-singlehost-gateway.sh
     # Run this step even the previous step fail to upload artifacts to GH
     - uses: actions/upload-artifact@v2
       if: ${{ always() }}
@@ -60,32 +41,16 @@ jobs:
         path: /tmp/artifacts-che
   minikube-native:
     name: Testing latest changes (single-host/native)
-    runs-on: macos-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
-    - name: Build Che operator image
-      run: |
-        export OPERATOR_IMAGE=test/che-operator:test
-        # coreutils provides a readlink that supports `-f`
-        brew install coreutils docker docker-machine
-        mkdir -p ~/.docker/machine/cache/
-        sudo curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
-        docker-machine --github-api-token="${{ secrets.GITHUB_TOKEN }}" create --driver virtualbox default
-        eval "$(docker-machine env default)"
-        export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
-        docker build -t "${OPERATOR_IMAGE}" -f Dockerfile . && docker save "${OPERATOR_IMAGE}" > /tmp/operator.tar
-        docker-machine stop
+    - name: Install yq
+      run: sudo pip install yq
     - name: Provision Minikube cluster
       run: |
-        curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-amd64
-        sudo install minikube-darwin-amd64 /usr/local/bin/minikube
-        minikube start --memory=10000 --cpus=2
-    - name: Install kubectl
-      run: |
-        curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl"
-        chmod +x ./kubectl
-        sudo mv ./kubectl /usr/local/bin/kubectl
-        kubectl version --client
+        curl -LO https://storage.googleapis.com/minikube/releases/v1.18.1/minikube-linux-amd64
+        sudo install minikube-linux-amd64 /usr/local/bin/minikube
+        minikube start --memory=6000mb
     - name: Enable minikube addons
       run: |
         minikube addons enable ingress
@@ -93,9 +58,6 @@ jobs:
         /bin/bash olm/minikube-registry-addon.sh &
     - name: Install chectl
       run: bash <(curl -sL  https://www.eclipse.org/che/chectl/) --channel=next
-    - name: Install yq
-      run: |
-        brew install python-yq
     - name: Run tests
       run: /bin/bash .github/bin/minikube/test-operator-singlehost-native.sh
     # Run this step even the previous step fail to upload artifacts to GH

--- a/.github/workflows/minikube-operator-singlehost.yaml
+++ b/.github/workflows/minikube-operator-singlehost.yaml
@@ -14,26 +14,44 @@ on: pull_request
 jobs:
   minikube-gateway:
     name: Testing latest changes (single-host/gateway)
-    runs-on: ubuntu-20.04
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Install yq
-      run: sudo pip install yq
+    - name: Build Che operator image
+      run: |
+        export OPERATOR_IMAGE=test/che-operator:test
+        # coreutils provides a readlink that supports `-f`
+        brew install coreutils docker docker-machine
+        mkdir -p ~/.docker/machine/cache/
+        sudo curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
+        docker-machine --github-api-token="${{ secrets.GITHUB_TOKEN }}" create --driver virtualbox default
+        eval "$(docker-machine env default)"
+        export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+        docker build -t "${OPERATOR_IMAGE}" -f Dockerfile . && docker save "${OPERATOR_IMAGE}" > /tmp/operator.tar
+        docker-machine stop
     - name: Provision Minikube cluster
       run: |
-        curl -LO https://storage.googleapis.com/minikube/releases/v1.18.1/minikube-linux-amd64
-        sudo install minikube-linux-amd64 /usr/local/bin/minikube
-        minikube start --memory=6000mb
+        curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-amd64
+        sudo install minikube-darwin-amd64 /usr/local/bin/minikube
+        minikube start --memory=10000 --cpus=2
+    - name: Install kubectl
+      run: |
+        curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl"
+        chmod +x ./kubectl
+        sudo mv ./kubectl /usr/local/bin/kubectl
+        kubectl version --client
     - name: Enable minikube addons
       run: |
         minikube addons enable ingress
-
         # Enable registry and portfward to push images to registry
         /bin/bash olm/minikube-registry-addon.sh &
     - name: Install chectl
       run: bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next
+    - name: Install jq
+      run: brew install python-yq
     - name: Run tests
-      run: /bin/bash .github/bin/minikube/test-operator-singlehost-gateway.sh
+      run: |
+        /bin/bash .github/bin/minikube/test-operator-singlehost-gateway.sh
     # Run this step even the previous step fail to upload artifacts to GH
     - uses: actions/upload-artifact@v2
       if: ${{ always() }}
@@ -42,24 +60,42 @@ jobs:
         path: /tmp/artifacts-che
   minikube-native:
     name: Testing latest changes (single-host/native)
-    runs-on: ubuntu-20.04
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Install yq
-      run: sudo pip install yq
+    - name: Build Che operator image
+      run: |
+        export OPERATOR_IMAGE=test/che-operator:test
+        # coreutils provides a readlink that supports `-f`
+        brew install coreutils docker docker-machine
+        mkdir -p ~/.docker/machine/cache/
+        sudo curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
+        docker-machine --github-api-token="${{ secrets.GITHUB_TOKEN }}" create --driver virtualbox default
+        eval "$(docker-machine env default)"
+        export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+        docker build -t "${OPERATOR_IMAGE}" -f Dockerfile . && docker save "${OPERATOR_IMAGE}" > /tmp/operator.tar
+        docker-machine stop
     - name: Provision Minikube cluster
       run: |
-        curl -LO https://storage.googleapis.com/minikube/releases/v1.18.1/minikube-linux-amd64
-        sudo install minikube-linux-amd64 /usr/local/bin/minikube
-        minikube start --memory=6000mb
+        curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-amd64
+        sudo install minikube-darwin-amd64 /usr/local/bin/minikube
+        minikube start --memory=10000 --cpus=2
+    - name: Install kubectl
+      run: |
+        curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/darwin/amd64/kubectl"
+        chmod +x ./kubectl
+        sudo mv ./kubectl /usr/local/bin/kubectl
+        kubectl version --client
     - name: Enable minikube addons
       run: |
         minikube addons enable ingress
-
         # Enable registry and portfward to push images to registry
         /bin/bash olm/minikube-registry-addon.sh &
     - name: Install chectl
       run: bash <(curl -sL  https://www.eclipse.org/che/chectl/) --channel=next
+    - name: Install yq
+      run: |
+        brew install python-yq
     - name: Run tests
       run: /bin/bash .github/bin/minikube/test-operator-singlehost-native.sh
     # Run this step even the previous step fail to upload artifacts to GH


### PR DESCRIPTION
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
- Tests will fail sooner if workspace failed to start
- Disable devworkspace startup on minikube for single-host mode

https://github.com/eclipse/che/issues/19765

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19765


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
