### PR TITLE
feat: Don't deploy CheManager - it no longer is a thing

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -37,7 +37,7 @@ oc apply -f ${BASE_DIR}/deploy/crds/org.eclipse.che_chebackupserverconfiguration
 oc apply -f ${BASE_DIR}/deploy/crds/org.eclipse.che_checlusterbackups_crd.yaml -n $NAMESPACE
 oc apply -f ${BASE_DIR}/deploy/crds/org.eclipse.che_checlusterrestores_crd.yaml -n $NAMESPACE
 # sometimes the operator cannot get CRD right away
-sleep 2
+sleep 5
 
 cp -f ${BASE_DIR}/deploy/operator.yaml /tmp/operator.yaml
 yq -riyY "( .spec.template.spec.containers[] | select(.name == \"che-operator\") | .image ) = \"${CHE_OPERATOR_IMAGE}\"" /tmp/operator.yaml

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -132,6 +132,7 @@ rules:
       - org.eclipse.che
     resources:
       - checlusters
+      - checlusters/status
       - checlusters/finalizers
     verbs:
       - '*'

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -86,13 +86,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2021-06-30T12:42:36Z"
+    createdAt: "2021-07-01T21:02:20Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.33.0-244.nightly
+  name: eclipse-che-preview-kubernetes.v7.33.0-246.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -318,6 +318,7 @@ spec:
                 - org.eclipse.che
               resources:
                 - checlusters
+                - checlusters/status
                 - checlusters/finalizers
               verbs:
                 - '*'
@@ -1252,4 +1253,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.33.0-244.nightly
+  version: 7.33.0-246.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -77,13 +77,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2021-06-30T12:42:43Z"
+    createdAt: "2021-07-01T21:02:26Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.33.0-244.nightly
+  name: eclipse-che-preview-openshift.v7.33.0-246.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -365,6 +365,7 @@ spec:
                 - org.eclipse.che
               resources:
                 - checlusters
+                - checlusters/status
                 - checlusters/finalizers
               verbs:
                 - '*'
@@ -1329,4 +1330,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.33.0-244.nightly
+  version: 7.33.0-246.nightly

--- a/local-debug.sh
+++ b/local-debug.sh
@@ -18,6 +18,7 @@ command -v operator-sdk >/dev/null 2>&1 || { echo "operator-sdk is not installed
 ECLIPSE_CHE_NAMESPACE="eclipse-che"
 ECLIPSE_CHE_CR="./deploy/crds/org_v1_che_cr.yaml"
 ECLIPSE_CHE_CRD="./deploy/crds/org_v1_che_crd.yaml"
+ECLIPSE_CHE_CRD_V1BETA1="./deploy/crds/org_v1_che_crd-v1beta1.yaml"
 ECLIPSE_CHE_BACKUP_SERVER_CONFIGURATION_CRD="./deploy/crds/org.eclipse.che_chebackupserverconfigurations_crd.yaml"
 ECLIPSE_CHE_BACKUP_CRD="./deploy/crds/org.eclipse.che_checlusterbackups_crd.yaml"
 ECLIPSE_CHE_RESTORE_CRD="./deploy/crds/org.eclipse.che_checlusterrestores_crd.yaml"

--- a/pkg/apis/org/conversion.go
+++ b/pkg/apis/org/conversion.go
@@ -60,6 +60,9 @@ func V1ToV2alpha1(v1 *v1.CheCluster, v2 *v2alpha1.CheCluster) error {
 	v1ToV2alpha1_WorkspaceDomainEndpointsTlsSecretName(v1, v2)
 	v1ToV2alpha1_K8sIngressAnnotations(v1, v2)
 
+	// we don't need to store the serialized v2 on a v2 object
+	delete(v2.Annotations, v2alpha1StorageAnnotation)
+
 	return nil
 }
 
@@ -96,6 +99,9 @@ func V2alpha1ToV1(v2 *v2alpha1.CheCluster, v1Obj *v1.CheCluster) error {
 	v2alpha1ToV1_WorkspaceDomainEndpointsBaseDomain(v1Obj, v2)
 	v2alpha1ToV1_WorkspaceDomainEndpointsTlsSecretName(v1Obj, v2)
 	v2alpha1ToV1_K8sIngressAnnotations(v1Obj, v2)
+
+	// we don't need to store the serialized v1 on a v1 object
+	delete(v1Obj.Annotations, v1StorageAnnotation)
 
 	return nil
 }

--- a/pkg/apis/org/conversion_test.go
+++ b/pkg/apis/org/conversion_test.go
@@ -666,6 +666,14 @@ func TestFullCircleV1(t *testing.T) {
 	if !reflect.DeepEqual(&v1Obj, &convertedV1) {
 		t.Errorf("V1 not equal to itself after the conversion through v2alpha1: %v", cmp.Diff(&v1Obj, &convertedV1))
 	}
+
+	if convertedV1.Annotations[v1StorageAnnotation] != "" {
+		t.Errorf("The v1 storage annotations should not be present on the v1 object")
+	}
+
+	if convertedV1.Annotations[v2alpha1StorageAnnotation] == "" {
+		t.Errorf("The v2alpha1 storage annotation should be present on the v1 object")
+	}
 }
 
 func TestFullCircleV2(t *testing.T) {
@@ -710,6 +718,14 @@ func TestFullCircleV2(t *testing.T) {
 
 	if !reflect.DeepEqual(&v2Obj, &convertedV2) {
 		t.Errorf("V2alpha1 not equal to itself after the conversion through v1: %v", cmp.Diff(&v2Obj, &convertedV2))
+	}
+
+	if convertedV2.Annotations[v2alpha1StorageAnnotation] != "" {
+		t.Errorf("The v2alpha1 storage annotations should not be present on the v2alpha1 object")
+	}
+
+	if convertedV2.Annotations[v1StorageAnnotation] == "" {
+		t.Errorf("The v1 storage annotation should be present on the v2alpha1 object")
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR changes the devworkspace deployment and doesn't deploy the `CheManager` resource, which the DWCO is phasing out. This should be merged RIGHT AFTER https://github.com/che-incubator/devworkspace-che-operator/pull/49 is merged.

### Screenshot/screencast of this PR
N/A


### What issues does this PR fix or reference?
eclipse/che#19847

### How to test this PR?
1. There is a test image of DWCO built from https://github.com/che-incubator/devworkspace-che-operator/tree/issue-19847
2. Build che-operator from this PR that sources the deployment files from the above DWCO:
```
export IMAGE="quay.io/lkrejci/che-operator:issue-19847" && docker build -t $IMAGE --build-arg=DEV_WORKSPACE_CHE_OPERATOR_VERSION=issue-19847 --no-cache . && docker push $IMAGE
```
(replace `quay.io/lkrejci/che-operator:issue-19847` with your image name or you can actually just use that image and skip this step, if you want to).

3. Deploy the previously built `che-operator` to an OpenShift cluster, e.g.: `chectl server:deploy -p openshift -a operator --che-operator-image=quay.io/lkrejci/che-operator:issue-19847` (replacing the operator image with your image name, if you rebuilt manually)
4. Enabled devworkspaces in the `CheCluster` CR.
5. Check there is no `CheManager` resource in the cluster (not even the `chemanagers.che.eclipse.org` CRD)
5. Deploy some devfile v2 workspace.
6. Observe the workspace starting and working as expected.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
