### PR TITLE
Configure keycloak by setting -Dkeycloak.connectionsHttpClient.default.expect-continue-enabled=true and -Dkeycloak.connectionsHttpClient.default.reuse-connections=false

### DIFF
--- a/pkg/deploy/identity-provider/deployment_keycloak.go
+++ b/pkg/deploy/identity-provider/deployment_keycloak.go
@@ -545,23 +545,21 @@ func GetSpecKeycloakDeployment(
 		}
 	}
 
+	evaluateKeycloakSystemProperties := "KEYCLOAK_SYS_PROPS=\"-Dkeycloak.profile.feature.token_exchange=enabled -Dkeycloak.profile.feature.admin_fine_grained_authz=enabled\""
+
 	// Evaluating keycloak.connectionsHttpClient.default system properties, see details: https://github.com/eclipse/che/issues/19653
-	evaluateExpectContinueEnabled := "if [[ \"x$CONNECTIONS_HTTP_CLIENT_DEFAULT_EXPECT_CONTINUE_ENABLED\" == \"x\" ]]; then CONNECTIONS_HTTP_CLIENT_DEFAULT_EXPECT_CONTINUE_ENABLED=-Dkeycloak.connectionsHttpClient.default.expect-continue-enabled=true; fi"
-	evaluateReuseConnections := "if [[ \"x$CONNECTIONS_HTTP_CLIENT_DEFAULT_REUSE_CONNECTIONS\" == \"x\" ]]; then CONNECTIONS_HTTP_CLIENT_DEFAULT_REUSE_CONNECTIONS=-Dkeycloak.connectionsHttpClient.default.reuse-connections=false; fi"
+	evaluateExpectContinueEnabled := "if [[ \"$KEYCLOAK_CONNECTIONS_HTTP_CLIENT_DEFAULT_EXPECT_CONTINUE_ENABLED\" != false ]]; then KEYCLOAK_SYS_PROPS=$KEYCLOAK_SYS_PROPS\" -Dkeycloak.connectionsHttpClient.default.expect-continue-enabled=true\"; fi"	evaluateReuseConnections := "if [[ \"KEYCLOAK_CONNECTIONS_HTTP_CLIENT_DEFAULT_REUSE_CONNECTIONS\" != true ]]; then KEYCLOAK_SYS_PROPS=$KEYCLOAK_SYS_PROPS\" -Dkeycloak.connectionsHttpClient.default.reuse-connections=false\"; fi"
 
 	command := bashFunctions + "\n" +
 		addCertToTrustStoreCommand +
 		addProxyCliCommand +
 		applyProxyCliCommand +
+		" && " + evaluateKeycloakSystemProperties +
 		" && " + evaluateExpectContinueEnabled +
 		" && " + evaluateReuseConnections +
 		" && " + changeConfigCommand + enableFixedHostNameProvider +
-		" && /opt/jboss/docker-entrypoint.sh -b 0.0.0.0 -c standalone.xml"
-	command += " -Dkeycloak.profile.feature.token_exchange=enabled -Dkeycloak.profile.feature.admin_fine_grained_authz=enabled"
+		" && /opt/jboss/docker-entrypoint.sh -b 0.0.0.0 -c standalone.xml $KEYCLOAK_SYS_PROPS"
 
-	// Adding keycloak.connectionsHttpClient.default system properties, see details: https://github.com/eclipse/che/issues/19653
-	command += " $CONNECTIONS_HTTP_CLIENT_DEFAULT_EXPECT_CONTINUE_ENABLED"
-	command += " $CONNECTIONS_HTTP_CLIENT_DEFAULT_REUSE_CONNECTIONS"
 	if cheFlavor == "codeready" {
 		addUsernameReadonlyTheme := "baseTemplate=/opt/eap/themes/base/login/login-update-profile.ftl" +
 			" && readOnlyTemplateDir=/opt/eap/themes/codeready-username-readonly/login" +

--- a/pkg/deploy/identity-provider/deployment_keycloak.go
+++ b/pkg/deploy/identity-provider/deployment_keycloak.go
@@ -545,9 +545,23 @@ func GetSpecKeycloakDeployment(
 		}
 	}
 
-	command := bashFunctions + "\n" + addCertToTrustStoreCommand + addProxyCliCommand + applyProxyCliCommand + " && " + changeConfigCommand + enableFixedHostNameProvider +
-		" && /opt/jboss/docker-entrypoint.sh --debug -b 0.0.0.0 -c standalone.xml"
+	// Evaluating keycloak.connectionsHttpClient.default system properties, see details: https://github.com/eclipse/che/issues/19653
+	evaluateExpectContinueEnabled := "if [[ \"x$CONNECTIONS_HTTP_CLIENT_DEFAULT_EXPECT_CONTINUE_ENABLED\" == \"x\" ]]; then CONNECTIONS_HTTP_CLIENT_DEFAULT_EXPECT_CONTINUE_ENABLED=-Dkeycloak.connectionsHttpClient.default.expect-continue-enabled=true; fi"
+	evaluateReuseConnections := "if [[ \"x$CONNECTIONS_HTTP_CLIENT_DEFAULT_REUSE_CONNECTIONS\" == \"x\" ]]; then CONNECTIONS_HTTP_CLIENT_DEFAULT_REUSE_CONNECTIONS=-Dkeycloak.connectionsHttpClient.default.reuse-connections=false; fi"
+
+	command := bashFunctions + "\n" +
+		addCertToTrustStoreCommand +
+		addProxyCliCommand +
+		applyProxyCliCommand +
+		" && " + evaluateExpectContinueEnabled +
+		" && " + evaluateReuseConnections +
+		" && " + changeConfigCommand + enableFixedHostNameProvider +
+		" && /opt/jboss/docker-entrypoint.sh -b 0.0.0.0 -c standalone.xml"
 	command += " -Dkeycloak.profile.feature.token_exchange=enabled -Dkeycloak.profile.feature.admin_fine_grained_authz=enabled"
