### PR TITLE
chore: Ensure that che-server's SA have enough permission to manipulate with devworkspaces resource on kubernetes

### DIFF
--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -76,13 +76,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-06-04T11:26:58Z"
+    createdAt: "2021-06-07T15:13:20Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.32.0-194.nightly
+  name: eclipse-che-preview-kubernetes.v7.32.0-196.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1134,4 +1134,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.32.0-194.nightly
+  version: 7.32.0-196.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -67,13 +67,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2021-06-04T11:27:06Z"
+    createdAt: "2021-06-07T15:13:25Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.32.0-194.nightly
+  name: eclipse-che-preview-openshift.v7.32.0-196.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1209,4 +1209,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.32.0-194.nightly
+  version: 7.32.0-196.nightly

--- a/pkg/controller/che/workspace_namespace_permission.go
+++ b/pkg/controller/che/workspace_namespace_permission.go
@@ -167,13 +167,14 @@ func (r *ReconcileChe) delegateDevWorkspacePermissions(deployContext *deploy.Dep
 
 func (r *ReconcileChe) removeDevWorkspacePermissions(deployContext *deploy.DeployContext) (bool, error) {
 	devWorkspaceClusterRoleName := fmt.Sprintf(DevWorkspaceClusterRoleNameTemplate, deployContext.CheCluster.Namespace)
+	devWorkspaceClusterRoleBindingName := devWorkspaceClusterRoleName
 
 	done, err := deploy.Delete(deployContext, types.NamespacedName{Name: devWorkspaceClusterRoleName}, &rbac.ClusterRole{})
 	if !done {
 		return false, err
 	}
 
-	done, err = deploy.Delete(deployContext, types.NamespacedName{Name: devWorkspaceClusterRoleName}, &rbac.ClusterRoleBinding{})
+	done, err = deploy.Delete(deployContext, types.NamespacedName{Name: devWorkspaceClusterRoleBindingName}, &rbac.ClusterRoleBinding{})
 	if !done {
 		return false, err
 	}

--- a/pkg/controller/che/workspace_namespace_permission.go
+++ b/pkg/controller/che/workspace_namespace_permission.go
@@ -205,7 +205,7 @@ func getDevWorkspacePolicies() []rbac.PolicyRule {
 	k8sPolicies := []rbac.PolicyRule{
 		{
 			APIGroups: []string{"workspace.devfile.io"},
-			Resources: []string{"devworkspaces", "devworkspacetemplate"},
+			Resources: []string{"devworkspaces", "devworkspacetemplates"},
 			Verbs:     []string{"get", "create", "delete", "list", "update", "patch"},
 		},
 	}

--- a/pkg/controller/che/workspace_namespace_permission.go
+++ b/pkg/controller/che/workspace_namespace_permission.go
@@ -151,7 +151,6 @@ func (r *ReconcileChe) delegateDevWorkspacePermissions(deployContext *deploy.Dep
 	devWorkspaceClusterRoleName := fmt.Sprintf(DevWorkspaceClusterRoleNameTemplate, deployContext.CheCluster.Namespace)
 	devWorkspaceClusterRoleBindingName := devWorkspaceClusterRoleName
 
-	// Create clusterrole "<workspace-namespace/project-name>-clusterrole-manage-namespaces" to manage namespace/projects for Che workspaces.
 	done, err := deploy.SyncClusterRoleToCluster(deployContext, devWorkspaceClusterRoleName, getDevWorkspacePolicies())
 	if !done {
 		return false, err

--- a/pkg/controller/che/workspace_namespace_permission_test.go
+++ b/pkg/controller/che/workspace_namespace_permission_test.go
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package che
+
+import (
+	"testing"
+
+	"github.com/eclipse-che/che-operator/pkg/deploy"
+	"github.com/eclipse-che/che-operator/pkg/util"
+	rbac "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestReconcileWorkspacePermissions(t *testing.T) {
+	deployContext := deploy.GetTestDeployContext(nil, []runtime.Object{})
+	reconciler := &ReconcileChe{
+		client:          deployContext.ClusterAPI.Client,
+		nonCachedClient: deployContext.ClusterAPI.Client,
+		discoveryClient: deployContext.ClusterAPI.DiscoveryClient,
+		scheme:          deployContext.ClusterAPI.Scheme,
+		tests:           true,
+	}
+
+	done, err := reconciler.reconcileWorkspacePermissions(deployContext)
+	if err != nil {
+		t.Fatalf("Failed to reconcile permissions: %v", err)
+	}
+	if !done {
+		t.Fatalf("Permissions are not reconciled.")
+	}
+
+	if !util.ContainsString(deployContext.CheCluster.Finalizers, CheWorkspacesClusterPermissionsFinalizerName) {
+		t.Fatalf("Finalizer '%s' not added", CheWorkspacesClusterPermissionsFinalizerName)
+	}
+	if !util.ContainsString(deployContext.CheCluster.Finalizers, NamespacesEditorPermissionsFinalizerName) {
+		t.Fatalf("Finalizer '%s' not added", NamespacesEditorPermissionsFinalizerName)
+	}
+	if !util.ContainsString(deployContext.CheCluster.Finalizers, DevWorkspacePermissionsFinalizerName) {
+		t.Fatalf("Finalizer '%s' not added", DevWorkspacePermissionsFinalizerName)
+	}
+
+	name := "eclipse-che-cheworkspaces-clusterrole"
+	exists, _ := deploy.Get(deployContext, types.NamespacedName{Name: name}, &rbac.ClusterRole{})
+	if !exists {
+		t.Fatalf("Cluster Role '%s' not found", name)
+	}
+
+	name = "eclipse-che-cheworkspaces-clusterrole"
+	exists, _ = deploy.Get(deployContext, types.NamespacedName{Name: name}, &rbac.ClusterRoleBinding{})
+	if !exists {
+		t.Fatalf("Cluster Role Binding '%s' not found", name)
+	}
+
+	name = "eclipse-che-cheworkspaces-namespaces-clusterrole"
+	exists, _ = deploy.Get(deployContext, types.NamespacedName{Name: name}, &rbac.ClusterRole{})
+	if !exists {
+		t.Fatalf("Cluster Role '%s' not found", name)
+	}
+
+	name = "eclipse-che-cheworkspaces-namespaces-clusterrole"
+	exists, _ = deploy.Get(deployContext, types.NamespacedName{Name: name}, &rbac.ClusterRoleBinding{})
+	if !exists {
+		t.Fatalf("Cluster Role Binding '%s' not found", name)
+	}
+
+	name = "eclipse-che-cheworkspaces-devworkspace-clusterrole"
+	exists, _ = deploy.Get(deployContext, types.NamespacedName{Name: name}, &rbac.ClusterRole{})
+	if !exists {
+		t.Fatalf("Cluster Role '%s' not found", name)
+	}
+
+	name = "eclipse-che-cheworkspaces-devworkspace-clusterrole"
+	exists, _ = deploy.Get(deployContext, types.NamespacedName{Name: name}, &rbac.ClusterRoleBinding{})
+	if !exists {
+		t.Fatalf("Cluster Role Binding '%s' not found", name)
+	}
+}

--- a/pkg/controller/che/workspace_namespace_permission_test.go
+++ b/pkg/controller/che/workspace_namespace_permission_test.go
@@ -54,8 +54,6 @@ func TestReconcileWorkspacePermissions(t *testing.T) {
 	if !exists {
 		t.Fatalf("Cluster Role '%s' not found", name)
 	}
-
-	name = "eclipse-che-cheworkspaces-clusterrole"
 	exists, _ = deploy.Get(deployContext, types.NamespacedName{Name: name}, &rbac.ClusterRoleBinding{})
 	if !exists {
 		t.Fatalf("Cluster Role Binding '%s' not found", name)
@@ -66,8 +64,6 @@ func TestReconcileWorkspacePermissions(t *testing.T) {
 	if !exists {
 		t.Fatalf("Cluster Role '%s' not found", name)
 	}
-
-	name = "eclipse-che-cheworkspaces-namespaces-clusterrole"
 	exists, _ = deploy.Get(deployContext, types.NamespacedName{Name: name}, &rbac.ClusterRoleBinding{})
 	if !exists {
 		t.Fatalf("Cluster Role Binding '%s' not found", name)
@@ -78,8 +74,6 @@ func TestReconcileWorkspacePermissions(t *testing.T) {
 	if !exists {
 		t.Fatalf("Cluster Role '%s' not found", name)
 	}
-
-	name = "eclipse-che-cheworkspaces-devworkspace-clusterrole"
 	exists, _ = deploy.Get(deployContext, types.NamespacedName{Name: name}, &rbac.ClusterRoleBinding{})
 	if !exists {
 		t.Fatalf("Cluster Role Binding '%s' not found", name)


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
che-operator delegates some permissions to manipulates with devworkspace resources

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19920

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
1. deploy Eclipse Che
2. check if `eclipse-che-cheworkspaces-devworkspace-clusterrole` cluster role & cluster role binding are created

Image to test: `docker.io/abazko/operator:19920`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
