### PR TITLE
fix: Add PVC delete permission to che service account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.4-200 as builder
+FROM registry.access.redhat.com/ubi8-minimal:8.4-200
 RUN microdnf install -y golang unzip && \
     go version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.4-200
+FROM registry.access.redhat.com/ubi8-minimal:8.4-200 as builder
 RUN microdnf install -y golang unzip && \
     go version
 

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -195,6 +195,7 @@ rules:
       - get
       - list
       - watch
+      - delete
   - apiGroups:
       - ''
     resources:

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -76,13 +76,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-05-26T13:50:09Z"
+    createdAt: "2021-05-31T16:11:40Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.31.0-186.nightly
+  name: eclipse-che-preview-kubernetes.v7.32.0-188.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -358,6 +358,7 @@ spec:
                 - get
                 - list
                 - watch
+                - delete
             - apiGroups:
                 - ""
               resources:
@@ -1133,4 +1134,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.31.0-186.nightly
+  version: 7.32.0-188.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -76,13 +76,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-05-31T16:11:40Z"
+    createdAt: "2021-06-01T06:17:02Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.32.0-188.nightly
+  name: eclipse-che-preview-kubernetes.v7.32.0-190.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1134,4 +1134,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.32.0-188.nightly
+  version: 7.32.0-190.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -67,13 +67,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-05-31T16:11:54Z"
+    createdAt: "2021-06-01T06:17:09Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.32.0-188.nightly
+  name: eclipse-che-preview-openshift.v7.32.0-190.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1209,4 +1209,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.32.0-188.nightly
+  version: 7.32.0-190.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -67,13 +67,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-05-26T13:50:19Z"
+    createdAt: "2021-05-31T16:11:54Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.31.0-186.nightly
+  name: eclipse-che-preview-openshift.v7.32.0-188.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -419,6 +419,7 @@ spec:
                 - get
                 - list
                 - watch
+                - delete
             - apiGroups:
                 - ""
               resources:
@@ -1208,4 +1209,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.31.0-186.nightly
+  version: 7.32.0-188.nightly

--- a/pkg/controller/che/workspace_namespace_permission.go
+++ b/pkg/controller/che/workspace_namespace_permission.go
@@ -60,7 +60,7 @@ func (r *ReconcileChe) reconcileWorkspacePermissions(deployContext *deploy.Deplo
 // Create cluster roles and cluster role bindings for "che" service account.
 // che-server uses "che" service account for creation new workspaces and workspace components.
 // Operator will create two cluster roles:
-// - "<workspace-namespace/project-name>-cheworkspaces-namespaces-clusterrole" - cluster role to mange namespace(for Kubernetes platform)
+// - "<workspace-namespace/project-name>-cheworkspaces-namespaces-clusterrole" - cluster role to manage namespace(for Kubernetes platform)
 //    or project(for Openshift platform) for new workspace.
 // - "<workspace-namespace/project-name>-cheworkspaces-clusterrole" - cluster role to create and manage k8s objects required for
 //    workspace components.
@@ -205,7 +205,7 @@ func getWorkspacesPolicies() []rbac.PolicyRule {
 		{
 			APIGroups: []string{""},
 			Resources: []string{"persistentvolumeclaims"},
-			Verbs:     []string{"get", "create", "watch"},
+			Verbs:     []string{"get", "create", "watch", "delete"},
 		},
 		{
 			APIGroups: []string{""},


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
This PR adds delete permissions for the Che service account to allow deleting PVCs.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
Che service account is now able to delete PVCs:
![image](https://user-images.githubusercontent.com/83611742/119720238-ba1eee00-be37-11eb-9ddc-241371cb57ea.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Fixes https://github.com/eclipse/che/issues/19867

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
Here is the Che operator image: `quay.io/dkwon17/che-operator:19867`

1. Start minikube and deploy Che with the operator with `chectl`
```
minikube start --addons=ingress --vm=true --memory=8192
chectl server:deploy --installer operator -p minikube --che-operator-image=quay.io/dkwon17/che-operator:19867
```

2. Create a workspace, which creates a PVC named `claim-che-workspace` (here the PVC strategy is `common`) in the `admin-che` namespace:
![image](https://user-images.githubusercontent.com/83611742/119572172-5b4a6d80-bd80-11eb-9ad0-cb56f9e9e4d6.png)

3. Delete the PVC using `oc`
```
oc login --token=<che service account token>
oc project admin-che
oc delete pvc claim-che-workspace
```
The PVC should be deleted.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
