### PR TITLE
Add support for configuring the labels for gateway configmaps

### DIFF
--- a/pkg/apis/org/conversion.go
+++ b/pkg/apis/org/conversion.go
@@ -55,6 +55,7 @@ func V1ToV2alpha1(v1 *v1.CheCluster, v2 *v2alpha1.CheCluster) error {
 	v1ToV2alpha1_GatewayImage(v1, v2)
 	v1ToV2alpha1_GatewayConfigurerImage(v1, v2)
 	v1ToV2alpha1_GatewayTlsSecretName(v1, v2)
+	v1toV2alpha1_GatewayConfigLabels(v1, v2)
 	v1ToV2alpha1_WorkspaceDomainEndpointsBaseDomain(v1, v2)
 	v1ToV2alpha1_WorkspaceDomainEndpointsTlsSecretName(v1, v2)
 	v1ToV2alpha1_K8sIngressAnnotations(v1, v2)
@@ -91,6 +92,7 @@ func V2alpha1ToV1(v2 *v2alpha1.CheCluster, v1Obj *v1.CheCluster) error {
 	v2alpha1ToV1_GatewayImage(v1Obj, v2)
 	v2alpha1ToV1_GatewayConfigurerImage(v1Obj, v2)
 	v2alpha1ToV1_GatewayTlsSecretName(v1Obj, v2)
+	v2alpha1ToV1_GatewayConfigLabels(v1Obj, v2)
 	v2alpha1ToV1_WorkspaceDomainEndpointsBaseDomain(v1Obj, v2)
 	v2alpha1ToV1_WorkspaceDomainEndpointsTlsSecretName(v1Obj, v2)
 	v2alpha1ToV1_K8sIngressAnnotations(v1Obj, v2)
@@ -149,6 +151,10 @@ func v1ToV2alpha1_GatewayTlsSecretName(v1 *v1.CheCluster, v2 *v2alpha1.CheCluste
 	// In DW we would only used that for subpath endpoints but wouldn't know what TLS to use for subdomain endpoints.
 
 	v2.Spec.Gateway.TlsSecretName = v1.Spec.Server.CheHostTLSSecret
+}
+
+func v1toV2alpha1_GatewayConfigLabels(v1 *v1.CheCluster, v2 *v2alpha1.CheCluster) {
+	v2.Spec.Gateway.ConfigLabels = v1.Spec.Server.SingleHostGatewayConfigMapLabels
 }
 
 func v1ToV2alpha1_K8sIngressAnnotations(v1 *v1.CheCluster, v2 *v2alpha1.CheCluster) {
@@ -267,6 +273,10 @@ func v2alpha1ToV1_GatewayConfigurerImage(v1 *v1.CheCluster, v2 *v2alpha1.CheClus
 func v2alpha1ToV1_GatewayTlsSecretName(v1 *v1.CheCluster, v2 *v2alpha1.CheCluster) {
 	// see the comments in the v1 to v2alpha1 conversion method
 	v1.Spec.Server.CheHostTLSSecret = v2.Spec.Gateway.TlsSecretName
+}
+
+func v2alpha1ToV1_GatewayConfigLabels(v1 *v1.CheCluster, v2 *v2alpha1.CheCluster) {
+	v1.Spec.Server.SingleHostGatewayConfigMapLabels = v2.Spec.Gateway.ConfigLabels
 }
 
 func v2alpha1ToV1_K8sIngressAnnotations(v1 *v1.CheCluster, v2 *v2alpha1.CheCluster) {

--- a/pkg/apis/org/v2alpha1/checluster.go
+++ b/pkg/apis/org/v2alpha1/checluster.go
@@ -14,6 +14,7 @@ package v2alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -104,6 +105,11 @@ type CheGatewaySpec struct {
 	// it is taken from the `RELATED_IMAGE_gateway_configurer` environment variable of the operator
 	// deployment/pod. If not defined there, it defaults to a hardcoded value.
 	ConfigurerImage string `json:"configurerImage,omitempty"`
+
+	// ConfigLabels are labels that are put on the gateway configuration configmaps so that they are picked up
+	// by the gateway configurer. The default value are labels: app=che,component=chec-gateway-config
+	// +optional
+	ConfigLabels labels.Set `json:"configLabels,omitempty"`
 }
 
 // CheClusterSpecK8s contains the configuration options specific to Kubernetes only.

--- a/pkg/apis/org/v2alpha1/checluster.go
+++ b/pkg/apis/org/v2alpha1/checluster.go
@@ -107,7 +107,7 @@ type CheGatewaySpec struct {
 	ConfigurerImage string `json:"configurerImage,omitempty"`
 
 	// ConfigLabels are labels that are put on the gateway configuration configmaps so that they are picked up
-	// by the gateway configurer. The default value are labels: app=che,component=chec-gateway-config
+	// by the gateway configurer. The default value are labels: app=che,component=che-gateway-config
 	// +optional
 	ConfigLabels labels.Set `json:"configLabels,omitempty"`
 }


### PR DESCRIPTION
### What does this PR do?
This adds the ability to configure the labels that should be put on the config maps with the traefik configuration for workspaces. This is needed for the future where che-operator and dwco will share a single gateway.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
eclipse/che#19846

### How to test this PR?
This does not introduce any runtime behavior in che-operator.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
