### PR TITLE
feat: set RELATED_IMAGES images to image puller spec

### DIFF
--- a/deploy/crds/org_v1_che_crd-v1beta1.yaml
+++ b/deploy/crds/org_v1_che_crd-v1beta1.yaml
@@ -358,16 +358,17 @@ spec:
               description: Kubernetes Image Puller configuration
               properties:
                 enable:
-                  description: "Install and configure the Community Supported Kubernetes
+                  description: Install and configure the Community Supported Kubernetes
                     Image Puller Operator. When set to `true` and no spec is provided,
                     it will create a default KubernetesImagePuller object to be managed
                     by the Operator. When set to `false`, the KubernetesImagePuller
                     object will be deleted, and the Operator will be uninstalled,
-                    regardless of whether a spec is provided. 
- Note that while this
-                    the Operator and its behavior is community-supported, its payload
-                    may be commercially-supported for pulling commercially-supported
-                    images."
+                    regardless of whether a spec is provided. If the `spec.images`
+                    field is empty, a set of recommended workspace-related images
+                    will be automatically detected and pre-pulled after installation.
+                    Note that while this Operator and its behavior is community-supported,
+                    its payload may be commercially-supported for pulling commercially-supported
+                    images.
                   type: boolean
                 spec:
                   description: A KubernetesImagePullerSpec to configure the image
@@ -390,6 +391,9 @@ spec:
                     deploymentName:
                       type: string
                     images:
+                      description: If empty, a set of recommended workspace-related
+                        images will be automatically detected and pre-pulled after
+                        installation.
                       type: string
                     nodeSelector:
                       type: string

--- a/deploy/crds/org_v1_che_crd.yaml
+++ b/deploy/crds/org_v1_che_crd.yaml
@@ -364,16 +364,17 @@ spec:
                 description: Kubernetes Image Puller configuration
                 properties:
                   enable:
-                    description: "Install and configure the Community Supported Kubernetes
+                    description: Install and configure the Community Supported Kubernetes
                       Image Puller Operator. When set to `true` and no spec is provided,
                       it will create a default KubernetesImagePuller object to be
                       managed by the Operator. When set to `false`, the KubernetesImagePuller
                       object will be deleted, and the Operator will be uninstalled,
-                      regardless of whether a spec is provided. 
- Note that while
-                      this the Operator and its behavior is community-supported, its
-                      payload may be commercially-supported for pulling commercially-supported
-                      images."
+                      regardless of whether a spec is provided. If the `spec.images`
+                      field is empty, a set of recommended workspace-related images
+                      will be automatically detected and pre-pulled after installation.
+                      Note that while this Operator and its behavior is community-supported,
+                      its payload may be commercially-supported for pulling commercially-supported
+                      images.
                     type: boolean
                   spec:
                     description: A KubernetesImagePullerSpec to configure the image
@@ -396,6 +397,9 @@ spec:
                       deploymentName:
                         type: string
                       images:
+                        description: If empty, a set of recommended workspace-related
+                          images will be automatically detected and pre-pulled after
+                          installation.
                         type: string
                       nodeSelector:
                         type: string

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -86,13 +86,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2021-07-07T09:30:36Z"
+    createdAt: "2021-07-12T13:17:30Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.33.0-250.nightly
+  name: eclipse-che-preview-kubernetes.v7.33.0-252.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1241,4 +1241,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.33.0-250.nightly
+  version: 7.33.0-252.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/org_v1_che_crd.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/org_v1_che_crd.yaml
@@ -364,16 +364,17 @@ spec:
                 description: Kubernetes Image Puller configuration
                 properties:
                   enable:
-                    description: "Install and configure the Community Supported Kubernetes
+                    description: Install and configure the Community Supported Kubernetes
                       Image Puller Operator. When set to `true` and no spec is provided,
                       it will create a default KubernetesImagePuller object to be
                       managed by the Operator. When set to `false`, the KubernetesImagePuller
                       object will be deleted, and the Operator will be uninstalled,
-                      regardless of whether a spec is provided. 
- Note that while
-                      this the Operator and its behavior is community-supported, its
-                      payload may be commercially-supported for pulling commercially-supported
-                      images."
+                      regardless of whether a spec is provided. If the `spec.images`
+                      field is empty, a set of recommended workspace-related images
+                      will be automatically detected and pre-pulled after installation.
+                      Note that while this Operator and its behavior is community-supported,
+                      its payload may be commercially-supported for pulling commercially-supported
+                      images.
                     type: boolean
                   spec:
                     description: A KubernetesImagePullerSpec to configure the image
@@ -396,6 +397,9 @@ spec:
                       deploymentName:
                         type: string
                       images:
+                        description: If empty, a set of recommended workspace-related
+                          images will be automatically detected and pre-pulled after
+                          installation.
                         type: string
                       nodeSelector:
                         type: string

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -77,13 +77,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2021-07-07T09:30:48Z"
+    createdAt: "2021-07-12T13:17:47Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.33.0-250.nightly
+  name: eclipse-che-preview-openshift.v7.33.0-252.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1318,4 +1318,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.33.0-250.nightly
+  version: 7.33.0-252.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
@@ -370,15 +370,17 @@ spec:
                   description: Kubernetes Image Puller configuration
                   properties:
                     enable:
-                      description: "Install and configure the Community Supported\
-                        \ Kubernetes Image Puller Operator. When set to `true` and\
-                        \ no spec is provided, it will create a default KubernetesImagePuller\
-                        \ object to be managed by the Operator. When set to `false`,\
-                        \ the KubernetesImagePuller object will be deleted, and the\
-                        \ Operator will be uninstalled, regardless of whether a spec\
-                        \ is provided. Note that while this the Operator and its behavior\
-                        \ is community-supported, its payload may be commercially-supported\
-                        \ for pulling commercially-supported images."
+                      description: Install and configure the Community Supported Kubernetes
+                        Image Puller Operator. When set to `true` and no spec is provided,
+                        it will create a default KubernetesImagePuller object to be
+                        managed by the Operator. When set to `false`, the KubernetesImagePuller
+                        object will be deleted, and the Operator will be uninstalled,
+                        regardless of whether a spec is provided. If the `spec.images`
+                        field is empty, a set of recommended workspace-related images
+                        will be automatically detected and pre-pulled after installation.
+                        Note that while this Operator and its behavior is community-supported,
+                        its payload may be commercially-supported for pulling commercially-supported
+                        images.
                       type: boolean
                     spec:
                       description: A KubernetesImagePullerSpec to configure the image
@@ -401,6 +403,9 @@ spec:
                         deploymentName:
                           type: string
                         images:
+                          description: If empty, a set of recommended workspace-related
+                            images will be automatically detected and pre-pulled after
+                            installation.
                           type: string
                         nodeSelector:
                           type: string

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -592,8 +592,9 @@ type CheClusterSpecImagePuller struct {
 	// it will create a default KubernetesImagePuller object to be managed by the Operator.
 	// When set to `false`, the KubernetesImagePuller object will be deleted, and the Operator will be uninstalled,
 	// regardless of whether a spec is provided.
-	//
-	// Note that while this the Operator and its behavior is community-supported, its payload may be commercially-supported
+	// If the `spec.images` field is empty, a set of recommended workspace-related images will be automatically detected and
+	// pre-pulled after installation.
+	// Note that while this Operator and its behavior is community-supported, its payload may be commercially-supported
 	// for pulling commercially-supported images.
 	Enable bool `json:"enable"`
 	// A KubernetesImagePullerSpec to configure the image puller in the CheCluster
@@ -747,4 +748,8 @@ func (c *CheCluster) IsAirGapMode() bool {
 
 func (c *CheCluster) IsImagePullerSpecEmpty() bool {
 	return c.Spec.ImagePuller.Spec == (chev1alpha1.KubernetesImagePullerSpec{})
+}
+
+func (c *CheCluster) IsImagePullerImagesEmpty() bool {
+	return len(c.Spec.ImagePuller.Spec.Images) == 0
 }

--- a/vendor/github.com/che-incubator/kubernetes-image-puller-operator/pkg/apis/che/v1alpha1/kubernetesimagepuller_types.go
+++ b/vendor/github.com/che-incubator/kubernetes-image-puller-operator/pkg/apis/che/v1alpha1/kubernetesimagepuller_types.go
@@ -8,12 +8,14 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+// +k8s:openapi-gen=true
 // KubernetesImagePullerSpec defines the desired state of KubernetesImagePuller
 type KubernetesImagePullerSpec struct {
+	// If empty, a set of recommended workspace-related images will be automatically detected and pre-pulled after installation.
+	Images               string `json:"images,omitempty"`
 	ConfigMapName        string `json:"configMapName,omitempty"`
 	DaemonsetName        string `json:"daemonsetName,omitempty"`
 	DeploymentName       string `json:"deploymentName,omitempty"`
-	Images               string `json:"images,omitempty"`
 	CachingIntervalHours string `json:"cachingIntervalHours,omitempty"`
 	CachingMemoryRequest string `json:"cachingMemoryRequest,omitempty"`
 	CachingMemoryLimit   string `json:"cachingMemoryLimit,omitempty"`


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
This PR reads the RELATED_IMAGES environment variables ([link](https://github.com/eclipse-che/che-operator/blob/c9890991e831a8ca8f1db2a20ec066833778a52b/deploy/olm-catalog/stable/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml#L1029-L1142)) and sets images of interest to the image puller spec.

#### How the images are chosen:
Images that correspond to images from [codeready-image-puller.yaml](https://github.com/codeready-toolchain/sandbox-sre/blob/master/resources/sandbox-stage.gb17.p1.openshiftapps.com/configure/member/crw/codeready-image-puller.yaml#L13) are chosen. As a result the theia, theia-endpoint, plugin broker, and cpp/php/golang images are chosen. Currently, 9 images are being chosen.

### Screenshot/screencast of this PR
Thanks to this PR, when the Kubernetes image puller is installed with `--olm-channel=stable` through `chectl`, images of interest are accessible to the image puller. Therefore when the image puller is installed via the Eclipse Che operator, there is a 
`kubernetes-image-puller-*` pod with 9 containers (one container per image).
![image](https://user-images.githubusercontent.com/83611742/123483162-4e65a780-d5d4-11eb-8134-444088299192.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19657

### How to test this PR?
Image: [quay.io/dkwon17/che-operator:che-19657](quay.io/dkwon17/che-operator:che-19657)

1. Start crc and deploy 
```
$ crc start --memory=16192 --cpus=4
$ chectl server:deploy -n eclipse-che --olm-channel=stable -p openshift --che-operator-image=quay.io/dkwon17/che-operator:che-19657
```
2. Enable the kubernetes image puller from the `eclipse-che` `CheCluster` custom resource yaml file by setting `spec.imagePuller.enable` to true and save the changes.
![image](https://user-images.githubusercontent.com/83611742/123484126-dd26f400-d5d5-11eb-80eb-3e56aa07c089.png)

3. After a few minutes, there should be a new `kubernetes-image-puller-*` pod with 9/9 containers running, one container for each image.
![image](https://user-images.githubusercontent.com/83611742/123484794-f1b7bc00-d5d6-11eb-8af1-276c8dc37f42.png)



### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