+
+	// Adding keycloak.connectionsHttpClient.default system properties, see details: https://github.com/eclipse/che/issues/19653
+	command += " $CONNECTIONS_HTTP_CLIENT_DEFAULT_EXPECT_CONTINUE_ENABLED"
+	command += " $CONNECTIONS_HTTP_CLIENT_DEFAULT_REUSE_CONNECTIONS"
 	if cheFlavor == "codeready" {
 		addUsernameReadonlyTheme := "baseTemplate=/opt/eap/themes/base/login/login-update-profile.ftl" +
 			" && readOnlyTemplateDir=/opt/eap/themes/codeready-username-readonly/login" +

--- a/pkg/deploy/identity-provider/deployment_keycloak.go
+++ b/pkg/deploy/identity-provider/deployment_keycloak.go
@@ -548,7 +548,8 @@ func GetSpecKeycloakDeployment(
 	evaluateKeycloakSystemProperties := "KEYCLOAK_SYS_PROPS=\"-Dkeycloak.profile.feature.token_exchange=enabled -Dkeycloak.profile.feature.admin_fine_grained_authz=enabled\""
 
 	// Evaluating keycloak.connectionsHttpClient.default system properties, see details: https://github.com/eclipse/che/issues/19653
-	evaluateExpectContinueEnabled := "if [[ \"$KEYCLOAK_CONNECTIONS_HTTP_CLIENT_DEFAULT_EXPECT_CONTINUE_ENABLED\" != false ]]; then KEYCLOAK_SYS_PROPS=$KEYCLOAK_SYS_PROPS\" -Dkeycloak.connectionsHttpClient.default.expect-continue-enabled=true\"; fi"	evaluateReuseConnections := "if [[ \"KEYCLOAK_CONNECTIONS_HTTP_CLIENT_DEFAULT_REUSE_CONNECTIONS\" != true ]]; then KEYCLOAK_SYS_PROPS=$KEYCLOAK_SYS_PROPS\" -Dkeycloak.connectionsHttpClient.default.reuse-connections=false\"; fi"
+	evaluateExpectContinueEnabled := "if [[ $KEYCLOAK_CONNECTIONS_HTTP_CLIENT_DEFAULT_EXPECT_CONTINUE_ENABLED != false ]]; then KEYCLOAK_SYS_PROPS=$KEYCLOAK_SYS_PROPS\" -Dkeycloak.connectionsHttpClient.default.expect-continue-enabled=true\"; fi"
+	evaluateReuseConnections := "if [[ $KEYCLOAK_CONNECTIONS_HTTP_CLIENT_DEFAULT_REUSE_CONNECTIONS != true ]]; then KEYCLOAK_SYS_PROPS=$KEYCLOAK_SYS_PROPS\" -Dkeycloak.connectionsHttpClient.default.reuse-connections=false\"; fi"
 
 	command := bashFunctions + "\n" +
 		addCertToTrustStoreCommand +


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
- Allows to configure keycloak by setting the following system properties (by default) to avoid ConnectionReset exception
```
-Dkeycloak.connectionsHttpClient.default.expect-continue-enabled=true
-Dkeycloak.connectionsHttpClient.default.reuse-connections=false
```
- Allows to turn them off by setting env variable via mounting secret into keycloak container
```yaml
kind: Secret
apiVersion: v1
metadata:
  name: keycloak-secret
  namespace: eclipse-che
  labels:
    app.kubernetes.io/component: keycloak-secret
    app.kubernetes.io/part-of: che.eclipse.org
  annotations:
    che.eclipse.org/mount-as: env
    che.eclipse.org/CONTINUE_ENABLED_env-name: KEYCLOAK_CONNECTIONS_HTTP_CLIENT_DEFAULT_EXPECT_CONTINUE_ENABLED
    che.eclipse.org/REUSE_CONNECTIONS_env-name: KEYCLOAK_CONNECTIONS_HTTP_CLIENT_DEFAULT_REUSE_CONNECTIONS
data:
  CONTINUE_ENABLED: ZmFsc2U= // false in base64
  REUSE_CONNECTIONS: dHJ1ZQ== // true in base64
type: Opaque

```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19653

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
1. Deploy Eclipse Che on minkube
2. Exec into keycloak pod `ps -x | grep keycloak.connectionsHttpClient.default` to check that system properties are set
3. Mount secret above 
4. Exec into keycloak pod `ps -x | grep keycloak.connectionsHttpClient.default` to check that system properties are NOT set

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
