### PR TITLE
feat: Add DevWorkspace as a dependency in che operator

### DIFF
--- a/.ci/oci-stable-all-namespaces.sh
+++ b/.ci/oci-stable-all-namespaces.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright (c) 2019-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+
+export OPERATOR_REPO=$(dirname $(dirname $(readlink -f "$0")));
+source "${OPERATOR_REPO}"/.github/bin/common.sh
+source "${OPERATOR_REPO}"/.github/bin/oauth-provision.sh
+
+#Stop execution on any error
+trap "catchFinish" EXIT SIGINT
+
+overrideDefaults() {
+  export DEV_WORKSPACE_ENABLE="true"
+}
+
+runTests() {
+    # create namespace
+    oc create namespace eclipse-che || true
+
+    # Deploy Eclipse Che applying CR
+    applyOlmCR
+    waitEclipseCheDeployed "${LAST_PACKAGE_VERSION}"
+
+    sleep 10s
+    createWorkspaceDevWorkspaceCheOperator
+    waitAllPodsRunning ${DEVWORKSPACE_CHE_OPERATOR_TEST_NAMESPACE}
+}
+
+initDefaults
+overrideDefaults
+provisionOpenShiftOAuthUser
+initStableTemplates "openshift" "stable"
+runTests

--- a/.ci/oci-stable-all-namespaces.sh
+++ b/.ci/oci-stable-all-namespaces.sh
@@ -17,6 +17,14 @@ set -o pipefail
 # error on unset variables
 set -u
 
+################################ !!!   IMPORTANT   !!! ################################
+########### THIS JOB USE openshift ci operators workflows to run  #####################
+##########  More info about how it is configured can be found here: https://docs.ci.openshift.org/docs/how-tos/testing-operator-sdk-operators #############
+######### Script which install the given bundles from stable-all-namespace https://steps.ci.openshift.org/reference/optional-operators-subscribe ##########
+######## !!! Related PR in openshift CI is: https://github.com/openshift/release/pull/20610 ##############################################################
+#######################################################################################################################################################
+
+
 export OPERATOR_REPO=$(dirname $(dirname $(readlink -f "$0")));
 source "${OPERATOR_REPO}"/.github/bin/common.sh
 source "${OPERATOR_REPO}"/.github/bin/oauth-provision.sh
@@ -26,6 +34,7 @@ trap "catchFinish" EXIT SIGINT
 
 overrideDefaults() {
   export DEV_WORKSPACE_ENABLE="true"
+  export CHE_EXPOSURE_STRATEGY="single-host"
 }
 
 runTests() {

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,8 @@ bundle/nightly/eclipse-che-preview-kubernetes/generated
 bundle/nightly/eclipse-che-preview-openshift/generated
 bundle/stable/eclipse-che-preview-kubernetes/generated
 bundle/stable/eclipse-che-preview-openshift/generated
+bundle/stable-all-namespaces/eclipse-che-preview-kubernetes/generated
+bundle/stable-all-namespaces/eclipse-che-preview-openshift/generated
 
 testbin/setup-envtest.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -118,7 +118,6 @@ bundle/nightly/eclipse-che-preview-kubernetes/generated
 bundle/nightly/eclipse-che-preview-openshift/generated
 bundle/stable/eclipse-che-preview-kubernetes/generated
 bundle/stable/eclipse-che-preview-openshift/generated
-bundle/stable-all-namespaces/eclipse-che-preview-kubernetes/generated
 bundle/stable-all-namespaces/eclipse-che-preview-openshift/generated
 
 testbin/setup-envtest.sh

--- a/README.md
+++ b/README.md
@@ -133,8 +133,29 @@ spec:
 
 5. Deploy Che operator:
 
+
 ```bash
 $ chectl server:deploy --installer=olm --platform=<CHECTL_SUPPORTED_PLATFORM> --catalog-source-yaml <PATH_TO_CUSTOM_CATALOG_SOURCE_YAML> --olm-channel=nightly --package-manifest-name=eclipse-che-preview-<openshift|kubernetes>
+```
+
+### Deploy stable Che operator in Cluster Wide Availability
+
+Eclipse Che introduce a new channel which install Eclipse Che in AllNamespace mode with Devworkspace Operator like a OLM dependency.
+More info about DevWorkspace Operator can be found [here](https://github.com/devfile/devworkspace-operator).
+
+Before installing Eclipse Che using channel `stable-all-namespaces` we need to consider the following:
+
+* It is not possible to have Eclipse Che installed in single Namespace (currently the default one) and then try to install Che in All Namespace mode using the new channel stable-all-namespaces.
+* To update to stable-all-namespaces channel you need first to remove all subscriptions created for che installed from nightly or stable
+channels. IMPORTANT: Removing subscriptions doesn’t mean Eclipse Che operands(che-server, keycloak or roles) will be removed from the cluster.
+* DevWorkspace engine will be by default enabled in the new channel.
+* In case if you have already installed Che with devWorkspace enabled from channels nightly or stable you need to uninstall DevWorkspace completely from the cluster and then install the Che Operator using stable-all-namespaces channel.
+* `stable-all-namespaces` channel is supported only in openshift.
+
+If the Openshift Cluster already have all these considerations done you can proceed to install the Eclipse Che using stable-all-namespaces channel from OperatorHub or using the new channel you need to perform next chectl command:
+
+```bash
+chectl server:deploy --installer=olm --platform=openshift  --olm-channel=stable-all-namespaces
 ```
 
 ### Deploy Che operator using operator-sdk

--- a/README.md
+++ b/README.md
@@ -140,19 +140,19 @@ $ chectl server:deploy --installer=olm --platform=<CHECTL_SUPPORTED_PLATFORM> --
 
 ### Deploy stable Che operator in Cluster Wide Availability
 
-Eclipse Che introduce a new channel which install Eclipse Che in AllNamespace mode with Devworkspace Operator like a OLM dependency.
+Eclipse Che introduced a new channel which installs Eclipse Che in AllNamespace mode with Devworkspace Operator like an OLM dependency.
 More info about DevWorkspace Operator can be found [here](https://github.com/devfile/devworkspace-operator).
 
 Before installing Eclipse Che using channel `stable-all-namespaces` we need to consider the following:
 
 * It is not possible to have Eclipse Che installed in single Namespace (currently the default one) and then try to install Che in All Namespace mode using the new channel stable-all-namespaces.
-* To update to stable-all-namespaces channel you need first to remove all subscriptions created for che installed from nightly or stable
+* To update to stable-all-namespaces channel you need first to remove all subscriptions created for Che installed from nightly or stable
 channels. IMPORTANT: Removing subscriptions doesn’t mean Eclipse Che operands(che-server, keycloak or roles) will be removed from the cluster.
 * DevWorkspace engine will be by default enabled in the new channel.
 * In case if you have already installed Che with DevWorkspace engine enabled from channels nightly or stable you need to remove all DevWorkspace resources from the cluster following the next [scripts](https://github.com/devfile/devworkspace-operator/blob/main/build/make/deploy.mk#L77).
-* `stable-all-namespaces` channel is supported only in openshift.
+* `stable-all-namespaces` channel is supported only in OpenShift.
 
-If the Openshift Cluster already have all these considerations done you can proceed to install the Eclipse Che using stable-all-namespaces channel from OperatorHub or using the new channel you need to perform next chectl command:
+If the OpenShift Cluster already have all these considerations done you can proceed to install the Eclipse Che using stable-all-namespaces channel from OperatorHub or using the new channel you need to perform the following chectl command:
 
 ```bash
 chectl server:deploy --installer=olm --platform=openshift --olm-channel=stable-all-namespaces

--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ Before installing Eclipse Che using channel `stable-all-namespaces` we need to c
 * To update to stable-all-namespaces channel you need first to remove all subscriptions created for che installed from nightly or stable
 channels. IMPORTANT: Removing subscriptions doesn’t mean Eclipse Che operands(che-server, keycloak or roles) will be removed from the cluster.
 * DevWorkspace engine will be by default enabled in the new channel.
-* In case if you have already installed Che with devWorkspace enabled from channels nightly or stable you need to uninstall DevWorkspace completely from the cluster and then install the Che Operator using stable-all-namespaces channel.
+* In case if you have already installed Che with DevWorkspace engine enabled from channels nightly or stable you need to remove all DevWorkspace resources from the cluster following the next [scripts](https://github.com/devfile/devworkspace-operator/blob/main/build/make/deploy.mk#L77).
 * `stable-all-namespaces` channel is supported only in openshift.
 
 If the Openshift Cluster already have all these considerations done you can proceed to install the Eclipse Che using stable-all-namespaces channel from OperatorHub or using the new channel you need to perform next chectl command:
 
 ```bash
-chectl server:deploy --installer=olm --platform=openshift  --olm-channel=stable-all-namespaces
+chectl server:deploy --installer=olm --platform=openshift --olm-channel=stable-all-namespaces
 ```
 
 ### Deploy Che operator using operator-sdk

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/bundle.Dockerfile
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/bundle.Dockerfile
@@ -1,0 +1,21 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=eclipse-che-preview-openshift
+LABEL operators.operatorframework.io.bundle.channels.v1=stable-all-namespaces
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable-all-namespaces
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.7.1+git
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
+COPY manifests /manifests/
+COPY metadata /metadata/
+COPY tests/scorecard /tests/scorecard/

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
               "externalDb": false
             },
             "devWorkspace": {
-              "enable": false
+              "enable": true
             },
             "metrics": {
               "enable": true
@@ -60,7 +60,6 @@ metadata:
               "serverExposureStrategy": "",
               "serverTrustStoreConfigMapName": "",
               "tlsSupport": true,
-              "useInternalClusterSVCNames": true,
               "workspaceNamespaceDefault": "<username>-che"
             },
             "storage": {
@@ -74,13 +73,15 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    categories: Developer Tools, OpenShift Optional
+    categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator@sha256:4bb9f5859f2094d13c42b27f3aa41daac750725f611690aa083a265b3f760a16
-    createdAt: "2021-07-21T11:59:56Z"
+    createdAt: "2021-07-26T13:09:55Z"
     description: A Kube-native development solution that delivers portable and collaborative
-      developer workspaces in OpenShift.
-    operatorframework.io/suggested-namespace: eclipse-che
+      developer workspaces.
+    operatorframework.io/suggested-namespace: openshift-operators
+    operators.operatorframework.io/builder: operator-sdk-v1.6.1+git
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
   name: eclipse-che-preview-openshift.v7.33.2-all-namespaces
@@ -89,29 +90,28 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: The `CheBackupServerConfiguration` custom resource allows defining
-          and managing Eclipse Che Backup Server Configurations
-        displayName: Eclipse Che Cluster Backup Server Configuration
+      - displayName: Eclipse Che Cluster Backup Server Configuration
         kind: CheBackupServerConfiguration
         name: chebackupserverconfigurations.org.eclipse.che
         version: v1
-      - description: The `CheClusterBackup` custom resource allows defining and managing
-          Eclipse Che backup
-        displayName: Eclipse Che Cluster Backup
+      - displayName: Eclipse Che Cluster Backup
         kind: CheClusterBackup
         name: checlusterbackups.org.eclipse.che
         version: v1
-      - description: The `CheClusterRestore` custom resource allows defining and managing
-          Eclipse Che restore
-        displayName: Eclipse Che Cluster Restore
-        kind: CheClusterRestore
+      - kind: CheClusterRestore
         name: checlusterrestores.org.eclipse.che
         version: v1
-      - description: The `CheCluster` custom resource allows defining and managing
-          a Che server installation
-        displayName: Eclipse Che Cluster
+      - displayName: Eclipse Che Cluster
         kind: CheCluster
         name: checlusters.org.eclipse.che
+        specDescriptors:
+          - description: Deploys the DevWorkspace Operator in the cluster. Does nothing
+              when a matching version of the Operator is already installed. Fails
+              when a non-matching version of the Operator is already installed.
+            displayName: Enable Dev Workspace operator
+            path: devWorkspace.enable
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         statusDescriptors:
           - description: Status of a Che installation. Can be `Available`, `Unavailable`,
               or `Available, Rolling Update in Progress`.
@@ -168,98 +168,112 @@ spec:
             displayName: Reason
             path: reason
             x-descriptors:
-              - urn:alm:descriptor:io.kubernetes.phase:reason
               - urn:alm:descriptor:text
         version: v1
   description: |
-    A collaborative Kubernetes-native development solution that delivers OpenShift workspaces and in-browser IDE for rapid cloud application development.
-    This operator installs PostgreSQL, Keycloak, and the Eclipse Che server, as well as configures all three services.
+    A collaborative Kubernetes-native development solution that delivers Kubernetes workspaces and in-browser IDE for rapid cloud application development.
+    This operator installs PostgreSQL, Keycloak, Registries and the Eclipse Che server, as well as configures all these services.
+    ## Prerequisites
+    - Operator Lifecycle Manager (OLM) needs to be installed.
+    - Kubernetes Platform. For OpenShift, the installation is directly made from OperatorHub UI in the admin console.
+
+    OLM installation can be checked by running the command:
+    ```
+    $ kubectl get pods --all-namespaces | grep olm
+    olm             catalog-operator-7b8cd7f8bf-2v7zj                       1/1     Running   0          10m
+    olm             olm-operator-5c5c798cd5-s6ll5                           1/1     Running   0          10m
+    olm             olm-operators-fm5wc                                     1/1     Running   0          10m
+    olm             operatorhubio-catalog-d78km                             1/1     Running   0          10m
+    olm             packageserver-5c5f64947b-trghp                          1/1     Running   0          9m56s
+    olm             packageserver-5c5f64947b-zqvxg                          1/1     Running   0          9m56s
+    ```
 
     ## How to Install
+    Install `Eclipse Che Operator` by following instructions in top right button `Install`.
 
-    Press the **Install** button, choose the upgrade strategy, and wait for the **Installed** Operator status.
-
-    When the operator is installed, create a new CR of Kind CheCluster (click the **Create New** button).
-    The CR spec contains all defaults (see below).
-
-    You can start using Eclipse Che when the CR status is set to **Available**, and you see a URL to Eclipse Che.
-
-    ## Defaults
-
-    By default, the operator deploys Eclipse Che with:
-
-    * Bundled PostgreSQL and Keycloak
-
-    * Per-Workspace PVC strategy
-
-    * Auto-generated passwords
-
-    * TLS mode (secure routes)
-
-    * Regular login extended with OpenShift OAuth authentication
-
-    ## Installation Options
-
-    Eclipse Che operator installation options include:
-
-    * Connection to external database and Keycloak
-
-    * Configuration of default passwords and object names
-
-    * PVC strategy (once shared PVC for all workspaces, PVC per workspace, or PVC per volume)
-
-    * Authentication options
-
-    ### External Database and Keycloak
-
-    To instruct the operator to skip deploying PostgreSQL and Keycloak and connect to an existing DB and Keycloak instead:
-
-    * set respective fields to `true` in a custom resource spec
-
-    * provide the operator with connection and authentication details:
-
-
-
-      `externalDb: true`
-
-
-      `chePostgresHostname: 'yourPostgresHost'`
-
-
-      `chePostgresPort: '5432'`
-
-
-      `chePostgresUser: 'myuser'`
-
-
-      `chePostgresPassword: 'mypass'`
-
-
-      `chePostgresDb: 'mydb'`
-
-
-      `externalIdentityProvider: true`
-
-
-      `identityProviderURL: 'https://my-keycloak.com'`
-
-
-      `identityProviderRealm: 'myrealm'`
-
-
-      `identityProviderClientId: 'myClient'`
-
-
-    #### Self-signed Certificates
-
-    Eclipse Che uses self-signed certificates by default.
-
-    You can also manually create a secret:
-
-
+    A new pod che-operator is created in `my-eclipse-che` namespace
 
     ```
-    oc create secret generic self-signed-certificate  --from-file=/path/to/certificate/ca.crt -n=$codeReadyNamespace
+    $ kubectl get pods --all-namespaces | grep my-eclipse-che
+    my-eclipse-che   che-operator-554c564476-fl98z                           1/1     Running   0          13s
+    ```
+
+    The operator is now providing new Custom Resources Definitions: `checluster.org.eclipse.che`
+
+    Create a new Eclipse Che instance by creating a new CheCluster resource:
+
+    On the bottom of this page, there is a section `Custom Resource Definitions` with `Eclipse Che Cluster` name.
+
+    Click on `View YAML Example` *Link* and copy the content to a new file named `my-eclipse-che.yaml`
+    **Important!** Make sure you provide **K8s.ingressDomain** which is a global ingress domain of your k8s cluster, for example, `gcp.my-ide.cloud`
+    Create the new CheCluster by creating the resource in the `my-eclipse-che` namespace :
+    ```
+    $ kubectl create -f my-eclipse-che.yaml -n my-eclipse-che
+    ```
+    ***important:*** The operator is only tracking resources in its own namespace. If CheCluster is not created in this namespace it's ignored.
+    The operator will now create pods for Eclipse Che. The deployment status can be tracked by looking at the Operator logs by using the command:
+    ```
+    $ kubectl logs -n my-eclipse-che che-operator-554c564476-fl98z
+    ```
+    ***important:*** pod name is different on each installation
+
+    When all Eclipse Che containers are running, the Eclipse Che URL is printed
+
+
+    Eclipse Che URL can be tracked by searching for available trace:
+    ```
+    $ kubectl logs -f -n my-eclipse-che che-operator-7b6b4bcb9c-m4m2m | grep "Eclipse Che is now available"
+    time="2019-08-01T13:31:05Z" level=info msg="Eclipse Che is now available at: http://che-my-eclipse-che.gcp.my-ide.cloud"
+    ```
+    When Eclipse Che is ready, the Eclipse Che URL is displayed in CheCluster resource in `status` section
+    ```
+    $ kubectl describe checluster/eclipse-che -n my-eclipse-che
+    ```
+
+    ```
+    Status:
+      Che Cluster Running:           Available
+      Che URL:                       http://che-my-eclipse-che.gcp.my-ide.cloud
+      Che Version:                   7.26.0
+      ...
+    ```
+
+    By opening this URL in a web browser, Eclipse Che is ready to use.
+    ## Defaults
+    By default, the operator deploys Eclipse Che with:
+    * Bundled PostgreSQL and Keycloak
+    * Common PVC strategy
+    * Auto-generated passwords
+    * TLS mode (secure ingresses)
+    ## Installation Options
+    Eclipse Che operator installation options include:
+    * Connection to external database and Keycloak
+    * Configuration of default passwords and object names
+    * PVC strategy (once shared PVC for all workspaces, PVC per workspace, or PVC per volume)
+    * Authentication options
+    ### External Database and Keycloak
+    To instruct the operator to skip deploying PostgreSQL and Keycloak and connect to an existing DB and Keycloak instead:
+    * set respective fields to `true` in a custom resource spec
+    * provide the operator with connection and authentication details:
+      ```
+      externalDb: true
+      chePostgresHostname: 'yourPostgresHost'
+      chePostgresPort: '5432'
+      chePostgresUser: 'myuser'
+      chePostgresPassword: 'mypass'
+      chePostgresDb: 'mydb'
+      externalIdentityProvider: true
+      identityProviderURL: 'https://my-keycloak.com'
+      identityProviderRealm: 'myrealm'
+      identityProviderClientId: 'myClient'
+      ```
+    #### Self-signed Certificates and TLS Secrets
+
+    Eclipse Che uses self-signed certificates by default, as TLS mode is on by default.
+
+    To provide the name of the tls secret that will be used for Eclipse Che and workspaces ingresses:
+    ```
+    tlsSecretName: 'my-ingress-tls-secret'
     ```
   displayName: Eclipse Che
   icon:
@@ -269,6 +283,12 @@ spec:
     spec:
       clusterPermissions:
         - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - get
             - apiGroups:
                 - oauth.openshift.io
               resources:
@@ -352,6 +372,7 @@ spec:
               verbs:
                 - get
                 - create
+                - update
                 - delete
             - apiGroups:
                 - authorization.openshift.io
@@ -369,6 +390,7 @@ spec:
               verbs:
                 - get
                 - create
+                - update
                 - delete
             - apiGroups:
                 - rbac.authorization.k8s.io
@@ -385,6 +407,7 @@ spec:
                 - checlusters
                 - checlusters/status
                 - checlusters/finalizers
+                - checlusters/status
               verbs:
                 - '*'
             - apiGroups:
@@ -993,8 +1016,10 @@ spec:
                   app.kubernetes.io/name: che
               spec:
                 containers:
-                  - command:
-                      - /usr/local/bin/che-operator
+                  - args:
+                      - --leader-elect
+                    command:
+                      - /manager
                     env:
                       - name: WATCH_NAMESPACE
                         valueFrom:
@@ -1030,6 +1055,8 @@ spec:
                         value: quay.io/eclipse/che-jwtproxy@sha256:881d1c91e7f5840314f25104ef5c0acee59ed484a5f9ef39daf3008725ea1033
                       - name: RELATED_IMAGE_single_host_gateway
                         value: quay.io/eclipse/che--traefik@sha256:6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
+                      - name: RELATED_IMAGE_single_host_gateway_native_user_mode
+                        value: quay.io/eclipse/che--traefik@sha256:df90799aaca1ad6fb9e06d311140035d2a0c2295a4f8f508f6b55ee056bb677e
                       - name: RELATED_IMAGE_single_host_gateway_config_sidecar
                         value: quay.io/che-incubator/configbump@sha256:175ff2ba1bd74429de192c0a9facf39da5699c6da9f151bd461b3dc8624dd532
                       - name: RELATED_IMAGE_devworkspace_che_operator
@@ -1039,7 +1066,7 @@ spec:
                       - name: RELATED_IMAGE_internal_rest_backup_server
                         value: quay.io/eclipse/che-backup-server-rest@sha256:24983ce54474bbe87239f23773faeb59a5471a6a4b20e731518ad5738bfea6d7
                       - name: RELATED_IMAGE_gateway_authentication_sidecar
-                        value: quay.io/openshift/origin-oauth-proxy@sha256:82719931600d90a8c3eb26b1632cc99020bc12921fa6ad13c9d4929fe2d0f025
+                        value: quay.io/openshift/origin-oauth-proxy@sha256:4814e2dc961acf570a6318294ae0f253426a3d387c9b128a2522f416d0cf6e2f
                       - name: RELATED_IMAGE_gateway_authorization_sidecar
                         value: quay.io/openshift/origin-kube-rbac-proxy@sha256:fcce680899a37d6bdc621a58b6da0587d01cbb49a2d7b713e0d606dffc9f685a
                       - name: RELATED_IMAGE_gateway_header_sidecar
@@ -1062,118 +1089,118 @@ spec:
                         value: che-postgres-secret
                       - name: CHE_SERVER_TRUST_STORE_CONFIGMAP_NAME
                         value: ca-certs
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNDCMNSTEZJTHFTGKZJWMI4WKNDBHBRDIZJYGY4DCMZYGBRWKMRUGYZDMNZUGU4TOYJUHBRDQMLDGEZTCY3CMJTDANJVMRSDKZBQMMZQ____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNDCMNSTEZJTHFTGKZJWMI4WKNDBHBRDIZJYGY4DCMZYGBRWKMRUGYZDMNZUGU4TOYJUHBRDQMLDGEZTCY3CMJTDANJVMRSDKZBQMMZQU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:4bce2e39fee6b9e4a8b4e8681380ce2462674597a48b81c131cbbf055dd5d0c3
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUN3DMY3GMMBQMQZWMMTEMFTDANBWG42TMMJYMM2DAODFGA4GMMBRHFTDENLCHEYWKYZQHBSDENZZGA4TIZTEMRRDAMLGGU2TSNJQGJRA____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUN3DMY3GMMBQMQZWMMTEMFTDANBWG42TMMJYMM2DAODFGA4GMMBRHFTDENLCHEYWKYZQHBSDENZZGA4TIZTEMRRDAMLGGU2TSNJQGJRAU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:7cf6f00d3f2daf04675618c408e08f019f25b91ec08d279094fddb01f559502b
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUMTFGJRDGNLGMIZTGYZXHA3TGOBTGY4DIMRXMIYGEMJUME2DMNJZMI3GEMBTGEYTGZBYHA3TINZSMM2DINLBMU3DCNLEHE3TMMLEGM4Q____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUMTFGJRDGNLGMIZTGYZXHA3TGOBTGY4DIMRXMIYGEMJUME2DMNJZMI3GEMBTGEYTGZBYHA3TINZSMM2DINLBMU3DCNLEHE3TMMLEGM4QU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:2e2b35fb33c78738368427b0b14a4659b6b03113d887472c445ae615d9761d39
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUYLFGUYTENDFGMYTSODBMM3DSNZXMNQTSNZTMFQWMNBYHA2WCMJUMU4DAMDEGY2DOYZZGZQTEM3EGE2WCMTCGZRGCYTCMU4GMZLGGJQQ____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUYLFGUYTENDFGMYTSODBMM3DSNZXMNQTSNZTMFQWMNBYHA2WCMJUMU4DAMDEGY2DOYZZGZQTEM3EGE2WCMTCGZRGCYTCMU4GMZLGGJQQU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:ae5124e3198ac6977ca973aaf4885a14e800d647c96a23d15a2b6babbe8fef2a
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUMTFGQ4WMYLGMI4WCYJWGUYTSZTDGYZTAMJZME3TEYJUGUZDMMRSGJRDMOJQGVSWIMBRMRRTIOBUMMZWKOLGGUYTGMLBMUYDAYRVGQ3A____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUMTFGQ4WMYLGMI4WCYJWGUYTSZTDGYZTAMJZME3TEYJUGUZDMMRSGJRDMOJQGVSWIMBRMRRTIOBUMMZWKOLGGUYTGMLBMUYDAYRVGQ3AU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:2e49fafb9aa6519fc63019a72a4526222b6905ed01dc484c3e9f5131ae00b546
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNZZGE4WIOJWGVQTON3GGFSWGOJWHFSTANZTMEYWGYZYGY3DQNTGHEZGKOJZMZRTKM3BGBRDAYZYMQZGKYRRGNQWKYJWGFRTMMZUGY3Q____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNZZGE4WIOJWGVQTON3GGFSWGOJWHFSTANZTMEYWGYZYGY3DQNTGHEZGKOJZMZRTKM3BGBRDAYZYMQZGKYRRGNQWKYJWGFRTMMZUGY3QU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:7919d965a77f1ec969e073a1cc86686f92e99fc53a0b0c8d2eb13aea61c63467
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUZBVGY2WEOJYMYYTCMDFMZSTIMRUGZTGKMLGGI2WKZJWGJSDONDEG4YGMNDGHE4TSZJUGY3TSZJYMY3TAOBVMYYTQYRRG4YTCZRXGZSA____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUZBVGY2WEOJYMYYTCMDFMZSTIMRUGZTGKMLGGI2WKZJWGJSDONDEG4YGMNDGHE4TSZJUGY3TSZJYMY3TAOBVMYYTQYRRG4YTCZRXGZSAU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUOBWGE2WCMRZGQZTKYRQGI2TMYTGMZQWMOBVMFRDEY3GHEZTEN3CGA2TSZRRGRSWCYJWGYYTIMZUGZSGMZBVGFSTGYJWMRSDSZRQGQYQ____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUOBWGE2WCMRZGQZTKYRQGI2TMYTGMZQWMOBVMFRDEY3GHEZTEN3CGA2TSZRRGRSWCYJWGYYTIMZUGZSGMZBVGFSTGYJWMRSDSZRQGQYQU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:8615a29435b0256bffaf85ab2cf9327b059f14eaa6614346dfd51e3a6dd9f041
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNJVG4YDGYLFGVTGCZLCMVSGKZJVGZTGIY3FGM4DOOLGMEZDEOBRMNRTENRQGQ4DQZBYME2DQODGMY3TOZLEGNSDIMDGG43TQZDEMY3Q____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNJVG4YDGYLFGVTGCZLCMVSGKZJVGZTGIY3FGM4DOOLGMEZDEOBRMNRTENRQGQ4DQZBYME2DQODGMY3TOZLEGNSDIMDGG43TQZDEMY3QU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:55703ae5faebedee56fdce3879fa2281cc260488d8a488ff77ed3d40f778ddf7
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNRZHFQTQZTEME3DOYTBMJRWGMLGMFSWIY3GGJSTIYLCGIZGMNTDMYYGGZRWMFSDAODDGQYWGMRZGM4TQM3CHAYTMOJRMM2TSYLFGRSA____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNRZHFQTQZTEME3DOYTBMJRWGMLGMFSWIY3GGJSTIYLCGIZGMNTDMYYGGZRWMFSDAODDGQYWGMRZGM4TQM3CHAYTMOJRMM2TSYLFGRSAU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:699a8fda67babcc1faedcf2e4ab22f6cf0cf6ad08c41c293983b81691c59ae4d
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUOJXGRSGIMDBGVQWEN3FGA3TKZBXMQZTINDBMYZGKODFGJQTEZRYGBQTANRZMU4GCNLBGRRTSZTGMMZGCNJXMU2DEMLCGYZGCYJRG5QQ____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUOJXGRSGIMDBGVQWEN3FGA3TKZBXMQZTINDBMYZGKODFGJQTEZRYGBQTANRZMU4GCNLBGRRTSZTGMMZGCNJXMU2DEMLCGYZGCYJRG5QQU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:974dd0a5ab7e075d7d344af2e8e2a2f80a069e8a5a4c9ffc2a57e421b62aa17a
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUOBSHE3WMYRRG4ZTEZBYG5SDKNTBGBQWCNDDGY4TCMBVMU3WEY3GGRRDKMBQMU2DAYTCGE3DINBWMQ3DEOBWMMYDOYRYHA2GKYRXGNSA____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUOBSHE3WMYRRG4ZTEZBYG5SDKNTBGBQWCNDDGY4TCMBVMU3WEY3GGRRDKMBQMU2DAYTCGE3DINBWMQ3DEOBWMMYDOYRYHA2GKYRXGNSAU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:8297fb1732d87d56a0aa4c69105e7bcf4b500e40bb16446d6286c07b884eb73d
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUMBZGVRTENBQGU2TAMZTMUZDCOLEGVQTSZRWMZSTSOBTGVRDOOLDGVSDGNBRGZTDAZDGMJRDEMRYMQZDSNJXGEZWKOBRMQZDOYZWGYYQ____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUMBZGVRTENBQGU2TAMZTMUZDCOLEGVQTSZRWMZSTSOBTGVRDOOLDGVSDGNBRGZTDAZDGMJRDEMRYMQZDSNJXGEZWKOBRMQZDOYZWGYYQU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:095c24055033e219d5a9f6fe9835b79c5d3416f0dfbb228d295713e81d27c661
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNJWMU3TSNRQHA2TOOBYGZQTANLGMM2DKOLFMQ3GKNZTMEYGCMZYGZTDCNBVMEZDINZUMMZDEODDGJRDOY3DMI4TOYJRMQYTQYRUMRTA____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNJWMU3TSNRQHA2TOOBYGZQTANLGMM2DKOLFMQ3GKNZTMEYGCMZYGZTDCNBVMEZDINZUMMZDEODDGJRDOY3DMI4TOYJRMQYTQYRUMRTAU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:56e7960857886a05fc459ed6e73a0a386f145a2474c228c2b7ccb97a1d18b4df
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUZDCHA3GGOJSGQYTQYRZMY2DAYRSGY2TIYRYMZRTINZTGA3TGNJWHFSTAZDDHBQTAMLEG5QWIYZTGFRTSOJSGVSTKNBWHFSDEYRRGE2A____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUZDCHA3GGOJSGQYTQYRZMY2DAYRSGY2TIYRYMZRTINZTGA3TGNJWHFSTAZDDHBQTAMLEG5QWIYZTGFRTSOJSGVSTKNBWHFSDEYRRGE2AU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:db86c92418b9f40b2654b8fc473073569e0dc8a01d7adc31c9925e5469d2b114
-                      - name: RELATED_IMAGE_mta_vscode_extension_plugin_registry_image_IBZWQYJSGU3DUNBVGEZWIMZYGIZDAYZWGVRGINJUHE2DIOBWME4WIMBRG44TEODFHBTDCZRVMUYWCMRVMU3TMYZUGFSDGYRRGI4TOM3FMYYDQODCMI4A____
+                      - name: RELATED_IMAGE_mta_vscode_extension_plugin_registry_image_IBZWQYJSGU3DUNBVGEZWIMZYGIZDAYZWGVRGINJUHE2DIOBWME4WIMBRG44TEODFHBTDCZRVMUYWCMRVMU3TMYZUGFSDGYRRGI4TOM3FMYYDQODCMI4AU___
                         value: quay.io/windupeng/mta-vscode-extension@sha256:4513d38220c65bd5494486a9d017928e8f1f5e1a25e76c41d3b12973ef088bb8
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNJQGJQWEY3GGY2TSOLGMRQWIYLCMVTDEOBZMRRWCZDDGVRTGMTDME3DEMTGMEYDEYRXGNQTOMTCGEYTGY3BGFSTKZJVMIYTOOJTG42Q____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNJQGJQWEY3GGY2TSOLGMRQWIYLCMVTDEOBZMRRWCZDDGVRTGMTDME3DEMTGMEYDEYRXGNQTOMTCGEYTGY3BGFSTKZJVMIYTOOJTG42QU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:502abcf6599fdadabef289dcadc5c32ca622fa02b73a72b113ca1e5e5b179375
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUZRTHE4GKM3GMZSDKMRQGBRTKNTCMY2TMYJWMY3WMOLFHBSGENDBMEZWMNRTHFQTMMJSGU4DKMDGGE3DSNBRGQ2TEOBSGYYGIY3FHBQQ____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUZRTHE4GKM3GMZSDKMRQGBRTKNTCMY2TMYJWMY3WMOLFHBSGENDBMEZWMNRTHFQTMMJSGU4DKMDGGE3DSNBRGQ2TEOBSGYYGIY3FHBQQU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:f398e3ffd5200c56bf56a6f7f9e8db4aa3f639a6125850f169414528260dce8a
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUZJTG42GKYZTGY3TINBXMFTGKYJZMIYTEZRVME4GMNRWHEYGCNTGHE4TGNJSGY2DAODBGM3TGMLGGUZDEYJVGNSTKZBQMJTGGMRYG5TA____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUZJTG42GKYZTGY3TINBXMFTGKYJZMIYTEZRVME4GMNRWHEYGCNTGHE4TGNJSGY2DAODBGM3TGMLGGUZDEYJVGNSTKZBQMJTGGMRYG5TAU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:e374ec367447afea9b12f5a8f6690a6f993526408a3731f522a53e5d0bfc287f
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUMTDMI2GMNZQMVSGEY3EMFRDGYRSG44WIYLFGUZWENTBG42TGZBWGNTGKZJQGNRGGYLFGNSDEYJTHA2WKMRUMYZDKZJWHE2WGMBTMRTA____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUMTDMI2GMNZQMVSGEY3EMFRDGYRSG44WIYLFGUZWENTBG42TGZBWGNTGKZJQGNRGGYLFGNSDEYJTHA2WKMRUMYZDKZJWHE2WGMBTMRTAU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:2cb4f70edbcdab3b279dae53b6a753d63fee03bcae3d2a385e24f25e695c03df
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNDGMRRDANBQGI3GGYTFMRSGEZTFGUZTCOBUMFTGGZBWMZRTKY3CGYYTGMTBGIZGEZJVHAYTAYRRGNSDGODBGEZDKYLGMQYDQMZSGIYQ____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNDGMRRDANBQGI3GGYTFMRSGEZTFGUZTCOBUMFTGGZBWMZRTKY3CGYYTGMTBGIZGEZJVHAYTAYRRGNSDGODBGEZDKYLGMQYDQMZSGIYQU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:4fdb04026cbeddbfe53184afcd6fc5cb6132a22be5810b13d38a125afd083221
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNBZGFRTMMTBGNQWGNZXGVSDKNBSGZSDOMTBGU4WCYZRHBRGIZBVGBTDKZRVMQ3DCZBQG5TGEZTCGM2GKMDDMQ3WMZLEGNSDIZDBGIYQ____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNBZGFRTMMTBGNQWGNZXGVSDKNBSGZSDOMTBGU4WCYZRHBRGIZBVGBTDKZRVMQ3DCZBQG5TGEZTCGM2GKMDDMQ3WMZLEGNSDIZDBGIYQU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:491c62a3ac775d5426d72a59ac18bdd50f5f5d61d07fbfb34e0cd7fed3d4da21
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNJZG5QTGMDDHFRTGZTDG5SGEYTGMI4WKMBYMIYWEYRSGE3TSZBYMVRDANRSMFSDCNBYGQ4DAZTGGMZDIOBZMI2GMMBRMVRTMNZVMY2A____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNJZG5QTGMDDHFRTGZTDG5SGEYTGMI4WKMBYMIYWEYRSGE3TSZBYMVRDANRSMFSDCNBYGQ4DAZTGGMZDIOBZMI2GMMBRMVRTMNZVMY2AU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:597a30c9c3fc7dbbfb9e08b1bb2179d8eb062ad148480ff32489b4f01ec675f4
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNTEGBRTINBQME3WIYZWGQ4DQMJWMZRWINBYHA2WEOLDMM4DKZRQMVRDAZRTHEYTMNJZMJRDSZTDHBQTSMJSGMYDONLCMVQTONJRGY2Q____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNTEGBRTINBQME3WIYZWGQ4DQMJWMZRWINBYHA2WEOLDMM4DKZRQMVRDAZRTHEYTMNJZMJRDSZTDHBQTSMJSGMYDONLCMVQTONJRGY2QU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:6d0c440a7dc648816fcd4885b9cc85f0eb0f391659bb9fc8a9123075bea75165
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUOLDGU3WINTGMM4DCYJZHE3WEMDEGZSTSYLDMMZTEZLCGUZGGOLEGIYGIMRWGUZTANBYMRRGCZJQMVSTSYJZME3GKODEMNSWKYZZMQZA____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUOLDGU3WINTGMM4DCYJZHE3WEMDEGZSTSYLDMMZTEZLCGUZGGOLEGIYGIMRWGUZTANBYMRRGCZJQMVSTSYJZME3GKODEMNSWKYZZMQZAU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:9c57d6fc81a997b0d6e9acc32eb52c9d20d2653048dbae0ee9a9a6e8dceec9d2
-                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUYTCGQYDIZTGMFQTCMRVGY2WEZLCGEZGENDDMQ4DCNRQMNTGCM3GMYZWKZRTMJSTIMRQGQZTAYJWGU3DEZRRMZSTIOBWGM4WGYTGGFTA____
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUYTCGQYDIZTGMFQTCMRVGY2WEZLCGEZGENDDMQ4DCNRQMNTGCM3GMYZWKZRTMJSTIMRQGQZTAYJWGU3DEZRRMZSTIOBWGM4WGYTGGFTAU___
                         value: quay.io/eclipse/che-plugin-sidecar@sha256:bb404ffaa12565beb12b4cd8160cfa3ff3ef3be420430a6562f1fe48639cbf1f
-                      - name: RELATED_IMAGE_che_theia_plugin_registry_image_IBZWQYJSGU3DUZBUMMYDGNBTGIZDOOJSMFTGEYZZG5STMN3BMEYWEZJYGQYTCNZZGI2TEMRVGBQTSNDBGNQWEYRTMVQTKYTBGIYWGZRQMJRDGMZWGM2A____
+                      - name: RELATED_IMAGE_che_theia_plugin_registry_image_IBZWQYJSGU3DUZBUMMYDGNBTGIZDOOJSMFTGEYZZG5STMN3BMEYWEZJYGQYTCNZZGI2TEMRVGBQTSNDBGNQWEYRTMVQTKYTBGIYWGZRQMJRDGMZWGM2AU___
                         value: quay.io/eclipse/che-theia@sha256:d4c034322792afbc97e67aa1be841179252250a94a3abb3ea5ba21cf0bb33634
-                      - name: RELATED_IMAGE_che_machine_exec_plugin_registry_image_IBZWQYJSGU3DUYRTGJTDMYTGME2DKNTEGFQTKNJVMM2DOMDDGRSDIZTGMEZWCMBQGBQTONRXMVTDINRSME2WCOBVHE2DCMLEHBQTEZDCG43DSMTBMFSQ____
+                      - name: RELATED_IMAGE_che_machine_exec_plugin_registry_image_IBZWQYJSGU3DUYRTGJTDMYTGME2DKNTEGFQTKNJVMM2DOMDDGRSDIZTGMEZWCMBQGBQTONRXMVTDINRSME2WCOBVHE2DCMLEHBQTEZDCG43DSMTBMFSQU___
                         value: quay.io/eclipse/che-machine-exec@sha256:b32f6bfa456d1a555c470c4d4ffa3a000a767ef462a5a859411d8a2db7692aae
-                      - name: RELATED_IMAGE_che_theia_endpoint_runtime_binary_plugin_registry_image_IBZWQYJSGU3DUZJTGAYTCNBWGU4GEZJVGM3WMYZVG44GKZTEMEYGKZDEGU3TMMDDGAZDIZTCGE2TSNRZGVQTIMZXMVTGEM3BMQ3TQZJWMJTDOYZWGE2Q____
+                      - name: RELATED_IMAGE_che_theia_endpoint_runtime_binary_plugin_registry_image_IBZWQYJSGU3DUZJTGAYTCNBWGU4GEZJVGM3WMYZVG44GKZTEMEYGKZDEGU3TMMDDGAZDIZTCGE2TSNRZGVQTIMZXMVTGEM3BMQ3TQZJWMJTDOYZWGE2QU___
                         value: quay.io/eclipse/che-theia-endpoint-runtime-binary@sha256:e30114658be537fc578efda0edd5760c024fb159695a437efb3ad78e6bf7c615
-                      - name: RELATED_IMAGE_che_editor_jupyter_plugin_registry_image_IBZWQYJSGU3DUOBTGQZTSYLFHFSWIY3BMEZWCOJXGUZTMNZUGIZTCNLBG44TCMTGHEZWKNBZHFTDIOJYGQ3WIYJQHE2GGNBYGAYDGMLFMFSTIYTBGQ3Q____
+                      - name: RELATED_IMAGE_che_editor_jupyter_plugin_registry_image_IBZWQYJSGU3DUOBTGQZTSYLFHFSWIY3BMEZWCOJXGUZTMNZUGIZTCNLBG44TCMTGHEZWKNBZHFTDIOJYGQ3WIYJQHE2GGNBYGAYDGMLFMFSTIYTBGQ3QU___
                         value: index.docker.io/ksmster/che-editor-jupyter@sha256:83439ae9edcaa3a97536742315a7912f93e499f49847da094c480031eae4ba47
-                      - name: RELATED_IMAGE_dirigible_openshift_plugin_registry_image_IBZWQYJSGU3DUMZTGY2TMMZVMQYWKMBUGAZTMOJXMRSWCMBWG42GEYTCMRRTONBZMM2GEZJSMRRDEOJYGE4GCOJTMI4GKMLFGUZWGM3DGUYTINBRGEZQ____
+                      - name: RELATED_IMAGE_dirigible_openshift_plugin_registry_image_IBZWQYJSGU3DUMZTGY2TMMZVMQYWKMBUGAZTMOJXMRSWCMBWG42GEYTCMRRTONBZMM2GEZJSMRRDEOJYGE4GCOJTMI4GKMLFGUZWGM3DGUYTINBRGEZQU___
                         value: index.docker.io/dirigiblelabs/dirigible-openshift@sha256:3365635d1e0403697dea0674bbbdc749c4be2db29818a93b8e1e53c3c5144113
-                      - name: RELATED_IMAGE_che_editor_intellij_community_plugin_registry_image_IBZWQYJSGU3DUMRZGAZDKZDCHA2TSMRWHBTDKZDDMYZDCYTBGZSWENDFGI4DINZUGRRDKM3DHEZGINTEGIZTKMJUMU2TMNLBGAZDCMJWGA3GMNRYGYZQ____
+                      - name: RELATED_IMAGE_che_editor_intellij_community_plugin_registry_image_IBZWQYJSGU3DUMRZGAZDKZDCHA2TSMRWHBTDKZDDMYZDCYTBGZSWENDFGI4DINZUGRRDKM3DHEZGINTEGIZTKMJUMU2TMNLBGAZDCMJWGA3GMNRYGYZQU___
                         value: quay.io/che-incubator/che-editor-intellij-community@sha256:29025db859268f5dcf21ba6eb4e284744b53c92d6d23514e565a0211606f6863
-                      - name: RELATED_IMAGE_eclipse_broadway_plugin_registry_image_IBZWQYJSGU3DUNJXMM4DEY3EHAYDMYJVGZTDMOLBME4DMNRTMY3DQNBQGVSDANZXHBRDMMRYMEZDSYJWGRTGEMJWHA4DCYRRGFRWKOLGGQ4DIZDEME3Q____
+                      - name: RELATED_IMAGE_eclipse_broadway_plugin_registry_image_IBZWQYJSGU3DUNJXMM4DEY3EHAYDMYJVGZTDMOLBME4DMNRTMY3DQNBQGVSDANZXHBRDMMRYMEZDSYJWGRTGEMJWHA4DCYRRGFRWKOLGGQ4DIZDEME3QU___
                         value: index.docker.io/wsskeleton/eclipse-broadway@sha256:57c82cd806a56f69aa8663f68405d0778b628a29a64fb16881b11ce9f484dda7
-                      - name: RELATED_IMAGE_code_server_plugin_registry_image_IBZWQYJSGU3DUZLGGA3TEOBRGAYDIOJQHFRGEMTDGIZDQNBSGJSGMMTFHE4WCNLCME2WKNBVGBTGGZJXGU2DMYRYMZQTCOBWHA2TEZRSGNRGMNRXGUYQ____
+                      - name: RELATED_IMAGE_code_server_plugin_registry_image_IBZWQYJSGU3DUZLGGA3TEOBRGAYDIOJQHFRGEMTDGIZDQNBSGJSGMMTFHE4WCNLCME2WKNBVGBTGGZJXGU2DMYRYMZQTCOBWHA2TEZRSGNRGMNRXGUYQU___
                         value: index.docker.io/codercom/code-server@sha256:ef07281004909bb2c228422df2e99a5ba5e450fce7546b8fa186852f23bf6751
-                      - name: RELATED_IMAGE_che_buildah_base_plugin_registry_image_IBZWQYJSGU3DUNBRG4ZDAM3EHA3DEOLFMRSDSMTGGE4DOYLGMQZWKYTCGNSDQZDDGI4DGMZYMQZTIOBQHFSWENZVMZTGGMTFGA4GCNBQGBTDQZBVGZRA____
+                      - name: RELATED_IMAGE_che_buildah_base_plugin_registry_image_IBZWQYJSGU3DUNBRG4ZDAM3EHA3DEOLFMRSDSMTGGE4DOYLGMQZWKYTCGNSDQZDDGI4DGMZYMQZTIOBQHFSWENZVMZTGGMTFGA4GCNBQGBTDQZBVGZRAU___
                         value: quay.io/eclipse/che-buildah-base@sha256:417203d8629edd92f187afd3ebb3d8dc28338d34809eb75ffc2e08a400f8d56b
-                      - name: RELATED_IMAGE_che_sidecar_workspace_data_sync_plugin_registry_image_IBZWQYJSGU3DUOBYMQYDCMRVHAZTOZBVME2TOY3CGI2GEYRTMVSDQMLFGZQTQZRUGEYTSYJVGA2DGYRXHEZDMYTEGJRGIMBRG4YTAOBVGRRTINDGGEYA____
+                      - name: RELATED_IMAGE_che_sidecar_workspace_data_sync_plugin_registry_image_IBZWQYJSGU3DUOBYMQYDCMRVHAZTOZBVME2TOY3CGI2GEYRTMVSDQMLFGZQTQZRUGEYTSYJVGA2DGYRXHEZDMYTEGJRGIMBRG4YTAOBVGRRTINDGGEYAU___
                         value: quay.io/eclipse/che-sidecar-workspace-data-sync@sha256:88d0125837d5a57cb24bb3ed81e6a8f4119a5043b7926bd2bd01710854c44f10
-                      - name: RELATED_IMAGE_che_buildkit_base_plugin_registry_image_IBZWQYJSGU3DUZLGMZQTSODEMQZGGZLEGMYGENJSGBRDENLBMZTGMMLBHA4DAZBRGIYWGZRWMIZWMODBMI2DEYJVGE2DSZLBMRQTINTCME3TSM3DMU4Q____
+                      - name: RELATED_IMAGE_che_buildkit_base_plugin_registry_image_IBZWQYJSGU3DUZLGMZQTSODEMQZGGZLEGMYGENJSGBRDENLBMZTGMMLBHA4DAZBRGIYWGZRWMIZWMODBMI2DEYJVGE2DSZLBMRQTINTCME3TSM3DMU4QU___
                         value: quay.io/eclipse/che-buildkit-base@sha256:effa98dd2ced30b520b25afff1a880d121cf6b3f8ab42a5149eada46ba793ce9
-                      - name: RELATED_IMAGE_che__centos__mongodb_36_centos7_devfile_registry_image_NRQXIZLTOQWWCOJRGVSGEN3CMVRWCOBXGE4TQZTDMQ3TQNRQGA4DMOJYHFTGKODBGMZDOYJRME2GMNRVGA4DAMRVMI3DIYLCGI4GMY3DG42DEM3CGI______
+                      - name: RELATED_IMAGE_che__centos__mongodb_36_centos7_devfile_registry_image_NRQXIZLTOQWWCOJRGVSGEN3CMVRWCOBXGE4TQZTDMQ3TQNRQGA4DMOJYHFTGKODBGMZDOYJRME2GMNRVGA4DAMRVMI3DIYLCGI4GMY3DG42DEM3CGIFA____
                         value: quay.io/eclipse/che--centos--mongodb-36-centos7@sha256:a915db7beca87198fcd7860086989fe8a327a1a4f6508025b64ab28fcc7423b2
-                      - name: RELATED_IMAGE_che__centos__mysql_57_centos7_devfile_registry_image_NRQXIZLTOQWWKMBYMVSTIZBUGNRDOMZVGY3DANZWHA2WENRZMJSGKNRTGM2WKMRXMNTDEMDDGAZDAZRTGQ2WENTDGZRTKOJUGAYDCOBTHA4DENZWGQ______
+                      - name: RELATED_IMAGE_che__centos__mysql_57_centos7_devfile_registry_image_NRQXIZLTOQWWKMBYMVSTIZBUGNRDOMZVGY3DANZWHA2WENRZMJSGKNRTGM2WKMRXMNTDEMDDGAZDAZRTGQ2WENTDGZRTKOJUGAYDCOBTHA4DENZWGQFA____
                         value: quay.io/eclipse/che--centos--mysql-57-centos7@sha256:e08ee4d43b7356607685b69bde6335e27cf20c020f345b6c6c59400183882764
-                      - name: RELATED_IMAGE_che_cpp_rhel7_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_cpp_rhel7_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-cpp-rhel7@sha256:1a570e20e7f9b9c46cfbab829838cca8e5082ab54a350b8b1947499128f0c4e6
-                      - name: RELATED_IMAGE_che_dotnet_2_2_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_dotnet_2_2_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-dotnet-2.2@sha256:0e7dac64a33f1f55eed9a5399ac257e0b895fcf5fb4379d3e9620f53e06f1505
-                      - name: RELATED_IMAGE_che_dotnet_3_1_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_dotnet_3_1_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-dotnet-3.1@sha256:f1c062b0db7e624f2e964e088ccaa9024d04bca04c5cc5a1dae3bdb760394206
-                      - name: RELATED_IMAGE_che_golang_1_14_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_golang_1_14_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-golang-1.14@sha256:f7cae5166c979ae1503478b96cc5d48a9a06aaabcc550a9d843e10a515630fa5
-                      - name: RELATED_IMAGE_che_java11_gradle_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_java11_gradle_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-java11-gradle@sha256:92ab2b6c9ac4fdcbd9db5705399b548a59533762e3c48c5c317432b30c36b454
-                      - name: RELATED_IMAGE_che_java11_maven_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_java11_maven_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-java11-maven@sha256:78c2225c0451272d463ad5d6e006ef9fab0086a9bcc0d7d359d9ebefeeff1a28
-                      - name: RELATED_IMAGE_che_java8_maven_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_java8_maven_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-java8-maven@sha256:2a1b7f4cfae15a6e44bd4729723c723f00e9dabaae98db7edb50aef5105ee690
-                      - name: RELATED_IMAGE_che_nodejs10_community_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_nodejs10_community_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-nodejs10-community@sha256:87800ae68d0624911408381b744742cff842f7479360ebae3b9fb65b8f326223
-                      - name: RELATED_IMAGE_che_nodejs10_ubi_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_nodejs10_ubi_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-nodejs10-ubi@sha256:61cd13dfbb4579f1d4ebd3b4fdfb2922ab35055eb9c590e27c888d8b491fdfdb
-                      - name: RELATED_IMAGE_che_nodejs12_community_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_nodejs12_community_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-nodejs12-community@sha256:a10407084cb0e418d4d303235463cd78081636c4691518f465284aeaac2bcf23
-                      - name: RELATED_IMAGE_che_nodejs8_centos_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_nodejs8_centos_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-nodejs8-centos@sha256:557d886c11e3840da9938e7f529f5119d6bdf91f25e40b0bb6af9411791fa3ca
-                      - name: RELATED_IMAGE_che_php_7_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_php_7_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-php-7@sha256:676cf5f744eb7f2404a37953ed28d7e840878277e73f02ff031f99ef37f90d07
-                      - name: RELATED_IMAGE_che_python_3_8_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_python_3_8_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-python-3.8@sha256:20ebf82e73785a0844b6511e2981da19a55410d3a6aa07a2dc0b3dcfb3838694
-                      - name: RELATED_IMAGE_che_quarkus_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_quarkus_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-quarkus@sha256:95c5f1587c7ce719ec8e64b90b69948ea04a57eb8f384c66b0561347e4cb83a2
-                      - name: RELATED_IMAGE_che_rust_1_39_devfile_registry_image_G4XDGMZOGI______
+                      - name: RELATED_IMAGE_che_rust_1_39_devfile_registry_image_G4XDGMZOGIFA____
                         value: quay.io/eclipse/che-rust-1.39@sha256:d033f2366e22214660561a0279f3ff55edc6cb60a57178c87022f09699a7b2e7
-                      - name: RELATED_IMAGE_ubi8_minimal_devfile_registry_image_HAXDG___
+                      - name: RELATED_IMAGE_ubi8_minimal_devfile_registry_image_HAXDGCQ_
                         value: registry.access.redhat.com/ubi8-minimal@sha256:2f6b88c037c0503da7704bccd3fc73cb76324101af39ad28f16460e7bce98324
-                      - name: RELATED_IMAGE_ubi_minimal_devfile_registry_image_
-                        value: registry.access.redhat.com/ubi8/ubi-minimal@sha256:b6b0c30bb747dfacee216e5ae2ad02adb18920d8f744c04f29354278e19df2a9
+                      - name: RELATED_IMAGE_ubi_minimal_devfile_registry_image_BI______
+                        value: registry.access.redhat.com/ubi8/ubi-minimal@sha256:d9b92ea78e76300968f5c9a4a04c2cf220a0bbfac667f77e5e7287692163d898
                     image: quay.io/eclipse/che-operator@sha256:4bb9f5859f2094d13c42b27f3aa41daac750725f611690aa083a265b3f760a16
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
@@ -1190,22 +1217,15 @@ spec:
                       - containerPort: 60000
                         name: metrics
                     readinessProbe:
-                      exec:
-                        command:
-                          - stat
-                          - /tmp/operator-sdk-ready
                       failureThreshold: 10
+                      httpGet:
+                        path: /readyz
+                        port: 6789
                       initialDelaySeconds: 5
                       periodSeconds: 10
                       successThreshold: 1
                       timeoutSeconds: 5
-                    resources:
-                      limits:
-                        cpu: 500m
-                        memory: 256Mi
-                      requests:
-                        cpu: 100m
-                        memory: 64Mi
+                    resources: {}
                     securityContext:
                       allowPrivilegeEscalation: false
                       capabilities:
@@ -1239,7 +1259,7 @@ spec:
                         value: quay.io/eclipse/che--traefik@sha256:6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
                       - name: RELATED_IMAGE_gateway_configurer
                         value: quay.io/che-incubator/configbump@sha256:175ff2ba1bd74429de192c0a9facf39da5699c6da9f151bd461b3dc8624dd532
-                    image: quay.io/che-incubator/devworkspace-che-operator@sha256:b01a7eae740850593a8f8a1fec8421c7ac7eef46eeacffb1ed635c68d384f2ca
+                    image: quay.io/che-incubator/devworkspace-che-operator@sha256:655f40624932918410f7c4e7b19f745744d0e13e49f571969930e38bdf6245eb
                     imagePullPolicy: IfNotPresent
                     name: devworkspace-che-operator
                     resources:
@@ -1404,18 +1424,50 @@ spec:
                 - events
               verbs:
                 - create
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
           serviceAccountName: che-operator
     strategy: deployment
   installModes:
-    - supported: true
-      type: OwnNamespace
-    - supported: true
-      type: SingleNamespace
-    - supported: true
-      type: MultiNamespace
     - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
       type: AllNamespaces
   keywords:
+    - eclipse che
     - workspaces
     - devtools
     - developer
@@ -1434,32 +1486,33 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
+  replaces: eclipse-che-preview-openshift.v7.33.2-all-namespaces
   version: 7.33.2-all-namespaces
   relatedImages:
     - name: che-operator-7.33.2
       image: quay.io/eclipse/che-operator@sha256:4bb9f5859f2094d13c42b27f3aa41daac750725f611690aa083a265b3f760a16
       # tag: quay.io/eclipse/che-operator:7.33.2
-    - name: devworkspace-che-operator-v7.33.2
-      image: quay.io/che-incubator/devworkspace-che-operator@sha256:b01a7eae740850593a8f8a1fec8421c7ac7eef46eeacffb1ed635c68d384f2ca
-      # tag: quay.io/che-incubator/devworkspace-che-operator:v7.33.2
+    - name: devworkspace-che-operator-ci
+      image: quay.io/che-incubator/devworkspace-che-operator@sha256:655f40624932918410f7c4e7b19f745744d0e13e49f571969930e38bdf6245eb
+      # tag: quay.io/che-incubator/devworkspace-che-operator:ci
     - name: configbump-0.1.4
       image: quay.io/che-incubator/configbump@sha256:175ff2ba1bd74429de192c0a9facf39da5699c6da9f151bd461b3dc8624dd532
       # tag: quay.io/che-incubator/configbump:0.1.4
+    - name: devworkspace-che-operator-v7.33.2
+      image: quay.io/che-incubator/devworkspace-che-operator@sha256:b01a7eae740850593a8f8a1fec8421c7ac7eef46eeacffb1ed635c68d384f2ca
+      # tag: quay.io/che-incubator/devworkspace-che-operator:v7.33.2
     - name: header-rewrite-proxy-latest
       image: quay.io/che-incubator/header-rewrite-proxy@sha256:bd7873b8feef35f218f54c6251ea224bea2c8bf202a328230019a0ba2941245d
       # tag: quay.io/che-incubator/header-rewrite-proxy:latest
     - name: devworkspace-controller-v0.7.2
       image: quay.io/devfile/devworkspace-controller@sha256:f17dad6df3f2f0f7b245e05677293bef1d35a17e0349002f9e47816de03c0cdd
       # tag: quay.io/devfile/devworkspace-controller:v0.7.2
-    - name: che--centos--postgresql-96-centos7-9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
-      image: quay.io/eclipse/che--centos--postgresql-96-centos7@sha256:b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
-      # tag: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
-    - name: che--traefik-v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
-      image: quay.io/eclipse/che--traefik@sha256:6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
-      # tag: quay.io/eclipse/che--traefik:v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
     - name: che-backup-server-rest-eeacd92
       image: quay.io/eclipse/che-backup-server-rest@sha256:24983ce54474bbe87239f23773faeb59a5471a6a4b20e731518ad5738bfea6d7
       # tag: quay.io/eclipse/che-backup-server-rest:eeacd92
+    - name: che--centos--postgresql-96-centos7-9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
+      image: quay.io/eclipse/che--centos--postgresql-96-centos7@sha256:b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
+      # tag: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
     - name: che-dashboard-7.33.2
       image: quay.io/eclipse/che-dashboard@sha256:ff44e57ddf7dbc76cca375979401539c3bd9a6a1db37d55f1c6b05e4d70f6ee1
       # tag: quay.io/eclipse/che-dashboard:7.33.2
@@ -1484,11 +1537,17 @@ spec:
     - name: che-server-7.33.2
       image: quay.io/eclipse/che-server@sha256:b4be065bff9c71b17804a0a8ede43982d2dc44bc555c4c8a90fd63e22b23f555
       # tag: quay.io/eclipse/che-server:7.33.2
+    - name: che--traefik-v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
+      image: quay.io/eclipse/che--traefik@sha256:6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
+      # tag: quay.io/eclipse/che--traefik:v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
+    - name: che--traefik-v2.5.0-rc2-df90799aaca1ad6fb9e06d311140035d2a0c2295a4f8f508f6b55ee056bb677e
+      image: quay.io/eclipse/che--traefik@sha256:df90799aaca1ad6fb9e06d311140035d2a0c2295a4f8f508f6b55ee056bb677e
+      # tag: quay.io/eclipse/che--traefik:v2.5.0-rc2-df90799aaca1ad6fb9e06d311140035d2a0c2295a4f8f508f6b55ee056bb677e
     - name: origin-kube-rbac-proxy-4.7
       image: quay.io/openshift/origin-kube-rbac-proxy@sha256:fcce680899a37d6bdc621a58b6da0587d01cbb49a2d7b713e0d606dffc9f685a
       # tag: quay.io/openshift/origin-kube-rbac-proxy:4.7
     - name: origin-oauth-proxy-4.7
-      image: quay.io/openshift/origin-oauth-proxy@sha256:82719931600d90a8c3eb26b1632cc99020bc12921fa6ad13c9d4929fe2d0f025
+      image: quay.io/openshift/origin-oauth-proxy@sha256:4814e2dc961acf570a6318294ae0f253426a3d387c9b128a2522f416d0cf6e2f
       # tag: quay.io/openshift/origin-oauth-proxy:4.7
     - name: ubi8-minimal-8.4-205
       image: registry.access.redhat.com/ubi8-minimal@sha256:b6b0c30bb747dfacee216e5ae2ad02adb18920d8f744c04f29354278e19df2a9
@@ -1659,5 +1718,5 @@ spec:
       image: registry.access.redhat.com/ubi8-minimal@sha256:2f6b88c037c0503da7704bccd3fc73cb76324101af39ad28f16460e7bce98324
       # tag: registry.access.redhat.com/ubi8-minimal:8.3
     - name: ubi-minimal-
-      image: registry.access.redhat.com/ubi8/ubi-minimal@sha256:b6b0c30bb747dfacee216e5ae2ad02adb18920d8f744c04f29354278e19df2a9
+      image: registry.access.redhat.com/ubi8/ubi-minimal@sha256:d9b92ea78e76300968f5c9a4a04c2cf220a0bbfac667f77e5e7287692163d898
       # tag: registry.access.redhat.com/ubi8/ubi-minimal

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -1,0 +1,1663 @@
+#
+#  Copyright (c) 2019-2021 Red Hat, Inc.
+#    This program and the accompanying materials are made
+#    available under the terms of the Eclipse Public License 2.0
+#    which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Contributors:
+#    Red Hat, Inc. - initial API and implementation
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "org.eclipse.che/v1",
+          "kind": "CheCluster",
+          "metadata": {
+            "name": "eclipse-che"
+          },
+          "spec": {
+            "auth": {
+              "externalIdentityProvider": false,
+              "identityProviderAdminUserName": "",
+              "identityProviderClientId": "",
+              "identityProviderPassword": "",
+              "identityProviderRealm": "",
+              "identityProviderURL": "",
+              "initialOpenShiftOAuthUser": true,
+              "oAuthClientName": "",
+              "oAuthSecret": ""
+            },
+            "database": {
+              "chePostgresDb": "",
+              "chePostgresHostName": "",
+              "chePostgresPassword": "",
+              "chePostgresPort": "",
+              "chePostgresUser": "",
+              "externalDb": false
+            },
+            "devWorkspace": {
+              "enable": false
+            },
+            "metrics": {
+              "enable": true
+            },
+            "server": {
+              "allowUserDefinedWorkspaceNamespaces": false,
+              "cheClusterRoles": "",
+              "cheFlavor": "",
+              "cheWorkspaceClusterRole": "",
+              "gitSelfSignedCert": false,
+              "nonProxyHosts": "",
+              "proxyPassword": "",
+              "proxyPort": "",
+              "proxyURL": "",
+              "proxyUser": "",
+              "serverExposureStrategy": "",
+              "serverTrustStoreConfigMapName": "",
+              "tlsSupport": true,
+              "useInternalClusterSVCNames": true,
+              "workspaceNamespaceDefault": "<username>-che"
+            },
+            "storage": {
+              "postgresPVCStorageClassName": "",
+              "preCreateSubPaths": true,
+              "pvcClaimSize": "10Gi",
+              "pvcStrategy": "common",
+              "workspacePVCStorageClassName": ""
+            }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Developer Tools, OpenShift Optional
+    certified: "false"
+    containerImage: quay.io/eclipse/che-operator@sha256:4bb9f5859f2094d13c42b27f3aa41daac750725f611690aa083a265b3f760a16
+    createdAt: "2021-07-21T11:59:56Z"
+    description: A Kube-native development solution that delivers portable and collaborative
+      developer workspaces in OpenShift.
+    operatorframework.io/suggested-namespace: eclipse-che
+    repository: https://github.com/eclipse-che/che-operator
+    support: Eclipse Foundation
+  name: eclipse-che-preview-openshift.v7.33.2-all-namespaces
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: The `CheBackupServerConfiguration` custom resource allows defining
+          and managing Eclipse Che Backup Server Configurations
+        displayName: Eclipse Che Cluster Backup Server Configuration
+        kind: CheBackupServerConfiguration
+        name: chebackupserverconfigurations.org.eclipse.che
+        version: v1
+      - description: The `CheClusterBackup` custom resource allows defining and managing
+          Eclipse Che backup
+        displayName: Eclipse Che Cluster Backup
+        kind: CheClusterBackup
+        name: checlusterbackups.org.eclipse.che
+        version: v1
+      - description: The `CheClusterRestore` custom resource allows defining and managing
+          Eclipse Che restore
+        displayName: Eclipse Che Cluster Restore
+        kind: CheClusterRestore
+        name: checlusterrestores.org.eclipse.che
+        version: v1
+      - description: The `CheCluster` custom resource allows defining and managing
+          a Che server installation
+        displayName: Eclipse Che Cluster
+        kind: CheCluster
+        name: checlusters.org.eclipse.che
+        statusDescriptors:
+          - description: Status of a Che installation. Can be `Available`, `Unavailable`,
+              or `Available, Rolling Update in Progress`.
+            displayName: Status
+            path: cheClusterRunning
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.phase
+          - description: Public URL to the Che server.
+            displayName: Eclipse Che URL
+            path: cheURL
+            x-descriptors:
+              - urn:alm:descriptor:org.w3:link
+          - description: Current installed Che version.
+            displayName: 'displayName: Eclipse Che version'
+            path: cheVersion
+            x-descriptors:
+              - urn:alm:descriptor:org.w3:link
+          - description: Public URL to the devfile registry.
+            displayName: Devfile registry URL
+            path: devfileRegistryURL
+            x-descriptors:
+              - urn:alm:descriptor:org.w3:link
+          - description: A URL that points to some URL where to find help related
+              to the current Operator status.
+            displayName: Help link
+            path: helpLink
+            x-descriptors:
+              - urn:alm:descriptor:org.w3:link
+          - description: Public URL to the Identity Provider server, Keycloak or RH-SSO,.
+            displayName: Keycloak Admin Console URL
+            path: keycloakURL
+            x-descriptors:
+              - urn:alm:descriptor:org.w3:link
+          - description: A human readable message indicating details about why the
+              Pod is in this condition.
+            displayName: Message
+            path: message
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - description: OpenShift OAuth secret in `openshift-config` namespace that
+              contains user credentials for HTPasswd identity provider.
+            displayName: OpenShift OAuth secret in `openshift-config` namespace that
+              contains user credentials for HTPasswd identity provider.
+            path: openShiftOAuthUserCredentialsSecret
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - description: Public URL to the plugin registry.
+            displayName: Plugin registry URL
+            path: pluginRegistryURL
+            x-descriptors:
+              - urn:alm:descriptor:org.w3:link
+          - description: A brief CamelCase message indicating details about why the
+              Pod is in this state.
+            displayName: Reason
+            path: reason
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.phase:reason
+              - urn:alm:descriptor:text
+        version: v1
+  description: |
+    A collaborative Kubernetes-native development solution that delivers OpenShift workspaces and in-browser IDE for rapid cloud application development.
+    This operator installs PostgreSQL, Keycloak, and the Eclipse Che server, as well as configures all three services.
+
+    ## How to Install
+
+    Press the **Install** button, choose the upgrade strategy, and wait for the **Installed** Operator status.
+
+    When the operator is installed, create a new CR of Kind CheCluster (click the **Create New** button).
+    The CR spec contains all defaults (see below).
+
+    You can start using Eclipse Che when the CR status is set to **Available**, and you see a URL to Eclipse Che.
+
+    ## Defaults
+
+    By default, the operator deploys Eclipse Che with:
+
+    * Bundled PostgreSQL and Keycloak
+
+    * Per-Workspace PVC strategy
+
+    * Auto-generated passwords
+
+    * TLS mode (secure routes)
+
+    * Regular login extended with OpenShift OAuth authentication
+
+    ## Installation Options
+
+    Eclipse Che operator installation options include:
+
+    * Connection to external database and Keycloak
+
+    * Configuration of default passwords and object names
+
+    * PVC strategy (once shared PVC for all workspaces, PVC per workspace, or PVC per volume)
+
+    * Authentication options
+
+    ### External Database and Keycloak
+
+    To instruct the operator to skip deploying PostgreSQL and Keycloak and connect to an existing DB and Keycloak instead:
+
+    * set respective fields to `true` in a custom resource spec
+
+    * provide the operator with connection and authentication details:
+
+
+
+      `externalDb: true`
+
+
+      `chePostgresHostname: 'yourPostgresHost'`
+
+
+      `chePostgresPort: '5432'`
+
+
+      `chePostgresUser: 'myuser'`
+
+
+      `chePostgresPassword: 'mypass'`
+
+
+      `chePostgresDb: 'mydb'`
+
+
+      `externalIdentityProvider: true`
+
+
+      `identityProviderURL: 'https://my-keycloak.com'`
+
+
+      `identityProviderRealm: 'myrealm'`
+
+
+      `identityProviderClientId: 'myClient'`
+
+
+    #### Self-signed Certificates
+
+    Eclipse Che uses self-signed certificates by default.
+
+    You can also manually create a secret:
+
+
+
+    ```
+    oc create secret generic self-signed-certificate  --from-file=/path/to/certificate/ca.crt -n=$codeReadyNamespace
+    ```
+  displayName: Eclipse Che
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAANMAAAD0CAYAAAABrhNXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAaNklEQVR42u3de3QU9dkH8O/zm91EQK0U77dqVdTW++1V20KigUSQahLjsSSbtp4eeqqVLHILCcoiyQZEIbF61B6PVQJ6XiOkr6TlYiABr603wHotar1bBUWUYDY787x/JIGoSchmZ+c3M/t8/iS7M8+M5+vs7szz/IiZIYRIntJdgBB+IWESwiYSJiFsImESwiYSJiFsImESwiaBvv5ARLprEwB4ddaJTBQF8w/JsKbQmI0v665JAL3dUqK+7jNJmPTiNWOHWYhNB1AOILPrn+MA369MazaNe+Iz3TWmMwmTB3AEyrwwu4SIbwVwWB+v+hxEt6gg7qLs1rjumtORhMnlePUlF5hk1RFw4QDf8rrFmBLMa12tu/Z0I2FyKV53yVGWyTVgLgGQ8IknoImMQBnlNL+t+1jShYTJZXjlhKFW8KsbQJgNYP8ktxYDcI8yh95E41bt1H1sfidhcpH4mtETCHQHgONs3vTHAEXUMy33UQSW7uP0KwmTC/DqS84xyaol4Bcp3tULiqiMxrY8pfuY/UjCpBG3ZB1sxfgmgK4HYDi1WwI9SnGaTuPXv6v7HPiJhEkDfv7coPX5AdeB+RaADtRURRtAC9UB7Qvo4md26z4nfiBhcljH6qwcRbgDwKm6a+nyATNVGrkt9USQrtAkSJgcwquyT2ZlLWLQON219FofsMEghGls6ybdtXiVhCnFuOnnw62gEQHoOvTz3KM7sAVSy5RS0yln3X91V+M1EqYU4ZasgBWjawGuAnCI7noStAOM+coaUkvjVrXrLsYrJEwp0LHmkksUrFoAp+uuJSnMbzLR1EBua5PuUrxAwmSj7tYIBhfprsVOBDQTU5jyWl7RXYubSZhs0KM1YiaA/XTXkyIdAN+tMmgOZbfu0F2MG0mYksAMMtdkh4h4AYDDddfj0FF3tnrsOOROurrB1F2Nm0iYBolXjT7fVFRHwEW6a9FkkyIK09iWDboLcQsJU4KSbY3wGwKaCNZkyt34ju5adJMwDRA/fdEQa2fmZBAqARygux536Wr1+CY+m6546ivd1Wg7CxKmfUtha4TP8EeAmpuurR4Spn7w46PONi2qJdAo3bV4CROeM1iFKXf907prcfS4JUzfx82XjrDM+M0Ot0b4TWerB8yplLvxfd3FOHLAEqYeJ2NPawTmAviB7np8YheA21QG5lN26ze6i0klCVOXjtVZOUpxHZh+orsWn3qfmWYH8lqW6C4kVdI+TLwq+2Q2+HZmjNddSzogoIUsI0yXrduiuxa7pW2YuOnnw62MwEwwTwEoQ3c96aWr1SMen+qnKbRpF6a901GthQAdqrueNPcFGAvUzkMW09UNMd3FJCutwtSxenS2ItQCdIbuWsS3vMFENwbGtvxddyHJSIsw8ZpRx1hkVIM5pLsW0TcCmsk0ymjculd11zIYvg5TmrRG+E1nq4cK3kxjmr/UXUwifBkmZpD5+OiriHEbQMfqrkcMynYQ5nmp1cN3YepsjUAtgS7WXYuwA7+oGGHK2/CE7kr2WalfwsRrxxxpcWwOgN8BJEuJ+gwBTWThBrqs9T+6a+mL58PEjxRlWAd99gcw5kFaI3yO20D0JxVEFWW3fq27mu9V5+UwdbVG1AE4XnctwlEfMlOF26bQejJMvDbrLJNRS8Bo3bUIfRj8T0NRGY1pfVZ3LYDHwsSrc39o0TdzpDVC7OWeKbSeCFOP1ogIgIO0FCHcrrPVwxxSo2sKrevD1LVqRC2Anzq+c+FFW5m4IjB2Q4PTO3ZtmLj50pFsmrczcLnTJ0V4HzHWESFMua3/cmqfrgsTt2QdZHWgHIwwgEynToTwpTjA96sMqqTs1m2p3plrwiStESJ1uqbQBnEXZbfGU7YXN4SpY1VWllKoBXBmqg5UCACvW4wpwbzW1anYuNYw8d+zjrYCFJXpqMJJBDSRESijnOa37dyuljDxyglDrYyvZkBaI4Q2XVNozaE30bhVO23ZopNhktYI4UIfAxSxYwqtY2HitVnndT0C9DOHT5YQA/GCIiqjsS1PDXYDKQ8Tr/7FERapCKQ1Qrhf5xTaOE2n8evfTfjNqQrT3tYIvgWgA3WfJSEGjtsAWpjoFNqUhKmzNQK1AP1Y92kRIgkfMFPlQFs9bA0TPz7qVLbUIgbydJ8FIezChFbDojDltWzu93V2hElaI4T/dbV6cHAa5a79tNdXJBMmbskKWDG6FszVIBys+3CFcMAOMOYra0jtd1s9Bh2mjrXZlyrmWgCn6T46IRzH/CYTTQ3ktjbt/acEw8RrR53EbFQzuEj38QihGwHNxBSmvJZXEgqT9Xj2bWC+QVaNEKInjoFQpca0zvvuXwJ9vwdT5XlUIXpiC6T+Vyn1597+Gkh0c0KkIwb+YUCV0diWfwBAbx/oJExC9G/AN3MlTEL0qudE2ZYBTZSVMAnxHQQ0Udz4Y6IPwEqYhNiDX1SdU2OfHMy7pU1CCMY2EMLqy0MvGGyQALkyifTWuXKhNfQmyku+nV3CJNISAc2krMk0ZuNrdm1TwiTSzRtMdKORgtXeJUwiXXwBwtzO4ZQtKRlOKWESftc5Ntm0ZtO4Jz5L5Y4kTMK3CLyerMAUumzdFif2J2HyBu58GkwmPg3QW8w01chr/T8ndyr/cVyPX1QKoxTUBcwY9D2QNLELwFyVgdMCeS2OBgmQK5N7MbZBoUrtOPROurrBBABmjDIfH30VgRaC8SPdJboIg2ip6uAZNL71E11F9N0cuDbbNStbp5nOG4n9zMXuMb99BoAhugvWiQnPGSaX0WUbnnF0vwl12kqYHEdAE5kqTOPWvzWQ16f5yiIfMlPFQOfc2U3C5F5vMHhKIHfDqsG8mddmj7Y6B96cpftAHLAbhDvU7o5quuKpr3QVIWFynx43EpNb5W7vaox8K4DDdB9YKhDQRLAmU+7Gd3TXImFyj5TdSOSWrP2tGKYBKIdf1glmvKRIhSl3/UbdpewpScKkH4HXk+Iwjdn4cir345MxbdtBmKd2HLLnF023kDDptZWJKwJjNzQ4udOO1Vk5ilAL4Ke6T0AiZQN8t1LBm2lM85e6i+mNhEmPXQBuS3TJEjvx8+cGre0H/tYLo617DnrUXUt/JEzOcsWNxG8V5OZFF3oZQexmEiaHMPifhoWw0zcSB1zf46NOZVMtZkKu7lrQPRx/5yGL6eqGmO5iBkrClHpabyQmqnOhOqoDcLzze9/3si1u1ltu5EFXe+wGYYHKwCmBvJYlXggSAARyN6xUXx5yCghhAI7dAGVCq2J1jjG2pdSLQeqLXJmSREATWbiBLmv9j+5aksFrxxxpcWwOUru49/vMNNsrV+7+yMc8OzFeUuAyytvwhO5SbD2stVnnmcx1BLrYxq0OahFmN5Mw2cO1NxLtwgwyHx99FTFuA+jYZDZFoEdJGdNoTPN7uo/LThKm5Lj+RqLdeM3YYRZi0wHMBLBfQu8FnjeIwjS25Sndx5GScyNhGhwCmsk0ymjculd116IDrxl1jEVGNZhDA3j5xwBF1DMt91EElu7aU3ZOJEwJe4OJbgykYMaaF3WsHp3d+WgSnfH9v3IMwD39NTX6iYRp4L4AY4HXbiQ6YW+rh7UQoEOBrl80jUAZ5TS/rbs+x86DhGmf4gD/WRmBmyln3XbdxbhZ56NJ7dMtqMeDuevX667H8eOXMPWNgBayjLBTM9aEt/WWG5lO1H0jMa9lie5ChLelc5h6tEa0+OJGotArHcPUeSMR5lTK3fi+7mKEf6RVmJjwnMEqTLnrn9Zdi/CfNHlqnD8C6PfG060XSpBEqvj9ytQ1Yy2udcaaSA++DdOeGWtj9c9YE/4RiUTUlreCpQAe+O7f/BimTQqqzE0z1oQ/FBTXnL9lK2oBvhg+D5PvWyOEHr+8ZsGRgUB8DsC/Qz+/M/ghTGnXGiGcUVS0aEg8s30ywawE6IB9vd7TYdo7Y63V1TPWhPcUhqommPxNHSUwbMabYeqasWZ4ZMaa8I4rJ1afpRTqmGlUou/1Wpg6Z6xZQ2tp3Kp23cUI/ygqivzQysiYw4RBD+j0SJh6zFjL889oKKHfpEn3Bre3bbvOBEUAHJTMtlwfJia0GpYKU27LZt21CH8pLK3J2bZrey2IbFnUwM1hep+ZZgdypTVC2Cu/NDpSMW5niy+3c/FSF4ap54w1aY0Q9rnyN5GDjHiwnC2EOQULwbkpTF0z1gK+m7Em9IpEImrz1mAJxelWTuESpa4Ik99nrAl98kPR0Vu2oo6AM1O9L81h4o8ANdfw+Yw14byC4gVHA2YUjBLAzm9GfdMSprhF2PThwZvf3Tli/NU33vOhjhqEP02YFBkabAvOAMwZAIY4uW/Hw/TCB4fgL8+fgv9+NeRMAM8Vhmoip5/Qfl8kEpErk0gCU35o/lXUxgsB/EhHBY6N+vrgy/3xwPMnY/NHI3r78/NghFcsq5DvTCJhV06sOVcprgPwM6f2ubx+1vc+Oqb8yvR1ewANL5+I1a8fA4v7/Oh6HghPFJZEH1VKTWtYUi6/5ol9KiipPgJAZF+tEU5J2ZXJtAgtbx2FhzediJ3fZCTy1jaAFx4Y6Jj/wAMRuc8kvqeoKJJhZQb/YIFuIeBAHTX0dmVKSZpf/mQEZvztItz77E8SDRIADAVozs54xr/zS6pLAXbklxjhDYWhqglmZsZrDKrVFaS+2Hpl+njnUDy86UQ88+7hthXIQCugwo1Ly+XZvDRW+KvoKWxgMYA83bUAKfzO9E2HgZWvHYfGl49Hh2XvxY6ALMB6saA4uoxVcFpj/XR5ajyN9GiNuA7a74v2L6krEwN44p0jUf/CSOzYnfDHucHYwaD53wwfVrvqT5Oln8nHsrIigRHHZF7LbFUDdLDuer7L1u9M/972A1Su+h/86cnTnAoSABxE4PlDvvh6S35x9HKndiqcdVVx9aUjjs54kZnvdWOQ+pLwZXN72354+KWTsPGdw8H6fhsYSYSVBcXRZgqo8PIHy2UGhA8UldScaIGjFlCku5bBGHCY2k2Fx145Hn995TjE4oPq6rUfIYdN66XC4ujdZjA2568PRHboLkkkLhRaOGwXx6ab4HKkoDXCKfv8zsRMePa9w1D/wkh8tiuhBbcdPhJ8Tsy3qPaT7mxouFrm5nkCU35JNESgBQDs+wnYAb19Z+o3TG9tPxAPPn8yXvt0uO7aE8CvEWHK8vrKNborEX27cmLVBUoZdQBfqLuWwUjop/G7nj4NG946AuzM0+s2olOZsbowFG1SMCc31N8ks8ZdpKi06ijTVDUglPjthnyfYWp960jdtSWFGZebMMYWFkfv6cg0Zj92/0xZBUOj7umopsWzQdhfdz2poP3hwBTLYMLkQMx8vTBUMykSifj9eF2pMFQ1wcz45lUCzwf8GSTA/2HqdiQz37tla8azV5VUXay7mHRRUFJ9Tn5JdCOzegyE43TXk2qufjwjBc63oJ6UVo/Uyi+NjlAmbmbgehrkdFQvSrcwAQAxUGRa1riCkurbpNXDPt3TUdnCXCb8QHc9TkuXj3m9GQbQnJ1mxpudrR4iGYWlNTmftW3fxKBaIP2CBKTnlenbGMcQ6MGCUPQ3RBxevqRyi+6SvKSoZN7JJoxFbPE4X/3OPQgSpm6MbGZ6SVo9Bmb8xJrh+ylrpgmaAsCxJ53dTML0bQqEkOKOy/NLahYE2tsXNzREYrqLcpM901HBCxl0qO563CSdvzP1iYHhBJ5vZma8XFBSPV53PW5RMLE6e8vWjJcI9CAACdJ3yJWpfyMBaioojjYbQFnDsopXdRekwxXXVB1jGKoahJDuWtxMwjQQhBwT2FRYHL1bxdTNDQ3labEQdXdrBEAzAbi4ZcAd5GPewAWZMNnMtN4qLKkuKyp6xMc3I5nyQzVFu7jjVYDmQII0IBKmxI1gUK2ZufW5gonzE15E2O0KimvOLyiZ/yQxPwLgWN31eIl8zBu8s6GsDX5p9fjlNQuODATic9wyHdWLJExJ6mr1uLSwpPqOjoxAtddaPbqnozLMeQAdoLseL5P/A9ljCINmBmLma16aQts1HfX1rkeAJEhJkiuTvY4i0IMFJTV/ZBUta1xS8YzugnqTH1pwKlnmYmbk6q7FTyRMqXE+WXiqoDi61AgGZjQ8MOMT3QUBPaajsnk9KH1aI5wiYUodAiFkxuMFuls9Jk26N7h99+e/NdmqBuCZoY5eI9+ZUm9Y16oeL+eHahwfrlhYWpOzbdf2l7w2HdWL5MrknBOJ+ZGCkuh6Ujwl1a0ehRPnnQTDWMQWX+65AVMeJWFy3iVs0QsFJdX3G0Ga3fCXis/s3PiVv4kcZMSD5QwKg707HdWLJEx6BACaZHWgyK5Wjz2tEXG6lYHDdB9gOpLvTBp1t3rEMzO3FIai4wa7nfxQdPTLWzNe6GqNkCBpIlcmFyDwycz4W0FxtJmVMbmxfuZrA3lfQfGCowEzCkYJQ74Z6SZhchNCDrG5ubA4encbYjetWhbZ2dvLJkyKDA22BWcA5gwAQ3SXLTrJxzz3CTJh8hAK9tLq0dkaEWzL6G6NkCC5SJ+rYBSGahJeIFqkxIsKCMctalOK6wD8THdBIoULRIuUOscCNijFDPkk4WoSJm8gyA8Mrif/pxPCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWzSd5iIbgcgS1AK8W2xrmx8T59hWlE/axpZ5mkENOiuXghXYDSToc5ZUT9rWm9/7rM5kGjvE/9XFVdfahHVAjhN9/EIocGbAN+4Ymnl37r/obfcDChMAJCVFQmMOCbzWmarWiaDijSxg0HzexvFllSYuu0Z/k64DtJcKPzJAmMZq+C0xvrpn/b2AlvC1K3wV9FT2MBiAHm6j1wIuzDQCqhw49Lyzf2+zs4wdSsMVU1gVrUAfqz7RAgxaIT3mXl249LKJQN5eW+5Sfo+0/L62SuN9tipBA4zsDPZ7QnhsDaA5x5oxEYONEh9SfrK1FNBSfURACIAySLDwu2YgEeVUtMalpS/l/CbU/ExrzdXTqw5V2a8CRd7HozwimUVTw12A46FqWt3lB+afxUxLwTwIyfPlBB9+JiIIqef0H5fJBKxktmQw2HqtHcuNslcbKFLjBj39De/PVFawtRtz4oNhBLIQEXhECI0waSy5Q/NetvO7WoNU7f8UHQ0MeoAnJmSHQgBAITXmWlK49JZq1Ox+ZT8NJ6oxvqKDWecGDuHwb8G8F+n9y98jvA5gcOfvx87PVVB6nPXTl+ZevrW+quQ9VdFUuIA399hZlaufHjatlTvzBUf83qTXxodqRi3M+Nyx3YqfIOBdSAON9ZX/suxfbo1TN0KS2ty2ORaEH7q+M6FB9G/mVDZWD/L8Z47V3xn6s/yJbOaDx424mwi+j3AKb9UC8/6GuC5u4cPO11HkPriqitTTz1aPa4HYCS9QeEHFhjL4hZPf+zhSq0/Xrn+Y15v8kMLTiXLXAxCru5ahEaEf8KyylYsm/2s7lIAj4apW1erRx2A43XXIhz1IYMrGpdW1APkmnWWXf+dqT9drR6nEDgM4Cvd9YiUayPwAqM9dkpna4R7gtQXz1yZevrlNQuODATic6TVw5+I0GQadMNfH5j1H9219MXTH/N6UxiqOo/ZqAP4Yt21CFu8qIDwo0srntBdyL74Lkxdh9Xd6nEbgGN1VyMGg7cRUKXaT7qzoeFqU3c1A6rYn2HqFAotHLaLY9MBmglgP931iAHpIMbddrZGOMXXYep2xTVVxxiGqgYhpLsW0Q9GMytjcmP9zNd0lzKo8tMhTN0KJlZnQ1EtgDN01yL2YtAbivjG5fUVf9ddS1LH4eWfxhO14qHKljNOjJ3d1erxadIbFEkh4AsGlQfa28/wepD6PEa/Xpl66tHqMQVAhu560owFxjIjA1Mb/lLxme5i7JJWH/N6k18aHUkWLQJ4vO5a0gKhhYjDy5dUbtFdit3SPkzdCktrciyL6wj4ie5afOo9Bt+U7FBHN0ur70z9Wb5kVvMhQ0ec1fVo0pe66/GRXQDPPTAQO9nPQepLWl6ZesovjY5QJm6WVo+kMBhLjWBgRsMDMz7RXYwjBywf8/pWWFpzNltWLUCjdNfiMc+xQlnjkopndBfiJAnTAEirx4B9xOBZbmuNcIqEaYCKihYNiWe2TyZwJYADdNfjMrsJfEdHRqD6sftnpm0rjIQpQUWlVUeZpqqRKbSdiNCkYE5uqL/pHd216CZhGqSC4przAa4D4SLdtWjyEiwVXvFQ+UbdhbiFhCkpTPkl0RCBFgA4XHc1DtlO4Hleao1wioTJBmnS6tFBjLtVTN3c0FAu9+F6IWGy0ZW/nneCYRo1DBTprsVWjGYKqPDyB8tf0V2Km0mYUiA/VHMJMS+G91s93mTG1MZlFU26C/ECeZwoBRrrZ63v0erhxaeidzCofPfw/c+QICVHrkw2Gj+xZvh+yprpkVYPC4xlrILTGuunS79XguRjnkOKSuadbMJYBGCc7lp6w0AroMKNS8s3667FqyRMDissrclhy7oDoFN119LlAwZXpusjQHaS70wOW75kVvPBQw8+0wWtHm1drREneWU6qhfJlckhmlo9mIBH2bKmr3ho9ru6z4GfyMc8FygoqT6HQbUE/CKV+yHCC2yhbMWyiqd0H7MfSZhcpDBUNYEtdQcIx9m86Y+JKHL6Ce33RSIRS/dx+pWEyWUmTIoMDbRl3kDg2QD2T3JzMWLc48XpqF4kYXKpZFs9iNAEk8qWPzTrbd3Hki4kTC535cSqC5Qy6gC+cEBvILzOTFMal85arbv2dCNh8oQBtHoQPifmW7Z/0HFXa2skrrvidCRh8pAerR7lADK7/jkO8P0dZmblyoenyWr0GkmYPKhw4ryTYBiL2EKQlTHFq6tG+E1CYRJCJEYeJxLCJhImIWwiYRLCJhImIWwiYRLCJv8P9sXhC7xE4kIAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDQtMTNUMDg6MTY6MDgrMDI6MDCcYZVaAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTA0LTEzVDA4OjE2OjA4KzAyOjAw7Twt5gAAAABJRU5ErkJggg==
+      mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - oauth.openshift.io
+              resources:
+                - oauthclients
+              verbs:
+                - create
+                - get
+                - delete
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - oauths
+              verbs:
+                - get
+                - list
+                - watch
+                - patch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - infrastructures
+                - proxies
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - user.openshift.io
+              resources:
+                - users
+              verbs:
+                - list
+                - delete
+            - apiGroups:
+                - user.openshift.io
+              resources:
+                - identities
+              verbs:
+                - delete
+            - apiGroups:
+                - console.openshift.io
+              resources:
+                - consolelinks
+              verbs:
+                - get
+                - list
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+              verbs:
+                - list
+                - create
+                - watch
+                - update
+                - get
+                - delete
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterroles
+              verbs:
+                - list
+                - create
+                - watch
+                - update
+                - get
+                - delete
+            - apiGroups:
+                - authorization.openshift.io
+              resources:
+                - roles
+              verbs:
+                - get
+                - create
+                - delete
+            - apiGroups:
+                - authorization.openshift.io
+              resources:
+                - rolebindings
+              verbs:
+                - get
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - roles
+              verbs:
+                - get
+                - create
+                - delete
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - rolebindings
+              verbs:
+                - get
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - org.eclipse.che
+              resources:
+                - checlusters
+                - checlusters/status
+                - checlusters/finalizers
+              verbs:
+                - '*'
+            - apiGroups:
+                - project.openshift.io
+              resources:
+                - projectrequests
+              verbs:
+                - create
+                - update
+            - apiGroups:
+                - project.openshift.io
+              resources:
+                - projects
+              verbs:
+                - get
+                - list
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - get
+                - list
+                - create
+                - update
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - get
+                - create
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods/exec
+              verbs:
+                - create
+            - apiGroups:
+                - apps
+              resources:
+                - secrets
+              verbs:
+                - list
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - list
+                - get
+                - create
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - persistentvolumeclaims
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - get
+                - list
+                - create
+                - watch
+                - delete
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - get
+                - list
+                - create
+                - patch
+                - watch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - services
+              verbs:
+                - list
+                - create
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - create
+                - delete
+                - list
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+              verbs:
+                - list
+                - create
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - replicasets
+              verbs:
+                - list
+                - get
+                - patch
+                - delete
+            - apiGroups:
+                - extensions
+              resources:
+                - ingresses
+              verbs:
+                - list
+                - create
+                - watch
+                - get
+                - delete
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - get
+                - create
+                - update
+            - apiGroups:
+                - operators.coreos.com
+              resources:
+                - subscriptions
+              verbs:
+                - get
+            - apiGroups:
+                - metrics.k8s.io
+              resources:
+                - pods
+                - nodes
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - workspace.devfile.io
+              resources:
+                - devworkspaces
+                - devworkspacetemplates
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - controller.devfile.io
+              resources:
+                - devworkspaceroutings
+                - components
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - workspace.devfile.io
+              resources:
+                - devworkspaces
+                - devworkspacetemplates
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - patch
+                - update
+            - apiGroups:
+                - controller.devfile.io
+              resources:
+                - devworkspaceroutings
+                - components
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - patch
+                - update
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps/status
+              verbs:
+                - get
+                - update
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - persistentvolumeclaims
+                - pods
+                - secrets
+                - serviceaccounts
+              verbs:
+                - '*'
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods/exec
+              verbs:
+                - create
+            - apiGroups:
+                - ""
+              resources:
+                - services
+              verbs:
+                - '*'
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - mutatingwebhookconfigurations
+                - validatingwebhookconfigurations
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resourceNames:
+                - devworkspace-controller
+              resources:
+                - deployments/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - apps
+                - extensions
+              resources:
+                - deployments
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apps
+                - extensions
+              resources:
+                - deployments
+                - replicasets
+              verbs:
+                - '*'
+            - apiGroups:
+                - apps
+                - extensions
+              resources:
+                - replicasets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - controller.devfile.io
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+                - controller.devfile.io
+              resources:
+                - devworkspaceroutings
+              verbs:
+                - '*'
+            - apiGroups:
+                - controller.devfile.io
+              resources:
+                - devworkspaceroutings/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - extensions
+              resources:
+                - ingresses
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - create
+                - get
+            - apiGroups:
+                - oauth.openshift.io
+              resources:
+                - oauthclients
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+                - clusterroles
+                - rolebindings
+                - roles
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+              verbs:
+                - '*'
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes/custom-host
+              verbs:
+                - create
+            - apiGroups:
+                - workspace.devfile.io
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+                - workspace.devfile.io
+              resources:
+                - devworkspaces
+                - devworkspacetemplates
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - controller.devfile.io
+              resources:
+                - devworkspaceroutings
+                - components
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - persistentvolumeclaims
+                - pods
+                - secrets
+                - serviceaccounts
+              verbs:
+                - '*'
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - pods/exec
+              verbs:
+                - create
+            - apiGroups:
+                - ""
+              resources:
+                - services
+              verbs:
+                - '*'
+            - apiGroups:
+                - apps
+              resourceNames:
+                - devworkspace-che-operator
+              resources:
+                - deployments/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - apps
+                - extensions
+              resources:
+                - deployments
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apps
+                - extensions
+              resources:
+                - deployments
+                - replicasets
+              verbs:
+                - '*'
+            - apiGroups:
+                - apps
+                - extensions
+              resources:
+                - replicasets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - create
+                - delete
+                - get
+                - update
+                - watch
+            - apiGroups:
+                - org.eclipse.che
+              resources:
+                - checlusters
+                - checlusters/status
+                - checlusters/finalizers
+              verbs:
+                - '*'
+            - apiGroups:
+                - controller.devfile.io
+              resources:
+                - devworkspaceroutings
+              verbs:
+                - '*'
+            - apiGroups:
+                - controller.devfile.io
+              resources:
+                - devworkspaceroutings/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - controller.devfile.io
+              resources:
+                - devworkspaceroutings/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - ""
+              resources:
+                - configmap
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - extensions
+              resources:
+                - ingresses
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - create
+                - get
+            - apiGroups:
+                - oauth.openshift.io
+              resources:
+                - oauthclients
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+                - clusterroles
+                - rolebindings
+                - roles
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+              verbs:
+                - '*'
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes/custom-host
+              verbs:
+                - create
+            - nonResourceURLs:
+                - /metrics
+              verbs:
+                - get
+          serviceAccountName: che-operator
+      deployments:
+        - name: che-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: che-operator
+            strategy:
+              type: RollingUpdate
+            template:
+              metadata:
+                labels:
+                  app: che-operator
+                  app.kubernetes.io/component: che-operator
+                  app.kubernetes.io/instance: che
+                  app.kubernetes.io/managed-by: olm
+                  app.kubernetes.io/name: che
+              spec:
+                containers:
+                  - command:
+                      - /usr/local/bin/che-operator
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: che-operator
+                      - name: CHE_VERSION
+                        value: 7.33.2
+                      - name: RELATED_IMAGE_che_server
+                        value: quay.io/eclipse/che-server@sha256:b4be065bff9c71b17804a0a8ede43982d2dc44bc555c4c8a90fd63e22b23f555
+                      - name: RELATED_IMAGE_dashboard
+                        value: quay.io/eclipse/che-dashboard@sha256:ff44e57ddf7dbc76cca375979401539c3bd9a6a1db37d55f1c6b05e4d70f6ee1
+                      - name: RELATED_IMAGE_plugin_registry
+                        value: quay.io/eclipse/che-plugin-registry@sha256:fe85f41baa90d8e1f8ba06cfbbe1247b65c7be10ede32755860d8fe01183895e
+                      - name: RELATED_IMAGE_devfile_registry
+                        value: quay.io/eclipse/che-devfile-registry@sha256:7a144352a496073d14a4983141cffda1aeb489d361b21aba4020f581445c9bb2
+                      - name: RELATED_IMAGE_pvc_jobs
+                        value: registry.access.redhat.com/ubi8-minimal@sha256:b6b0c30bb747dfacee216e5ae2ad02adb18920d8f744c04f29354278e19df2a9
+                      - name: RELATED_IMAGE_postgres
+                        value: quay.io/eclipse/che--centos--postgresql-96-centos7@sha256:b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
+                      - name: RELATED_IMAGE_keycloak
+                        value: quay.io/eclipse/che-keycloak@sha256:aba3d3db727ae11ad52fa121a2e465f2af48edeb2320f954ea5681290702b50d
+                      - name: RELATED_IMAGE_che_workspace_plugin_broker_metadata
+                        value: quay.io/eclipse/che-plugin-metadata-broker@sha256:df1ea2eadb28dbc97761adf4ea984af5ca941025a67b39c6abe373816a84bba9
+                      - name: RELATED_IMAGE_che_workspace_plugin_broker_artifacts
+                        value: quay.io/eclipse/che-plugin-artifacts-broker@sha256:4891a6e19be9eae59372f4b31144653f9bd1284e0301ecfe896a099ca6a12b58
+                      - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
+                        value: quay.io/eclipse/che-jwtproxy@sha256:881d1c91e7f5840314f25104ef5c0acee59ed484a5f9ef39daf3008725ea1033
+                      - name: RELATED_IMAGE_single_host_gateway
+                        value: quay.io/eclipse/che--traefik@sha256:6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
+                      - name: RELATED_IMAGE_single_host_gateway_config_sidecar
+                        value: quay.io/che-incubator/configbump@sha256:175ff2ba1bd74429de192c0a9facf39da5699c6da9f151bd461b3dc8624dd532
+                      - name: RELATED_IMAGE_devworkspace_che_operator
+                        value: quay.io/che-incubator/devworkspace-che-operator@sha256:b01a7eae740850593a8f8a1fec8421c7ac7eef46eeacffb1ed635c68d384f2ca
+                      - name: RELATED_IMAGE_devworkspace_controller
+                        value: quay.io/devfile/devworkspace-controller@sha256:f17dad6df3f2f0f7b245e05677293bef1d35a17e0349002f9e47816de03c0cdd
+                      - name: RELATED_IMAGE_internal_rest_backup_server
+                        value: quay.io/eclipse/che-backup-server-rest@sha256:24983ce54474bbe87239f23773faeb59a5471a6a4b20e731518ad5738bfea6d7
+                      - name: RELATED_IMAGE_gateway_authentication_sidecar
+                        value: quay.io/openshift/origin-oauth-proxy@sha256:82719931600d90a8c3eb26b1632cc99020bc12921fa6ad13c9d4929fe2d0f025
+                      - name: RELATED_IMAGE_gateway_authorization_sidecar
+                        value: quay.io/openshift/origin-kube-rbac-proxy@sha256:fcce680899a37d6bdc621a58b6da0587d01cbb49a2d7b713e0d606dffc9f685a
+                      - name: RELATED_IMAGE_gateway_header_sidecar
+                        value: quay.io/che-incubator/header-rewrite-proxy@sha256:bd7873b8feef35f218f54c6251ea224bea2c8bf202a328230019a0ba2941245d
+                      - name: CHE_FLAVOR
+                        value: che
+                      - name: CONSOLE_LINK_NAME
+                        value: che
+                      - name: CONSOLE_LINK_DISPLAY_NAME
+                        value: Eclipse Che
+                      - name: CONSOLE_LINK_SECTION
+                        value: Red Hat Applications
+                      - name: CONSOLE_LINK_IMAGE
+                        value: /dashboard/assets/branding/loader.svg
+                      - name: CHE_IDENTITY_SECRET
+                        value: che-identity-secret
+                      - name: CHE_IDENTITY_POSTGRES_SECRET
+                        value: che-identity-postgres-secret
+                      - name: CHE_POSTGRES_SECRET
+                        value: che-postgres-secret
+                      - name: CHE_SERVER_TRUST_STORE_CONFIGMAP_NAME
+                        value: ca-certs
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNDCMNSTEZJTHFTGKZJWMI4WKNDBHBRDIZJYGY4DCMZYGBRWKMRUGYZDMNZUGU4TOYJUHBRDQMLDGEZTCY3CMJTDANJVMRSDKZBQMMZQ____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:4bce2e39fee6b9e4a8b4e8681380ce2462674597a48b81c131cbbf055dd5d0c3
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUN3DMY3GMMBQMQZWMMTEMFTDANBWG42TMMJYMM2DAODFGA4GMMBRHFTDENLCHEYWKYZQHBSDENZZGA4TIZTEMRRDAMLGGU2TSNJQGJRA____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:7cf6f00d3f2daf04675618c408e08f019f25b91ec08d279094fddb01f559502b
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUMTFGJRDGNLGMIZTGYZXHA3TGOBTGY4DIMRXMIYGEMJUME2DMNJZMI3GEMBTGEYTGZBYHA3TINZSMM2DINLBMU3DCNLEHE3TMMLEGM4Q____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:2e2b35fb33c78738368427b0b14a4659b6b03113d887472c445ae615d9761d39
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUYLFGUYTENDFGMYTSODBMM3DSNZXMNQTSNZTMFQWMNBYHA2WCMJUMU4DAMDEGY2DOYZZGZQTEM3EGE2WCMTCGZRGCYTCMU4GMZLGGJQQ____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:ae5124e3198ac6977ca973aaf4885a14e800d647c96a23d15a2b6babbe8fef2a
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUMTFGQ4WMYLGMI4WCYJWGUYTSZTDGYZTAMJZME3TEYJUGUZDMMRSGJRDMOJQGVSWIMBRMRRTIOBUMMZWKOLGGUYTGMLBMUYDAYRVGQ3A____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:2e49fafb9aa6519fc63019a72a4526222b6905ed01dc484c3e9f5131ae00b546
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNZZGE4WIOJWGVQTON3GGFSWGOJWHFSTANZTMEYWGYZYGY3DQNTGHEZGKOJZMZRTKM3BGBRDAYZYMQZGKYRRGNQWKYJWGFRTMMZUGY3Q____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:7919d965a77f1ec969e073a1cc86686f92e99fc53a0b0c8d2eb13aea61c63467
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUZBVGY2WEOJYMYYTCMDFMZSTIMRUGZTGKMLGGI2WKZJWGJSDONDEG4YGMNDGHE4TSZJUGY3TSZJYMY3TAOBVMYYTQYRRG4YTCZRXGZSA____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUOBWGE2WCMRZGQZTKYRQGI2TMYTGMZQWMOBVMFRDEY3GHEZTEN3CGA2TSZRRGRSWCYJWGYYTIMZUGZSGMZBVGFSTGYJWMRSDSZRQGQYQ____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:8615a29435b0256bffaf85ab2cf9327b059f14eaa6614346dfd51e3a6dd9f041
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNJVG4YDGYLFGVTGCZLCMVSGKZJVGZTGIY3FGM4DOOLGMEZDEOBRMNRTENRQGQ4DQZBYME2DQODGMY3TOZLEGNSDIMDGG43TQZDEMY3Q____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:55703ae5faebedee56fdce3879fa2281cc260488d8a488ff77ed3d40f778ddf7
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNRZHFQTQZTEME3DOYTBMJRWGMLGMFSWIY3GGJSTIYLCGIZGMNTDMYYGGZRWMFSDAODDGQYWGMRZGM4TQM3CHAYTMOJRMM2TSYLFGRSA____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:699a8fda67babcc1faedcf2e4ab22f6cf0cf6ad08c41c293983b81691c59ae4d
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUOJXGRSGIMDBGVQWEN3FGA3TKZBXMQZTINDBMYZGKODFGJQTEZRYGBQTANRZMU4GCNLBGRRTSZTGMMZGCNJXMU2DEMLCGYZGCYJRG5QQ____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:974dd0a5ab7e075d7d344af2e8e2a2f80a069e8a5a4c9ffc2a57e421b62aa17a
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUOBSHE3WMYRRG4ZTEZBYG5SDKNTBGBQWCNDDGY4TCMBVMU3WEY3GGRRDKMBQMU2DAYTCGE3DINBWMQ3DEOBWMMYDOYRYHA2GKYRXGNSA____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:8297fb1732d87d56a0aa4c69105e7bcf4b500e40bb16446d6286c07b884eb73d
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUMBZGVRTENBQGU2TAMZTMUZDCOLEGVQTSZRWMZSTSOBTGVRDOOLDGVSDGNBRGZTDAZDGMJRDEMRYMQZDSNJXGEZWKOBRMQZDOYZWGYYQ____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:095c24055033e219d5a9f6fe9835b79c5d3416f0dfbb228d295713e81d27c661
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNJWMU3TSNRQHA2TOOBYGZQTANLGMM2DKOLFMQ3GKNZTMEYGCMZYGZTDCNBVMEZDINZUMMZDEODDGJRDOY3DMI4TOYJRMQYTQYRUMRTA____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:56e7960857886a05fc459ed6e73a0a386f145a2474c228c2b7ccb97a1d18b4df
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUZDCHA3GGOJSGQYTQYRZMY2DAYRSGY2TIYRYMZRTINZTGA3TGNJWHFSTAZDDHBQTAMLEG5QWIYZTGFRTSOJSGVSTKNBWHFSDEYRRGE2A____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:db86c92418b9f40b2654b8fc473073569e0dc8a01d7adc31c9925e5469d2b114
+                      - name: RELATED_IMAGE_mta_vscode_extension_plugin_registry_image_IBZWQYJSGU3DUNBVGEZWIMZYGIZDAYZWGVRGINJUHE2DIOBWME4WIMBRG44TEODFHBTDCZRVMUYWCMRVMU3TMYZUGFSDGYRRGI4TOM3FMYYDQODCMI4A____
+                        value: quay.io/windupeng/mta-vscode-extension@sha256:4513d38220c65bd5494486a9d017928e8f1f5e1a25e76c41d3b12973ef088bb8
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNJQGJQWEY3GGY2TSOLGMRQWIYLCMVTDEOBZMRRWCZDDGVRTGMTDME3DEMTGMEYDEYRXGNQTOMTCGEYTGY3BGFSTKZJVMIYTOOJTG42Q____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:502abcf6599fdadabef289dcadc5c32ca622fa02b73a72b113ca1e5e5b179375
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUZRTHE4GKM3GMZSDKMRQGBRTKNTCMY2TMYJWMY3WMOLFHBSGENDBMEZWMNRTHFQTMMJSGU4DKMDGGE3DSNBRGQ2TEOBSGYYGIY3FHBQQ____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:f398e3ffd5200c56bf56a6f7f9e8db4aa3f639a6125850f169414528260dce8a
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUZJTG42GKYZTGY3TINBXMFTGKYJZMIYTEZRVME4GMNRWHEYGCNTGHE4TGNJSGY2DAODBGM3TGMLGGUZDEYJVGNSTKZBQMJTGGMRYG5TA____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:e374ec367447afea9b12f5a8f6690a6f993526408a3731f522a53e5d0bfc287f
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUMTDMI2GMNZQMVSGEY3EMFRDGYRSG44WIYLFGUZWENTBG42TGZBWGNTGKZJQGNRGGYLFGNSDEYJTHA2WKMRUMYZDKZJWHE2WGMBTMRTA____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:2cb4f70edbcdab3b279dae53b6a753d63fee03bcae3d2a385e24f25e695c03df
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNDGMRRDANBQGI3GGYTFMRSGEZTFGUZTCOBUMFTGGZBWMZRTKY3CGYYTGMTBGIZGEZJVHAYTAYRRGNSDGODBGEZDKYLGMQYDQMZSGIYQ____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:4fdb04026cbeddbfe53184afcd6fc5cb6132a22be5810b13d38a125afd083221
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNBZGFRTMMTBGNQWGNZXGVSDKNBSGZSDOMTBGU4WCYZRHBRGIZBVGBTDKZRVMQ3DCZBQG5TGEZTCGM2GKMDDMQ3WMZLEGNSDIZDBGIYQ____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:491c62a3ac775d5426d72a59ac18bdd50f5f5d61d07fbfb34e0cd7fed3d4da21
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNJZG5QTGMDDHFRTGZTDG5SGEYTGMI4WKMBYMIYWEYRSGE3TSZBYMVRDANRSMFSDCNBYGQ4DAZTGGMZDIOBZMI2GMMBRMVRTMNZVMY2A____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:597a30c9c3fc7dbbfb9e08b1bb2179d8eb062ad148480ff32489b4f01ec675f4
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUNTEGBRTINBQME3WIYZWGQ4DQMJWMZRWINBYHA2WEOLDMM4DKZRQMVRDAZRTHEYTMNJZMJRDSZTDHBQTSMJSGMYDONLCMVQTONJRGY2Q____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:6d0c440a7dc648816fcd4885b9cc85f0eb0f391659bb9fc8a9123075bea75165
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUOLDGU3WINTGMM4DCYJZHE3WEMDEGZSTSYLDMMZTEZLCGUZGGOLEGIYGIMRWGUZTANBYMRRGCZJQMVSTSYJZME3GKODEMNSWKYZZMQZA____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:9c57d6fc81a997b0d6e9acc32eb52c9d20d2653048dbae0ee9a9a6e8dceec9d2
+                      - name: RELATED_IMAGE_che_plugin_sidecar_plugin_registry_image_IBZWQYJSGU3DUYTCGQYDIZTGMFQTCMRVGY2WEZLCGEZGENDDMQ4DCNRQMNTGCM3GMYZWKZRTMJSTIMRQGQZTAYJWGU3DEZRRMZSTIOBWGM4WGYTGGFTA____
+                        value: quay.io/eclipse/che-plugin-sidecar@sha256:bb404ffaa12565beb12b4cd8160cfa3ff3ef3be420430a6562f1fe48639cbf1f
+                      - name: RELATED_IMAGE_che_theia_plugin_registry_image_IBZWQYJSGU3DUZBUMMYDGNBTGIZDOOJSMFTGEYZZG5STMN3BMEYWEZJYGQYTCNZZGI2TEMRVGBQTSNDBGNQWEYRTMVQTKYTBGIYWGZRQMJRDGMZWGM2A____
+                        value: quay.io/eclipse/che-theia@sha256:d4c034322792afbc97e67aa1be841179252250a94a3abb3ea5ba21cf0bb33634
+                      - name: RELATED_IMAGE_che_machine_exec_plugin_registry_image_IBZWQYJSGU3DUYRTGJTDMYTGME2DKNTEGFQTKNJVMM2DOMDDGRSDIZTGMEZWCMBQGBQTONRXMVTDINRSME2WCOBVHE2DCMLEHBQTEZDCG43DSMTBMFSQ____
+                        value: quay.io/eclipse/che-machine-exec@sha256:b32f6bfa456d1a555c470c4d4ffa3a000a767ef462a5a859411d8a2db7692aae
+                      - name: RELATED_IMAGE_che_theia_endpoint_runtime_binary_plugin_registry_image_IBZWQYJSGU3DUZJTGAYTCNBWGU4GEZJVGM3WMYZVG44GKZTEMEYGKZDEGU3TMMDDGAZDIZTCGE2TSNRZGVQTIMZXMVTGEM3BMQ3TQZJWMJTDOYZWGE2Q____
+                        value: quay.io/eclipse/che-theia-endpoint-runtime-binary@sha256:e30114658be537fc578efda0edd5760c024fb159695a437efb3ad78e6bf7c615
+                      - name: RELATED_IMAGE_che_editor_jupyter_plugin_registry_image_IBZWQYJSGU3DUOBTGQZTSYLFHFSWIY3BMEZWCOJXGUZTMNZUGIZTCNLBG44TCMTGHEZWKNBZHFTDIOJYGQ3WIYJQHE2GGNBYGAYDGMLFMFSTIYTBGQ3Q____
+                        value: index.docker.io/ksmster/che-editor-jupyter@sha256:83439ae9edcaa3a97536742315a7912f93e499f49847da094c480031eae4ba47
+                      - name: RELATED_IMAGE_dirigible_openshift_plugin_registry_image_IBZWQYJSGU3DUMZTGY2TMMZVMQYWKMBUGAZTMOJXMRSWCMBWG42GEYTCMRRTONBZMM2GEZJSMRRDEOJYGE4GCOJTMI4GKMLFGUZWGM3DGUYTINBRGEZQ____
+                        value: index.docker.io/dirigiblelabs/dirigible-openshift@sha256:3365635d1e0403697dea0674bbbdc749c4be2db29818a93b8e1e53c3c5144113
+                      - name: RELATED_IMAGE_che_editor_intellij_community_plugin_registry_image_IBZWQYJSGU3DUMRZGAZDKZDCHA2TSMRWHBTDKZDDMYZDCYTBGZSWENDFGI4DINZUGRRDKM3DHEZGINTEGIZTKMJUMU2TMNLBGAZDCMJWGA3GMNRYGYZQ____
+                        value: quay.io/che-incubator/che-editor-intellij-community@sha256:29025db859268f5dcf21ba6eb4e284744b53c92d6d23514e565a0211606f6863
+                      - name: RELATED_IMAGE_eclipse_broadway_plugin_registry_image_IBZWQYJSGU3DUNJXMM4DEY3EHAYDMYJVGZTDMOLBME4DMNRTMY3DQNBQGVSDANZXHBRDMMRYMEZDSYJWGRTGEMJWHA4DCYRRGFRWKOLGGQ4DIZDEME3Q____
+                        value: index.docker.io/wsskeleton/eclipse-broadway@sha256:57c82cd806a56f69aa8663f68405d0778b628a29a64fb16881b11ce9f484dda7
+                      - name: RELATED_IMAGE_code_server_plugin_registry_image_IBZWQYJSGU3DUZLGGA3TEOBRGAYDIOJQHFRGEMTDGIZDQNBSGJSGMMTFHE4WCNLCME2WKNBVGBTGGZJXGU2DMYRYMZQTCOBWHA2TEZRSGNRGMNRXGUYQ____
+                        value: index.docker.io/codercom/code-server@sha256:ef07281004909bb2c228422df2e99a5ba5e450fce7546b8fa186852f23bf6751
+                      - name: RELATED_IMAGE_che_buildah_base_plugin_registry_image_IBZWQYJSGU3DUNBRG4ZDAM3EHA3DEOLFMRSDSMTGGE4DOYLGMQZWKYTCGNSDQZDDGI4DGMZYMQZTIOBQHFSWENZVMZTGGMTFGA4GCNBQGBTDQZBVGZRA____
+                        value: quay.io/eclipse/che-buildah-base@sha256:417203d8629edd92f187afd3ebb3d8dc28338d34809eb75ffc2e08a400f8d56b
+                      - name: RELATED_IMAGE_che_sidecar_workspace_data_sync_plugin_registry_image_IBZWQYJSGU3DUOBYMQYDCMRVHAZTOZBVME2TOY3CGI2GEYRTMVSDQMLFGZQTQZRUGEYTSYJVGA2DGYRXHEZDMYTEGJRGIMBRG4YTAOBVGRRTINDGGEYA____
+                        value: quay.io/eclipse/che-sidecar-workspace-data-sync@sha256:88d0125837d5a57cb24bb3ed81e6a8f4119a5043b7926bd2bd01710854c44f10
+                      - name: RELATED_IMAGE_che_buildkit_base_plugin_registry_image_IBZWQYJSGU3DUZLGMZQTSODEMQZGGZLEGMYGENJSGBRDENLBMZTGMMLBHA4DAZBRGIYWGZRWMIZWMODBMI2DEYJVGE2DSZLBMRQTINTCME3TSM3DMU4Q____
+                        value: quay.io/eclipse/che-buildkit-base@sha256:effa98dd2ced30b520b25afff1a880d121cf6b3f8ab42a5149eada46ba793ce9
+                      - name: RELATED_IMAGE_che__centos__mongodb_36_centos7_devfile_registry_image_NRQXIZLTOQWWCOJRGVSGEN3CMVRWCOBXGE4TQZTDMQ3TQNRQGA4DMOJYHFTGKODBGMZDOYJRME2GMNRVGA4DAMRVMI3DIYLCGI4GMY3DG42DEM3CGI______
+                        value: quay.io/eclipse/che--centos--mongodb-36-centos7@sha256:a915db7beca87198fcd7860086989fe8a327a1a4f6508025b64ab28fcc7423b2
+                      - name: RELATED_IMAGE_che__centos__mysql_57_centos7_devfile_registry_image_NRQXIZLTOQWWKMBYMVSTIZBUGNRDOMZVGY3DANZWHA2WENRZMJSGKNRTGM2WKMRXMNTDEMDDGAZDAZRTGQ2WENTDGZRTKOJUGAYDCOBTHA4DENZWGQ______
+                        value: quay.io/eclipse/che--centos--mysql-57-centos7@sha256:e08ee4d43b7356607685b69bde6335e27cf20c020f345b6c6c59400183882764
+                      - name: RELATED_IMAGE_che_cpp_rhel7_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-cpp-rhel7@sha256:1a570e20e7f9b9c46cfbab829838cca8e5082ab54a350b8b1947499128f0c4e6
+                      - name: RELATED_IMAGE_che_dotnet_2_2_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-dotnet-2.2@sha256:0e7dac64a33f1f55eed9a5399ac257e0b895fcf5fb4379d3e9620f53e06f1505
+                      - name: RELATED_IMAGE_che_dotnet_3_1_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-dotnet-3.1@sha256:f1c062b0db7e624f2e964e088ccaa9024d04bca04c5cc5a1dae3bdb760394206
+                      - name: RELATED_IMAGE_che_golang_1_14_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-golang-1.14@sha256:f7cae5166c979ae1503478b96cc5d48a9a06aaabcc550a9d843e10a515630fa5
+                      - name: RELATED_IMAGE_che_java11_gradle_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-java11-gradle@sha256:92ab2b6c9ac4fdcbd9db5705399b548a59533762e3c48c5c317432b30c36b454
+                      - name: RELATED_IMAGE_che_java11_maven_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-java11-maven@sha256:78c2225c0451272d463ad5d6e006ef9fab0086a9bcc0d7d359d9ebefeeff1a28
+                      - name: RELATED_IMAGE_che_java8_maven_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-java8-maven@sha256:2a1b7f4cfae15a6e44bd4729723c723f00e9dabaae98db7edb50aef5105ee690
+                      - name: RELATED_IMAGE_che_nodejs10_community_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-nodejs10-community@sha256:87800ae68d0624911408381b744742cff842f7479360ebae3b9fb65b8f326223
+                      - name: RELATED_IMAGE_che_nodejs10_ubi_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-nodejs10-ubi@sha256:61cd13dfbb4579f1d4ebd3b4fdfb2922ab35055eb9c590e27c888d8b491fdfdb
+                      - name: RELATED_IMAGE_che_nodejs12_community_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-nodejs12-community@sha256:a10407084cb0e418d4d303235463cd78081636c4691518f465284aeaac2bcf23
+                      - name: RELATED_IMAGE_che_nodejs8_centos_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-nodejs8-centos@sha256:557d886c11e3840da9938e7f529f5119d6bdf91f25e40b0bb6af9411791fa3ca
+                      - name: RELATED_IMAGE_che_php_7_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-php-7@sha256:676cf5f744eb7f2404a37953ed28d7e840878277e73f02ff031f99ef37f90d07
+                      - name: RELATED_IMAGE_che_python_3_8_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-python-3.8@sha256:20ebf82e73785a0844b6511e2981da19a55410d3a6aa07a2dc0b3dcfb3838694
+                      - name: RELATED_IMAGE_che_quarkus_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-quarkus@sha256:95c5f1587c7ce719ec8e64b90b69948ea04a57eb8f384c66b0561347e4cb83a2
+                      - name: RELATED_IMAGE_che_rust_1_39_devfile_registry_image_G4XDGMZOGI______
+                        value: quay.io/eclipse/che-rust-1.39@sha256:d033f2366e22214660561a0279f3ff55edc6cb60a57178c87022f09699a7b2e7
+                      - name: RELATED_IMAGE_ubi8_minimal_devfile_registry_image_HAXDG___
+                        value: registry.access.redhat.com/ubi8-minimal@sha256:2f6b88c037c0503da7704bccd3fc73cb76324101af39ad28f16460e7bce98324
+                      - name: RELATED_IMAGE_ubi_minimal_devfile_registry_image_
+                        value: registry.access.redhat.com/ubi8/ubi-minimal@sha256:b6b0c30bb747dfacee216e5ae2ad02adb18920d8f744c04f29354278e19df2a9
+                    image: quay.io/eclipse/che-operator@sha256:4bb9f5859f2094d13c42b27f3aa41daac750725f611690aa083a265b3f760a16
+                    imagePullPolicy: IfNotPresent
+                    livenessProbe:
+                      failureThreshold: 10
+                      httpGet:
+                        path: /healthz
+                        port: 6789
+                      initialDelaySeconds: 15
+                      periodSeconds: 10
+                      successThreshold: 1
+                      timeoutSeconds: 5
+                    name: che-operator
+                    ports:
+                      - containerPort: 60000
+                        name: metrics
+                    readinessProbe:
+                      exec:
+                        command:
+                          - stat
+                          - /tmp/operator-sdk-ready
+                      failureThreshold: 10
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                      successThreshold: 1
+                      timeoutSeconds: 5
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 256Mi
+                      requests:
+                        cpu: 100m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      privileged: false
+                      readOnlyRootFilesystem: false
+                      runAsNonRoot: true
+                  - args:
+                      - --enable-leader-election
+                      - --metrics-addr
+                      - "0"
+                    command:
+                      - /usr/local/bin/devworkspace-che-operator
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: devworkspace-che-operator
+                      - name: MAX_CONCURRENT_RECONCILES
+                        value: "1"
+                      - name: CONTROLLER_SERVICE_ACCOUNT_NAME
+                        value: che-operator
+                      - name: RELATED_IMAGE_gateway
+                        value: quay.io/eclipse/che--traefik@sha256:6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
+                      - name: RELATED_IMAGE_gateway_configurer
+                        value: quay.io/che-incubator/configbump@sha256:175ff2ba1bd74429de192c0a9facf39da5699c6da9f151bd461b3dc8624dd532
+                    image: quay.io/che-incubator/devworkspace-che-operator@sha256:b01a7eae740850593a8f8a1fec8421c7ac7eef46eeacffb1ed635c68d384f2ca
+                    imagePullPolicy: IfNotPresent
+                    name: devworkspace-che-operator
+                    resources:
+                      limits:
+                        cpu: 100m
+                        memory: 256Mi
+                      requests:
+                        cpu: 100m
+                        memory: 32Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      privileged: false
+                      readOnlyRootFilesystem: false
+                      runAsNonRoot: true
+                hostIPC: false
+                hostNetwork: false
+                hostPID: false
+                restartPolicy: Always
+                serviceAccountName: che-operator
+                terminationGracePeriodSeconds: 20
+      permissions:
+        - rules:
+            - apiGroups:
+                - extensions
+              resources:
+                - ingresses
+              verbs:
+                - '*'
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - '*'
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+                - routes/custom-host
+              verbs:
+                - '*'
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - roles
+                - rolebindings
+              verbs:
+                - '*'
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterroles
+                - clusterrolebindings
+              verbs:
+                - '*'
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - services
+                - serviceaccounts
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                - pods/exec
+                - pods/log
+              verbs:
+                - '*'
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - get
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - create
+            - apiGroups:
+                - org.eclipse.che
+              resources:
+                - checlusters
+                - checlusters/status
+                - checlusters/finalizers
+                - checlusterbackups
+                - checlusterbackups/status
+                - checlusterbackups/finalizers
+                - checlusterrestores
+                - checlusterrestores/status
+                - backupserverconfigurations
+                - backupserverconfigurations/status
+                - chebackupserverconfigurations
+              verbs:
+                - '*'
+            - apiGroups:
+                - metrics.k8s.io
+              resources:
+                - pods
+                - nodes
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - che.eclipse.org
+              resources:
+                - kubernetesimagepullers
+              verbs:
+                - '*'
+            - apiGroups:
+                - operators.coreos.com
+              resources:
+                - subscriptions
+                - clusterserviceversions
+                - operatorgroups
+              verbs:
+                - '*'
+            - apiGroups:
+                - packages.operators.coreos.com
+              resources:
+                - packagemanifests
+              verbs:
+                - get
+                - list
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps/status
+              verbs:
+                - get
+                - update
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+          serviceAccountName: che-operator
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+  keywords:
+    - workspaces
+    - devtools
+    - developer
+    - ide
+    - java
+  links:
+    - name: Product Page
+      url: http://www.eclipse.org/che
+    - name: Documentation
+      url: https://www.eclipse.org/che/docs
+    - name: Operator GitHub Repo
+      url: https://github.com/eclipse-che/che-operator
+  maintainers:
+    - email: dfestal@redhat.com
+      name: David Festal
+  maturity: stable
+  provider:
+    name: Eclipse Foundation
+  version: 7.33.2-all-namespaces
+  relatedImages:
+    - name: che-operator-7.33.2
+      image: quay.io/eclipse/che-operator@sha256:4bb9f5859f2094d13c42b27f3aa41daac750725f611690aa083a265b3f760a16
+      # tag: quay.io/eclipse/che-operator:7.33.2
+    - name: devworkspace-che-operator-v7.33.2
+      image: quay.io/che-incubator/devworkspace-che-operator@sha256:b01a7eae740850593a8f8a1fec8421c7ac7eef46eeacffb1ed635c68d384f2ca
+      # tag: quay.io/che-incubator/devworkspace-che-operator:v7.33.2
+    - name: configbump-0.1.4
+      image: quay.io/che-incubator/configbump@sha256:175ff2ba1bd74429de192c0a9facf39da5699c6da9f151bd461b3dc8624dd532
+      # tag: quay.io/che-incubator/configbump:0.1.4
+    - name: header-rewrite-proxy-latest
+      image: quay.io/che-incubator/header-rewrite-proxy@sha256:bd7873b8feef35f218f54c6251ea224bea2c8bf202a328230019a0ba2941245d
+      # tag: quay.io/che-incubator/header-rewrite-proxy:latest
+    - name: devworkspace-controller-v0.7.2
+      image: quay.io/devfile/devworkspace-controller@sha256:f17dad6df3f2f0f7b245e05677293bef1d35a17e0349002f9e47816de03c0cdd
+      # tag: quay.io/devfile/devworkspace-controller:v0.7.2
+    - name: che--centos--postgresql-96-centos7-9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
+      image: quay.io/eclipse/che--centos--postgresql-96-centos7@sha256:b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
+      # tag: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
+    - name: che--traefik-v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
+      image: quay.io/eclipse/che--traefik@sha256:6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
+      # tag: quay.io/eclipse/che--traefik:v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
+    - name: che-backup-server-rest-eeacd92
+      image: quay.io/eclipse/che-backup-server-rest@sha256:24983ce54474bbe87239f23773faeb59a5471a6a4b20e731518ad5738bfea6d7
+      # tag: quay.io/eclipse/che-backup-server-rest:eeacd92
+    - name: che-dashboard-7.33.2
+      image: quay.io/eclipse/che-dashboard@sha256:ff44e57ddf7dbc76cca375979401539c3bd9a6a1db37d55f1c6b05e4d70f6ee1
+      # tag: quay.io/eclipse/che-dashboard:7.33.2
+    - name: che-devfile-registry-7.33.2
+      image: quay.io/eclipse/che-devfile-registry@sha256:7a144352a496073d14a4983141cffda1aeb489d361b21aba4020f581445c9bb2
+      # tag: quay.io/eclipse/che-devfile-registry:7.33.2
+    - name: che-jwtproxy-0.10.0
+      image: quay.io/eclipse/che-jwtproxy@sha256:881d1c91e7f5840314f25104ef5c0acee59ed484a5f9ef39daf3008725ea1033
+      # tag: quay.io/eclipse/che-jwtproxy:0.10.0
+    - name: che-keycloak-7.33.2
+      image: quay.io/eclipse/che-keycloak@sha256:aba3d3db727ae11ad52fa121a2e465f2af48edeb2320f954ea5681290702b50d
+      # tag: quay.io/eclipse/che-keycloak:7.33.2
+    - name: che-plugin-artifacts-broker-v3.4.0
+      image: quay.io/eclipse/che-plugin-artifacts-broker@sha256:4891a6e19be9eae59372f4b31144653f9bd1284e0301ecfe896a099ca6a12b58
+      # tag: quay.io/eclipse/che-plugin-artifacts-broker:v3.4.0
+    - name: che-plugin-metadata-broker-v3.4.0
+      image: quay.io/eclipse/che-plugin-metadata-broker@sha256:df1ea2eadb28dbc97761adf4ea984af5ca941025a67b39c6abe373816a84bba9
+      # tag: quay.io/eclipse/che-plugin-metadata-broker:v3.4.0
+    - name: che-plugin-registry-7.33.2
+      image: quay.io/eclipse/che-plugin-registry@sha256:fe85f41baa90d8e1f8ba06cfbbe1247b65c7be10ede32755860d8fe01183895e
+      # tag: quay.io/eclipse/che-plugin-registry:7.33.2
+    - name: che-server-7.33.2
+      image: quay.io/eclipse/che-server@sha256:b4be065bff9c71b17804a0a8ede43982d2dc44bc555c4c8a90fd63e22b23f555
+      # tag: quay.io/eclipse/che-server:7.33.2
+    - name: origin-kube-rbac-proxy-4.7
+      image: quay.io/openshift/origin-kube-rbac-proxy@sha256:fcce680899a37d6bdc621a58b6da0587d01cbb49a2d7b713e0d606dffc9f685a
+      # tag: quay.io/openshift/origin-kube-rbac-proxy:4.7
+    - name: origin-oauth-proxy-4.7
+      image: quay.io/openshift/origin-oauth-proxy@sha256:82719931600d90a8c3eb26b1632cc99020bc12921fa6ad13c9d4929fe2d0f025
+      # tag: quay.io/openshift/origin-oauth-proxy:4.7
+    - name: ubi8-minimal-8.4-205
+      image: registry.access.redhat.com/ubi8-minimal@sha256:b6b0c30bb747dfacee216e5ae2ad02adb18920d8f744c04f29354278e19df2a9
+      # tag: registry.access.redhat.com/ubi8-minimal:8.4-205
+    - name: che-plugin-sidecar-@sha256:4bce2e39fee6b9e4a8b4e8681380ce2462674597a48b81c131cbbf055dd5d0c3
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:4bce2e39fee6b9e4a8b4e8681380ce2462674597a48b81c131cbbf055dd5d0c3
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:4bce2e39fee6b9e4a8b4e8681380ce2462674597a48b81c131cbbf055dd5d0c3
+    - name: che-plugin-sidecar-@sha256:7cf6f00d3f2daf04675618c408e08f019f25b91ec08d279094fddb01f559502b
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:7cf6f00d3f2daf04675618c408e08f019f25b91ec08d279094fddb01f559502b
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:7cf6f00d3f2daf04675618c408e08f019f25b91ec08d279094fddb01f559502b
+    - name: che-plugin-sidecar-@sha256:2e2b35fb33c78738368427b0b14a4659b6b03113d887472c445ae615d9761d39
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:2e2b35fb33c78738368427b0b14a4659b6b03113d887472c445ae615d9761d39
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:2e2b35fb33c78738368427b0b14a4659b6b03113d887472c445ae615d9761d39
+    - name: che-plugin-sidecar-@sha256:ae5124e3198ac6977ca973aaf4885a14e800d647c96a23d15a2b6babbe8fef2a
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:ae5124e3198ac6977ca973aaf4885a14e800d647c96a23d15a2b6babbe8fef2a
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:ae5124e3198ac6977ca973aaf4885a14e800d647c96a23d15a2b6babbe8fef2a
+    - name: che-plugin-sidecar-@sha256:2e49fafb9aa6519fc63019a72a4526222b6905ed01dc484c3e9f5131ae00b546
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:2e49fafb9aa6519fc63019a72a4526222b6905ed01dc484c3e9f5131ae00b546
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:2e49fafb9aa6519fc63019a72a4526222b6905ed01dc484c3e9f5131ae00b546
+    - name: che-plugin-sidecar-@sha256:7919d965a77f1ec969e073a1cc86686f92e99fc53a0b0c8d2eb13aea61c63467
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:7919d965a77f1ec969e073a1cc86686f92e99fc53a0b0c8d2eb13aea61c63467
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:7919d965a77f1ec969e073a1cc86686f92e99fc53a0b0c8d2eb13aea61c63467
+    - name: che-plugin-sidecar-@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:d565b98f110efe4246fe1f25ee62d74d70f4f999e4679e8f7085f18b1711f76d
+    - name: che-plugin-sidecar-@sha256:8615a29435b0256bffaf85ab2cf9327b059f14eaa6614346dfd51e3a6dd9f041
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:8615a29435b0256bffaf85ab2cf9327b059f14eaa6614346dfd51e3a6dd9f041
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:8615a29435b0256bffaf85ab2cf9327b059f14eaa6614346dfd51e3a6dd9f041
+    - name: che-plugin-sidecar-@sha256:55703ae5faebedee56fdce3879fa2281cc260488d8a488ff77ed3d40f778ddf7
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:55703ae5faebedee56fdce3879fa2281cc260488d8a488ff77ed3d40f778ddf7
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:55703ae5faebedee56fdce3879fa2281cc260488d8a488ff77ed3d40f778ddf7
+    - name: che-plugin-sidecar-@sha256:699a8fda67babcc1faedcf2e4ab22f6cf0cf6ad08c41c293983b81691c59ae4d
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:699a8fda67babcc1faedcf2e4ab22f6cf0cf6ad08c41c293983b81691c59ae4d
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:699a8fda67babcc1faedcf2e4ab22f6cf0cf6ad08c41c293983b81691c59ae4d
+    - name: che-plugin-sidecar-@sha256:974dd0a5ab7e075d7d344af2e8e2a2f80a069e8a5a4c9ffc2a57e421b62aa17a
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:974dd0a5ab7e075d7d344af2e8e2a2f80a069e8a5a4c9ffc2a57e421b62aa17a
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:974dd0a5ab7e075d7d344af2e8e2a2f80a069e8a5a4c9ffc2a57e421b62aa17a
+    - name: che-plugin-sidecar-@sha256:8297fb1732d87d56a0aa4c69105e7bcf4b500e40bb16446d6286c07b884eb73d
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:8297fb1732d87d56a0aa4c69105e7bcf4b500e40bb16446d6286c07b884eb73d
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:8297fb1732d87d56a0aa4c69105e7bcf4b500e40bb16446d6286c07b884eb73d
+    - name: che-plugin-sidecar-@sha256:095c24055033e219d5a9f6fe9835b79c5d3416f0dfbb228d295713e81d27c661
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:095c24055033e219d5a9f6fe9835b79c5d3416f0dfbb228d295713e81d27c661
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:095c24055033e219d5a9f6fe9835b79c5d3416f0dfbb228d295713e81d27c661
+    - name: che-plugin-sidecar-@sha256:56e7960857886a05fc459ed6e73a0a386f145a2474c228c2b7ccb97a1d18b4df
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:56e7960857886a05fc459ed6e73a0a386f145a2474c228c2b7ccb97a1d18b4df
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:56e7960857886a05fc459ed6e73a0a386f145a2474c228c2b7ccb97a1d18b4df
+    - name: che-plugin-sidecar-@sha256:db86c92418b9f40b2654b8fc473073569e0dc8a01d7adc31c9925e5469d2b114
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:db86c92418b9f40b2654b8fc473073569e0dc8a01d7adc31c9925e5469d2b114
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:db86c92418b9f40b2654b8fc473073569e0dc8a01d7adc31c9925e5469d2b114
+    - name: mta-vscode-extension-@sha256:4513d38220c65bd5494486a9d017928e8f1f5e1a25e76c41d3b12973ef088bb8
+      image: quay.io/windupeng/mta-vscode-extension@sha256:4513d38220c65bd5494486a9d017928e8f1f5e1a25e76c41d3b12973ef088bb8
+      # tag: quay.io/windupeng/mta-vscode-extension@sha256:4513d38220c65bd5494486a9d017928e8f1f5e1a25e76c41d3b12973ef088bb8
+    - name: che-plugin-sidecar-@sha256:502abcf6599fdadabef289dcadc5c32ca622fa02b73a72b113ca1e5e5b179375
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:502abcf6599fdadabef289dcadc5c32ca622fa02b73a72b113ca1e5e5b179375
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:502abcf6599fdadabef289dcadc5c32ca622fa02b73a72b113ca1e5e5b179375
+    - name: che-plugin-sidecar-@sha256:f398e3ffd5200c56bf56a6f7f9e8db4aa3f639a6125850f169414528260dce8a
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:f398e3ffd5200c56bf56a6f7f9e8db4aa3f639a6125850f169414528260dce8a
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:f398e3ffd5200c56bf56a6f7f9e8db4aa3f639a6125850f169414528260dce8a
+    - name: che-plugin-sidecar-@sha256:e374ec367447afea9b12f5a8f6690a6f993526408a3731f522a53e5d0bfc287f
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:e374ec367447afea9b12f5a8f6690a6f993526408a3731f522a53e5d0bfc287f
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:e374ec367447afea9b12f5a8f6690a6f993526408a3731f522a53e5d0bfc287f
+    - name: che-plugin-sidecar-@sha256:2cb4f70edbcdab3b279dae53b6a753d63fee03bcae3d2a385e24f25e695c03df
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:2cb4f70edbcdab3b279dae53b6a753d63fee03bcae3d2a385e24f25e695c03df
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:2cb4f70edbcdab3b279dae53b6a753d63fee03bcae3d2a385e24f25e695c03df
+    - name: che-plugin-sidecar-@sha256:4fdb04026cbeddbfe53184afcd6fc5cb6132a22be5810b13d38a125afd083221
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:4fdb04026cbeddbfe53184afcd6fc5cb6132a22be5810b13d38a125afd083221
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:4fdb04026cbeddbfe53184afcd6fc5cb6132a22be5810b13d38a125afd083221
+    - name: che-plugin-sidecar-@sha256:491c62a3ac775d5426d72a59ac18bdd50f5f5d61d07fbfb34e0cd7fed3d4da21
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:491c62a3ac775d5426d72a59ac18bdd50f5f5d61d07fbfb34e0cd7fed3d4da21
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:491c62a3ac775d5426d72a59ac18bdd50f5f5d61d07fbfb34e0cd7fed3d4da21
+    - name: che-plugin-sidecar-@sha256:597a30c9c3fc7dbbfb9e08b1bb2179d8eb062ad148480ff32489b4f01ec675f4
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:597a30c9c3fc7dbbfb9e08b1bb2179d8eb062ad148480ff32489b4f01ec675f4
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:597a30c9c3fc7dbbfb9e08b1bb2179d8eb062ad148480ff32489b4f01ec675f4
+    - name: che-plugin-sidecar-@sha256:6d0c440a7dc648816fcd4885b9cc85f0eb0f391659bb9fc8a9123075bea75165
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:6d0c440a7dc648816fcd4885b9cc85f0eb0f391659bb9fc8a9123075bea75165
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:6d0c440a7dc648816fcd4885b9cc85f0eb0f391659bb9fc8a9123075bea75165
+    - name: che-plugin-sidecar-@sha256:9c57d6fc81a997b0d6e9acc32eb52c9d20d2653048dbae0ee9a9a6e8dceec9d2
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:9c57d6fc81a997b0d6e9acc32eb52c9d20d2653048dbae0ee9a9a6e8dceec9d2
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:9c57d6fc81a997b0d6e9acc32eb52c9d20d2653048dbae0ee9a9a6e8dceec9d2
+    - name: che-plugin-sidecar-@sha256:bb404ffaa12565beb12b4cd8160cfa3ff3ef3be420430a6562f1fe48639cbf1f
+      image: quay.io/eclipse/che-plugin-sidecar@sha256:bb404ffaa12565beb12b4cd8160cfa3ff3ef3be420430a6562f1fe48639cbf1f
+      # tag: quay.io/eclipse/che-plugin-sidecar@sha256:bb404ffaa12565beb12b4cd8160cfa3ff3ef3be420430a6562f1fe48639cbf1f
+    - name: che-theia-@sha256:d4c034322792afbc97e67aa1be841179252250a94a3abb3ea5ba21cf0bb33634
+      image: quay.io/eclipse/che-theia@sha256:d4c034322792afbc97e67aa1be841179252250a94a3abb3ea5ba21cf0bb33634
+      # tag: quay.io/eclipse/che-theia@sha256:d4c034322792afbc97e67aa1be841179252250a94a3abb3ea5ba21cf0bb33634
+    - name: che-machine-exec-@sha256:b32f6bfa456d1a555c470c4d4ffa3a000a767ef462a5a859411d8a2db7692aae
+      image: quay.io/eclipse/che-machine-exec@sha256:b32f6bfa456d1a555c470c4d4ffa3a000a767ef462a5a859411d8a2db7692aae
+      # tag: quay.io/eclipse/che-machine-exec@sha256:b32f6bfa456d1a555c470c4d4ffa3a000a767ef462a5a859411d8a2db7692aae
+    - name: che-theia-endpoint-runtime-binary-@sha256:e30114658be537fc578efda0edd5760c024fb159695a437efb3ad78e6bf7c615
+      image: quay.io/eclipse/che-theia-endpoint-runtime-binary@sha256:e30114658be537fc578efda0edd5760c024fb159695a437efb3ad78e6bf7c615
+      # tag: quay.io/eclipse/che-theia-endpoint-runtime-binary@sha256:e30114658be537fc578efda0edd5760c024fb159695a437efb3ad78e6bf7c615
+    - name: che-editor-jupyter-@sha256:83439ae9edcaa3a97536742315a7912f93e499f49847da094c480031eae4ba47
+      image: index.docker.io/ksmster/che-editor-jupyter@sha256:83439ae9edcaa3a97536742315a7912f93e499f49847da094c480031eae4ba47
+      # tag: index.docker.io/ksmster/che-editor-jupyter@sha256:83439ae9edcaa3a97536742315a7912f93e499f49847da094c480031eae4ba47
+    - name: dirigible-openshift-@sha256:3365635d1e0403697dea0674bbbdc749c4be2db29818a93b8e1e53c3c5144113
+      image: index.docker.io/dirigiblelabs/dirigible-openshift@sha256:3365635d1e0403697dea0674bbbdc749c4be2db29818a93b8e1e53c3c5144113
+      # tag: index.docker.io/dirigiblelabs/dirigible-openshift@sha256:3365635d1e0403697dea0674bbbdc749c4be2db29818a93b8e1e53c3c5144113
+    - name: che-editor-intellij-community-@sha256:29025db859268f5dcf21ba6eb4e284744b53c92d6d23514e565a0211606f6863
+      image: quay.io/che-incubator/che-editor-intellij-community@sha256:29025db859268f5dcf21ba6eb4e284744b53c92d6d23514e565a0211606f6863
+      # tag: quay.io/che-incubator/che-editor-intellij-community@sha256:29025db859268f5dcf21ba6eb4e284744b53c92d6d23514e565a0211606f6863
+    - name: eclipse-broadway-@sha256:57c82cd806a56f69aa8663f68405d0778b628a29a64fb16881b11ce9f484dda7
+      image: index.docker.io/wsskeleton/eclipse-broadway@sha256:57c82cd806a56f69aa8663f68405d0778b628a29a64fb16881b11ce9f484dda7
+      # tag: index.docker.io/wsskeleton/eclipse-broadway@sha256:57c82cd806a56f69aa8663f68405d0778b628a29a64fb16881b11ce9f484dda7
+    - name: code-server-@sha256:ef07281004909bb2c228422df2e99a5ba5e450fce7546b8fa186852f23bf6751
+      image: index.docker.io/codercom/code-server@sha256:ef07281004909bb2c228422df2e99a5ba5e450fce7546b8fa186852f23bf6751
+      # tag: index.docker.io/codercom/code-server@sha256:ef07281004909bb2c228422df2e99a5ba5e450fce7546b8fa186852f23bf6751
+    - name: che-buildah-base-@sha256:417203d8629edd92f187afd3ebb3d8dc28338d34809eb75ffc2e08a400f8d56b
+      image: quay.io/eclipse/che-buildah-base@sha256:417203d8629edd92f187afd3ebb3d8dc28338d34809eb75ffc2e08a400f8d56b
+      # tag: quay.io/eclipse/che-buildah-base@sha256:417203d8629edd92f187afd3ebb3d8dc28338d34809eb75ffc2e08a400f8d56b
+    - name: che-sidecar-workspace-data-sync-@sha256:88d0125837d5a57cb24bb3ed81e6a8f4119a5043b7926bd2bd01710854c44f10
+      image: quay.io/eclipse/che-sidecar-workspace-data-sync@sha256:88d0125837d5a57cb24bb3ed81e6a8f4119a5043b7926bd2bd01710854c44f10
+      # tag: quay.io/eclipse/che-sidecar-workspace-data-sync@sha256:88d0125837d5a57cb24bb3ed81e6a8f4119a5043b7926bd2bd01710854c44f10
+    - name: che-buildkit-base-@sha256:effa98dd2ced30b520b25afff1a880d121cf6b3f8ab42a5149eada46ba793ce9
+      image: quay.io/eclipse/che-buildkit-base@sha256:effa98dd2ced30b520b25afff1a880d121cf6b3f8ab42a5149eada46ba793ce9
+      # tag: quay.io/eclipse/che-buildkit-base@sha256:effa98dd2ced30b520b25afff1a880d121cf6b3f8ab42a5149eada46ba793ce9
+    - name: che--centos--mongodb-36-centos7-latest-a915db7beca87198fcd7860086989fe8a327a1a4f6508025b64ab28fcc7423b2
+      image: quay.io/eclipse/che--centos--mongodb-36-centos7@sha256:a915db7beca87198fcd7860086989fe8a327a1a4f6508025b64ab28fcc7423b2
+      # tag: quay.io/eclipse/che--centos--mongodb-36-centos7:latest-a915db7beca87198fcd7860086989fe8a327a1a4f6508025b64ab28fcc7423b2
+    - name: che--centos--mysql-57-centos7-latest-e08ee4d43b7356607685b69bde6335e27cf20c020f345b6c6c59400183882764
+      image: quay.io/eclipse/che--centos--mysql-57-centos7@sha256:e08ee4d43b7356607685b69bde6335e27cf20c020f345b6c6c59400183882764
+      # tag: quay.io/eclipse/che--centos--mysql-57-centos7:latest-e08ee4d43b7356607685b69bde6335e27cf20c020f345b6c6c59400183882764
+    - name: che-cpp-rhel7-7.33.2
+      image: quay.io/eclipse/che-cpp-rhel7@sha256:1a570e20e7f9b9c46cfbab829838cca8e5082ab54a350b8b1947499128f0c4e6
+      # tag: quay.io/eclipse/che-cpp-rhel7:7.33.2
+    - name: che-dotnet-2.2-7.33.2
+      image: quay.io/eclipse/che-dotnet-2.2@sha256:0e7dac64a33f1f55eed9a5399ac257e0b895fcf5fb4379d3e9620f53e06f1505
+      # tag: quay.io/eclipse/che-dotnet-2.2:7.33.2
+    - name: che-dotnet-3.1-7.33.2
+      image: quay.io/eclipse/che-dotnet-3.1@sha256:f1c062b0db7e624f2e964e088ccaa9024d04bca04c5cc5a1dae3bdb760394206
+      # tag: quay.io/eclipse/che-dotnet-3.1:7.33.2
+    - name: che-golang-1.14-7.33.2
+      image: quay.io/eclipse/che-golang-1.14@sha256:f7cae5166c979ae1503478b96cc5d48a9a06aaabcc550a9d843e10a515630fa5
+      # tag: quay.io/eclipse/che-golang-1.14:7.33.2
+    - name: che-java11-gradle-7.33.2
+      image: quay.io/eclipse/che-java11-gradle@sha256:92ab2b6c9ac4fdcbd9db5705399b548a59533762e3c48c5c317432b30c36b454
+      # tag: quay.io/eclipse/che-java11-gradle:7.33.2
+    - name: che-java11-maven-7.33.2
+      image: quay.io/eclipse/che-java11-maven@sha256:78c2225c0451272d463ad5d6e006ef9fab0086a9bcc0d7d359d9ebefeeff1a28
+      # tag: quay.io/eclipse/che-java11-maven:7.33.2
+    - name: che-java8-maven-7.33.2
+      image: quay.io/eclipse/che-java8-maven@sha256:2a1b7f4cfae15a6e44bd4729723c723f00e9dabaae98db7edb50aef5105ee690
+      # tag: quay.io/eclipse/che-java8-maven:7.33.2
+    - name: che-nodejs10-community-7.33.2
+      image: quay.io/eclipse/che-nodejs10-community@sha256:87800ae68d0624911408381b744742cff842f7479360ebae3b9fb65b8f326223
+      # tag: quay.io/eclipse/che-nodejs10-community:7.33.2
+    - name: che-nodejs10-ubi-7.33.2
+      image: quay.io/eclipse/che-nodejs10-ubi@sha256:61cd13dfbb4579f1d4ebd3b4fdfb2922ab35055eb9c590e27c888d8b491fdfdb
+      # tag: quay.io/eclipse/che-nodejs10-ubi:7.33.2
+    - name: che-nodejs12-community-7.33.2
+      image: quay.io/eclipse/che-nodejs12-community@sha256:a10407084cb0e418d4d303235463cd78081636c4691518f465284aeaac2bcf23
+      # tag: quay.io/eclipse/che-nodejs12-community:7.33.2
+    - name: che-nodejs8-centos-7.33.2
+      image: quay.io/eclipse/che-nodejs8-centos@sha256:557d886c11e3840da9938e7f529f5119d6bdf91f25e40b0bb6af9411791fa3ca
+      # tag: quay.io/eclipse/che-nodejs8-centos:7.33.2
+    - name: che-php-7-7.33.2
+      image: quay.io/eclipse/che-php-7@sha256:676cf5f744eb7f2404a37953ed28d7e840878277e73f02ff031f99ef37f90d07
+      # tag: quay.io/eclipse/che-php-7:7.33.2
+    - name: che-python-3.8-7.33.2
+      image: quay.io/eclipse/che-python-3.8@sha256:20ebf82e73785a0844b6511e2981da19a55410d3a6aa07a2dc0b3dcfb3838694
+      # tag: quay.io/eclipse/che-python-3.8:7.33.2
+    - name: che-quarkus-7.33.2
+      image: quay.io/eclipse/che-quarkus@sha256:95c5f1587c7ce719ec8e64b90b69948ea04a57eb8f384c66b0561347e4cb83a2
+      # tag: quay.io/eclipse/che-quarkus:7.33.2
+    - name: che-rust-1.39-7.33.2
+      image: quay.io/eclipse/che-rust-1.39@sha256:d033f2366e22214660561a0279f3ff55edc6cb60a57178c87022f09699a7b2e7
+      # tag: quay.io/eclipse/che-rust-1.39:7.33.2
+    - name: ubi8-minimal-8.3
+      image: registry.access.redhat.com/ubi8-minimal@sha256:2f6b88c037c0503da7704bccd3fc73cb76324101af39ad28f16460e7bce98324
+      # tag: registry.access.redhat.com/ubi8-minimal:8.3
+    - name: ubi-minimal-
+      image: registry.access.redhat.com/ubi8/ubi-minimal@sha256:b6b0c30bb747dfacee216e5ae2ad02adb18920d8f744c04f29354278e19df2a9
+      # tag: registry.access.redhat.com/ubi8/ubi-minimal

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org.eclipse.che_chebackupserverconfigurations_crd.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org.eclipse.che_chebackupserverconfigurations_crd.yaml
@@ -1,0 +1,150 @@
+#
+#  Copyright (c) 2019-2021 Red Hat, Inc.
+#    This program and the accompanying materials are made
+#    available under the terms of the Eclipse Public License 2.0
+#    which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Contributors:
+#    Red Hat, Inc. - initial API and implementation
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: chebackupserverconfigurations.org.eclipse.che
+spec:
+  group: org.eclipse.che
+  names:
+    kind: CheBackupServerConfiguration
+    listKind: CheBackupServerConfigurationList
+    plural: chebackupserverconfigurations
+    singular: chebackupserverconfiguration
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: The `CheBackupServerConfiguration` custom resource allows defining
+          and managing Eclipse Che Backup Server Configurations
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CheBackupServerConfigurationSpec defines the desired state
+              of CheBackupServerConfiguration Only one type of backup server is allowed
+              to be configured per CR.
+            properties:
+              awss3:
+                description: Amazon S3 or compatible alternatives.
+                properties:
+                  awsAccessKeySecretRef:
+                    description: Reference to secret that contains awsAccessKeyId
+                      and awsSecretAccessKey keys.
+                    type: string
+                  hostname:
+                    description: Server hostname, defaults to 's3.amazonaws.com'.
+                      Might be customized in case of alternative server.
+                    type: string
+                  port:
+                    description: Backup server port. Usually default value is used.
+                      Might be customized in case of alternative server.
+                    type: integer
+                  protocol:
+                    description: Protocol to use when connection to the server. Might
+                      be customized in case of alternative server.
+                    type: string
+                  repositoryPasswordSecretRef:
+                    description: Holds reference to a secret with restic repository
+                      password under 'repo-password' field to encrypt / decrypt its
+                      content.
+                    type: string
+                  repositoryPath:
+                    description: Bucket name and repository, e.g. bucket/repo
+                    type: string
+                required:
+                - awsAccessKeySecretRef
+                - repositoryPasswordSecretRef
+                - repositoryPath
+                type: object
+              rest:
+                description: Rest backup server configuration.
+                properties:
+                  credentialsSecretRef:
+                    description: Secret that contains username and password fields
+                      to login into restic server. Note, each repository is encrypted
+                      with own password. See ResticRepoPasswordSecretRef field.
+                    type: string
+                  hostname:
+                    description: Backup server host
+                    type: string
+                  port:
+                    description: Backup server port
+                    type: integer
+                  protocol:
+                    description: Protocol to use when connection to the server Defaults
+                      to https.
+                    type: string
+                  repositoryPasswordSecretRef:
+                    description: Holds reference to a secret with restic repository
+                      password under 'repo-password' field to encrypt / decrypt its
+                      content.
+                    type: string
+                  repositoryPath:
+                    description: Restic repository path
+                    type: string
+                required:
+                - hostname
+                - repositoryPasswordSecretRef
+                type: object
+              sftp:
+                description: Sftp backup server configuration.
+                properties:
+                  hostname:
+                    description: Backup server host
+                    type: string
+                  port:
+                    description: Backup server port
+                    type: integer
+                  repositoryPasswordSecretRef:
+                    description: Holds reference to a secret with restic repository
+                      password under 'repo-password' field to encrypt / decrypt its
+                      content.
+                    type: string
+                  repositoryPath:
+                    description: Restic repository path, relative or absolute, e.g.
+                      /srv/repo
+                    type: string
+                  sshKeySecretRef:
+                    description: Private ssh key under 'ssh-privatekey' field for
+                      passwordless login
+                    type: string
+                  username:
+                    description: User login on the remote server
+                    type: string
+                required:
+                - hostname
+                - repositoryPasswordSecretRef
+                - repositoryPath
+                - sshKeySecretRef
+                - username
+                type: object
+            type: object
+          status:
+            description: CheBackupServerConfigurationStatus defines the observed state
+              of CheBackupServerConfiguration
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org.eclipse.che_chebackupserverconfigurations_crd.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org.eclipse.che_chebackupserverconfigurations_crd.yaml
@@ -1,16 +1,9 @@
-#
-#  Copyright (c) 2019-2021 Red Hat, Inc.
-#    This program and the accompanying materials are made
-#    available under the terms of the Eclipse Public License 2.0
-#    which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-#  SPDX-License-Identifier: EPL-2.0
-#
-#  Contributors:
-#    Red Hat, Inc. - initial API and implementation
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   name: chebackupserverconfigurations.org.eclipse.che
 spec:
   group: org.eclipse.che
@@ -24,49 +17,35 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: The `CheBackupServerConfiguration` custom resource allows defining
-          and managing Eclipse Che Backup Server Configurations
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: CheBackupServerConfigurationSpec defines the desired state
-              of CheBackupServerConfiguration Only one type of backup server is allowed
-              to be configured per CR.
+            description: CheBackupServerConfigurationSpec defines the desired state of CheBackupServerConfiguration Only one type of backup server is allowed to be configured per CR.
             properties:
               awss3:
                 description: Amazon S3 or compatible alternatives.
                 properties:
                   awsAccessKeySecretRef:
-                    description: Reference to secret that contains awsAccessKeyId
-                      and awsSecretAccessKey keys.
+                    description: Reference to secret that contains awsAccessKeyId and awsSecretAccessKey keys.
                     type: string
                   hostname:
-                    description: Server hostname, defaults to 's3.amazonaws.com'.
-                      Might be customized in case of alternative server.
+                    description: Server hostname, defaults to 's3.amazonaws.com'. Might be customized in case of alternative server.
                     type: string
                   port:
-                    description: Backup server port. Usually default value is used.
-                      Might be customized in case of alternative server.
+                    description: Backup server port. Usually default value is used. Might be customized in case of alternative server.
                     type: integer
                   protocol:
-                    description: Protocol to use when connection to the server. Might
-                      be customized in case of alternative server.
+                    description: Protocol to use when connection to the server. Might be customized in case of alternative server.
                     type: string
                   repositoryPasswordSecretRef:
-                    description: Holds reference to a secret with restic repository
-                      password under 'repo-password' field to encrypt / decrypt its
-                      content.
+                    description: Holds reference to a secret with restic repository password under 'repo-password' field to encrypt / decrypt its content.
                     type: string
                   repositoryPath:
                     description: Bucket name and repository, e.g. bucket/repo
@@ -80,9 +59,7 @@ spec:
                 description: Rest backup server configuration.
                 properties:
                   credentialsSecretRef:
-                    description: Secret that contains username and password fields
-                      to login into restic server. Note, each repository is encrypted
-                      with own password. See ResticRepoPasswordSecretRef field.
+                    description: Secret that contains username and password fields to login into restic server. Note, each repository is encrypted with own password. See ResticRepoPasswordSecretRef field.
                     type: string
                   hostname:
                     description: Backup server host
@@ -91,13 +68,10 @@ spec:
                     description: Backup server port
                     type: integer
                   protocol:
-                    description: Protocol to use when connection to the server Defaults
-                      to https.
+                    description: Protocol to use when connection to the server Defaults to https.
                     type: string
                   repositoryPasswordSecretRef:
-                    description: Holds reference to a secret with restic repository
-                      password under 'repo-password' field to encrypt / decrypt its
-                      content.
+                    description: Holds reference to a secret with restic repository password under 'repo-password' field to encrypt / decrypt its content.
                     type: string
                   repositoryPath:
                     description: Restic repository path
@@ -116,17 +90,13 @@ spec:
                     description: Backup server port
                     type: integer
                   repositoryPasswordSecretRef:
-                    description: Holds reference to a secret with restic repository
-                      password under 'repo-password' field to encrypt / decrypt its
-                      content.
+                    description: Holds reference to a secret with restic repository password under 'repo-password' field to encrypt / decrypt its content.
                     type: string
                   repositoryPath:
-                    description: Restic repository path, relative or absolute, e.g.
-                      /srv/repo
+                    description: Restic repository path, relative or absolute, e.g. /srv/repo
                     type: string
                   sshKeySecretRef:
-                    description: Private ssh key under 'ssh-privatekey' field for
-                      passwordless login
+                    description: Private ssh key under 'ssh-privatekey' field for passwordless login
                     type: string
                   username:
                     description: User login on the remote server
@@ -140,11 +110,16 @@ spec:
                 type: object
             type: object
           status:
-            description: CheBackupServerConfigurationStatus defines the observed state
-              of CheBackupServerConfiguration
+            description: CheBackupServerConfigurationStatus defines the observed state of CheBackupServerConfiguration
             type: object
         type: object
     served: true
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterbackups_crd.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterbackups_crd.yaml
@@ -1,0 +1,77 @@
+#
+#  Copyright (c) 2019-2021 Red Hat, Inc.
+#    This program and the accompanying materials are made
+#    available under the terms of the Eclipse Public License 2.0
+#    which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Contributors:
+#    Red Hat, Inc. - initial API and implementation
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: checlusterbackups.org.eclipse.che
+spec:
+  group: org.eclipse.che
+  names:
+    kind: CheClusterBackup
+    listKind: CheClusterBackupList
+    plural: checlusterbackups
+    singular: checlusterbackup
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: The `CheClusterBackup` custom resource allows defining and managing
+          Eclipse Che backup
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CheClusterBackupSpec defines the desired state of CheClusterBackup
+            properties:
+              backupServerConfigRef:
+                description: Name of custom resource with a backup server configuration
+                  to use for this backup. Note, UseInternalBackupServer field can
+                  configure internal backup server automatically.
+                type: string
+              useInternalBackupServer:
+                description: Automatically setup pod with REST backup server and use
+                  the server in this configuration. Note, this flag takes precedence
+                  and will overwrite existing backup server configuration.
+                type: boolean
+            type: object
+          status:
+            description: CheClusterBackupStatus defines the observed state of CheClusterBackup
+            properties:
+              message:
+                description: Message explaining the state of the backup or an error
+                  message
+                type: string
+              snapshotId:
+                description: Last backup snapshot ID
+                type: string
+              stage:
+                description: Describes backup progress
+                type: string
+              state:
+                description: 'Backup progress state: InProgress, Failed, Succeeded'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterbackups_crd.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterbackups_crd.yaml
@@ -1,16 +1,9 @@
-#
-#  Copyright (c) 2019-2021 Red Hat, Inc.
-#    This program and the accompanying materials are made
-#    available under the terms of the Eclipse Public License 2.0
-#    which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-#  SPDX-License-Identifier: EPL-2.0
-#
-#  Contributors:
-#    Red Hat, Inc. - initial API and implementation
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   name: checlusterbackups.org.eclipse.che
 spec:
   group: org.eclipse.che
@@ -24,18 +17,12 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: The `CheClusterBackup` custom resource allows defining and managing
-          Eclipse Che backup
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -43,22 +30,17 @@ spec:
             description: CheClusterBackupSpec defines the desired state of CheClusterBackup
             properties:
               backupServerConfigRef:
-                description: Name of custom resource with a backup server configuration
-                  to use for this backup. Note, UseInternalBackupServer field can
-                  configure internal backup server automatically.
+                description: Name of custom resource with a backup server configuration to use for this backup. Note, UseInternalBackupServer field can configure internal backup server automatically.
                 type: string
               useInternalBackupServer:
-                description: Automatically setup pod with REST backup server and use
-                  the server in this configuration. Note, this flag takes precedence
-                  and will overwrite existing backup server configuration.
+                description: Automatically setup pod with REST backup server and use the server in this configuration. Note, this flag takes precedence and will overwrite existing backup server configuration.
                 type: boolean
             type: object
           status:
             description: CheClusterBackupStatus defines the observed state of CheClusterBackup
             properties:
               message:
-                description: Message explaining the state of the backup or an error
-                  message
+                description: Message explaining the state of the backup or an error message
                 type: string
               snapshotId:
                 description: Last backup snapshot ID
@@ -75,3 +57,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterrestores_crd.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterrestores_crd.yaml
@@ -1,0 +1,72 @@
+#
+#  Copyright (c) 2019-2021 Red Hat, Inc.
+#    This program and the accompanying materials are made
+#    available under the terms of the Eclipse Public License 2.0
+#    which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Contributors:
+#    Red Hat, Inc. - initial API and implementation
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: checlusterrestores.org.eclipse.che
+spec:
+  group: org.eclipse.che
+  names:
+    kind: CheClusterRestore
+    listKind: CheClusterRestoreList
+    plural: checlusterrestores
+    singular: checlusterrestore
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: The `CheClusterRestore` custom resource allows defining and managing
+          Eclipse Che restore
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CheClusterRestoreSpec defines the desired state of CheClusterRestore
+            properties:
+              backupServerConfigRef:
+                description: Name of custom resource with a backup server configuration
+                  to use for this restore. Can be omitted if only one server configuration
+                  object exists within the namespace.
+                type: string
+              snapshotId:
+                description: Snapshot ID to restore from. If omitted, latest snapshot
+                  will be used.
+                type: string
+            type: object
+          status:
+            description: CheClusterRestoreStatus defines the observed state of CheClusterRestore
+            properties:
+              message:
+                description: Restore result or error message
+                type: string
+              stage:
+                description: Describes phase of restore progress
+                type: string
+              state:
+                description: 'Restore progress state: InProgress, Failed, Succeeded'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterrestores_crd.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterrestores_crd.yaml
@@ -1,16 +1,9 @@
-#
-#  Copyright (c) 2019-2021 Red Hat, Inc.
-#    This program and the accompanying materials are made
-#    available under the terms of the Eclipse Public License 2.0
-#    which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-#  SPDX-License-Identifier: EPL-2.0
-#
-#  Contributors:
-#    Red Hat, Inc. - initial API and implementation
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   name: checlusterrestores.org.eclipse.che
 spec:
   group: org.eclipse.che
@@ -24,18 +17,12 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: The `CheClusterRestore` custom resource allows defining and managing
-          Eclipse Che restore
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -43,13 +30,10 @@ spec:
             description: CheClusterRestoreSpec defines the desired state of CheClusterRestore
             properties:
               backupServerConfigRef:
-                description: Name of custom resource with a backup server configuration
-                  to use for this restore. Can be omitted if only one server configuration
-                  object exists within the namespace.
+                description: Name of custom resource with a backup server configuration to use for this restore. Can be omitted if only one server configuration object exists within the namespace.
                 type: string
               snapshotId:
-                description: Snapshot ID to restore from. If omitted, latest snapshot
-                  will be used.
+                description: If omitted, latest snapshot will be used.
                 type: string
             type: object
           status:
@@ -70,3 +54,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
@@ -1,0 +1,1093 @@
+#
+#  Copyright (c) 2019-2021 Red Hat, Inc.
+#    This program and the accompanying materials are made
+#    available under the terms of the Eclipse Public License 2.0
+#    which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Contributors:
+#    Red Hat, Inc. - initial API and implementation
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: checlusters.org.eclipse.che
+spec:
+  group: org.eclipse.che
+  names:
+    kind: CheCluster
+    listKind: CheClusterList
+    plural: checlusters
+    singular: checluster
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: The `CheCluster` custom resource allows defining and managing
+            a Che server installation
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired configuration of the Che installation. Based on
+                these settings, the  Operator automatically creates and maintains
+                several ConfigMaps that will contain the appropriate environment variables
+                the various components of the Che installation. These generated ConfigMaps
+                must NOT be updated manually.
+              properties:
+                auth:
+                  description: Configuration settings related to the Authentication
+                    used by the Che installation.
+                  properties:
+                    externalIdentityProvider:
+                      description: 'Instructs the Operator on whether or not to deploy
+                        a dedicated Identity Provider (Keycloak or RH SSO instance).
+                        Instructs the Operator on whether to deploy a dedicated Identity
+                        Provider (Keycloak or RH-SSO instance). By default, a dedicated
+                        Identity Provider server is deployed as part of the Che installation.
+                        When `externalIdentityProvider` is `true`, no dedicated identity
+                        provider will be deployed by the Operator and you will need
+                        to provide details about the external identity provider you
+                        are about to use. See also all the other fields starting with:
+                        `identityProvider`.'
+                      type: boolean
+                    gatewayAuthenticationSidecarImage:
+                      description: Gateway sidecar responsible for authentication
+                        when NativeUserMode is enabled. See link:https://github.com/oauth2-proxy/oauth2-proxy[oauth2-proxy]
+                        or link:https://github.com/openshift/oauth-proxy[openshift/oauth-proxy].
+                      type: string
+                    gatewayAuthorizationSidecarImage:
+                      description: Gateway sidecar responsible for authorization when
+                        NativeUserMode is enabled. See link:https://github.com/brancz/kube-rbac-proxy[kube-rbac-proxy]
+                        or link:https://github.com/openshift/kube-rbac-proxy[openshift/kube-rbac-proxy]
+                      type: string
+                    gatewayHeaderRewriteSidecarImage:
+                      description: Header Rewrite Proxy sidecar image is used to properly
+                        set authorization header. See link:https://github.com/che-incubator/header-rewrite-proxy[header-rewrite-proxy]
+                      type: string
+                    identityProviderAdminUserName:
+                      description: Overrides the name of the Identity Provider administrator
+                        user. Defaults to `admin`.
+                      type: string
+                    identityProviderClientId:
+                      description: Name of a Identity provider, Keycloak or RH-SSO,
+                        `client-id` that is used for Che. Override this when an external
+                        Identity Provider is in use. See the `externalIdentityProvider`
+                        field. When omitted or left blank, it is set to the value
+                        of the `flavour` field suffixed with `-public`.
+                      type: string
+                    identityProviderContainerResources:
+                      description: Identity provider container custom settings.
+                      properties:
+                        limits:
+                          description: Limits describes the maximum amount of compute
+                            resources allowed.
+                          properties:
+                            cpu:
+                              description: CPU, in cores. (500m = .5 cores)
+                              type: string
+                            memory:
+                              description: Memory, in bytes. (500Gi = 500GiB = 500
+                                * 1024 * 1024 * 1024)
+                              type: string
+                          type: object
+                        request:
+                          description: Requests describes the minimum amount of compute
+                            resources required.
+                          properties:
+                            cpu:
+                              description: CPU, in cores. (500m = .5 cores)
+                              type: string
+                            memory:
+                              description: Memory, in bytes. (500Gi = 500GiB = 500
+                                * 1024 * 1024 * 1024)
+                              type: string
+                          type: object
+                      type: object
+                    identityProviderImage:
+                      description: Overrides the container image used in the Identity
+                        Provider, Keycloak or RH-SSO, deployment. This includes the
+                        image tag. Omit it or leave it empty to use the default container
+                        image provided by the Operator.
+                      type: string
+                    identityProviderImagePullPolicy:
+                      description: Overrides the image pull policy used in the Identity
+                        Provider, Keycloak or RH-SSO, deployment. Default value is
+                        `Always` for `nightly` or `latest` images, and `IfNotPresent`
+                        in other cases.
+                      type: string
+                    identityProviderIngress:
+                      description: Ingress custom settings.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Unstructured key value map stored with a resource
+                            that may be set by external tools to store and retrieve
+                            arbitrary metadata.
+                          type: object
+                        labels:
+                          description: Comma separated list of labels that can be
+                            used to organize and categorize objects by scoping and
+                            selecting.
+                          type: string
+                      type: object
+                    identityProviderPassword:
+                      description: Overrides the password of Keycloak administrator
+                        user. Override this when an external Identity Provider is
+                        in use. See the `externalIdentityProvider` field. When omitted
+                        or left blank, it is set to an auto-generated password.
+                      type: string
+                    identityProviderPostgresPassword:
+                      description: Password for a Identity Provider, Keycloak or RH-SSO,
+                        to connect to the database. Override this when an external
+                        Identity Provider is in use. See the `externalIdentityProvider`
+                        field. When omitted or left blank, it is set to an auto-generated
+                        password.
+                      type: string
+                    identityProviderPostgresSecret:
+                      description: 'The secret that contains `password` for the Identity
+                        Provider, Keycloak or RH-SSO, to connect to the database.
+                        When the secret is defined, the `identityProviderPostgresPassword`
+                        is ignored. When the value is omitted or left blank, the one
+                        of following scenarios applies: 1. `identityProviderPostgresPassword`
+                        is defined, then it will be used to connect to the database.
+                        2. `identityProviderPostgresPassword` is not defined, then
+                        a new secret with the name `che-identity-postgres-secret`
+                        will be created with an auto-generated value for `password`.'
+                      type: string
+                    identityProviderRealm:
+                      description: Name of a Identity provider, Keycloak or RH-SSO,
+                        realm that is used for Che. Override this when an external
+                        Identity Provider is in use. See the `externalIdentityProvider`
+                        field. When omitted or left blank, it is set to the value
+                        of the `flavour` field.
+                      type: string
+                    identityProviderRoute:
+                      description: Route custom settings.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Unstructured key value map stored with a resource
+                            that may be set by external tools to store and retrieve
+                            arbitrary metadata.
+                          type: object
+                        domain:
+                          description: 'Operator uses the domain to generate a hostname
+                            for a route. In a conjunction with labels it creates a
+                            route, which is served by a non-default Ingress controller.
+                            The generated host name will follow this pattern: `<route-name>-<route-namespace>.<domain>`.'
+                          type: string
+                        labels:
+                          description: Comma separated list of labels that can be
+                            used to organize and categorize objects by scoping and
+                            selecting.
+                          type: string
+                      type: object
+                    identityProviderSecret:
+                      description: 'The secret that contains `user` and `password`
+                        for Identity Provider. When the secret is defined, the `identityProviderAdminUserName`
+                        and `identityProviderPassword` are ignored. When the value
+                        is omitted or left blank, the one of following scenarios applies:
+                        1. `identityProviderAdminUserName` and `identityProviderPassword`
+                        are defined, then they will be used. 2. `identityProviderAdminUserName`
+                        or `identityProviderPassword` are not defined, then a new
+                        secret with the name `che-identity-secret` will be created
+                        with default value `admin` for `user` and with an auto-generated
+                        value for `password`.'
+                      type: string
+                    identityProviderURL:
+                      description: Public URL of the Identity Provider server (Keycloak
+                        / RH-SSO server). Set this ONLY when a use of an external
+                        Identity Provider is needed. See the `externalIdentityProvider`
+                        field. By default, this will be automatically calculated and
+                        set by the Operator.
+                      type: string
+                    initialOpenShiftOAuthUser:
+                      description: For operating with the OpenShift OAuth authentication,
+                        create a new user account since the kubeadmin can not be used.
+                        If the value is true, then a new OpenShift OAuth user will
+                        be created for the HTPasswd identity provider. If the value
+                        is false and the user has already been created, then it will
+                        be removed. If value is an empty, then do nothing. The user's
+                        credentials are stored in the `openshift-oauth-user-credentials`
+                        secret in 'openshift-config' namespace by Operator. Note that
+                        this solution is Openshift 4 platform-specific.
+                      type: boolean
+                    nativeUserMode:
+                      description: Enables native user mode. Currently works only
+                        on OpenShift and DevWorkspace engine. Native User mode uses
+                        OpenShift OAuth directly as identity provider, without Keycloak.
+                      type: boolean
+                    oAuthClientName:
+                      description: Name of the OpenShift `OAuthClient` resource used
+                        to setup identity federation on the OpenShift side. Auto-generated
+                        when left blank. See also the `OpenShiftoAuth` field.
+                      type: string
+                    oAuthSecret:
+                      description: Name of the secret set in the OpenShift `OAuthClient`
+                        resource used to setup identity federation on the OpenShift
+                        side. Auto-generated when left blank. See also the `OAuthClientName`
+                        field.
+                      type: string
+                    openShiftoAuth:
+                      description: 'Enables the integration of the identity provider
+                        (Keycloak / RHSSO) with OpenShift OAuth. Empty value on OpenShift
+                        by default. This will allow users to directly login with their
+                        OpenShift user through the OpenShift login, and have their
+                        workspaces created under personal OpenShift namespaces. WARNING:
+                        the `kubeadmin` user is NOT supported, and logging through
+                        it will NOT allow accessing the Che Dashboard.'
+                      type: boolean
+                    updateAdminPassword:
+                      description: Forces the default `admin` Che user to update password
+                        on first login. Defaults to `false`.
+                      type: boolean
+                  type: object
+                database:
+                  description: Configuration settings related to the database used
+                    by the Che installation.
+                  properties:
+                    chePostgresContainerResources:
+                      description: PostgreSQL container custom settings
+                      properties:
+                        limits:
+                          description: Limits describes the maximum amount of compute
+                            resources allowed.
+                          properties:
+                            cpu:
+                              description: CPU, in cores. (500m = .5 cores)
+                              type: string
+                            memory:
+                              description: Memory, in bytes. (500Gi = 500GiB = 500
+                                * 1024 * 1024 * 1024)
+                              type: string
+                          type: object
+                        request:
+                          description: Requests describes the minimum amount of compute
+                            resources required.
+                          properties:
+                            cpu:
+                              description: CPU, in cores. (500m = .5 cores)
+                              type: string
+                            memory:
+                              description: Memory, in bytes. (500Gi = 500GiB = 500
+                                * 1024 * 1024 * 1024)
+                              type: string
+                          type: object
+                      type: object
+                    chePostgresDb:
+                      description: PostgreSQL database name that the Che server uses
+                        to connect to the DB. Defaults to `dbche`.
+                      type: string
+                    chePostgresHostName:
+                      description: PostgreSQL Database host name that the Che server
+                        uses to connect to. Defaults is `postgres`. Override this
+                        value ONLY when using an external database. See field `externalDb`.
+                        In the default case it will be automatically set by the Operator.
+                      type: string
+                    chePostgresPassword:
+                      description: PostgreSQL password that the Che server uses to
+                        connect to the DB. When omitted or left blank, it will be
+                        set to an automatically generated value.
+                      type: string
+                    chePostgresPort:
+                      description: PostgreSQL Database port that the Che server uses
+                        to connect to. Defaults to 5432. Override this value ONLY
+                        when using an external database. See field `externalDb`. In
+                        the default case it will be automatically set by the Operator.
+                      type: string
+                    chePostgresSecret:
+                      description: 'The secret that contains PostgreSQL`user` and
+                        `password` that the Che server uses to connect to the DB.
+                        When the secret is defined, the `chePostgresUser` and `chePostgresPassword`
+                        are ignored. When the value is omitted or left blank, the
+                        one of following scenarios applies: 1. `chePostgresUser` and
+                        `chePostgresPassword` are defined, then they will be used
+                        to connect to the DB. 2. `chePostgresUser` or `chePostgresPassword`
+                        are not defined, then a new secret with the name `che-postgres-secret`
+                        will be created with default value of `pgche` for `user` and
+                        with an auto-generated value for `password`.'
+                      type: string
+                    chePostgresUser:
+                      description: PostgreSQL user that the Che server uses to connect
+                        to the DB. Defaults to `pgche`.
+                      type: string
+                    externalDb:
+                      description: 'Instructs the Operator on whether to deploy a
+                        dedicated database. By default, a dedicated PostgreSQL database
+                        is deployed as part of the Che installation. When `externalDb`
+                        is `true`, no dedicated database will be deployed by the Operator
+                        and you will need to provide connection details to the external
+                        DB you are about to use. See also all the fields starting
+                        with: `chePostgres`.'
+                      type: boolean
+                    postgresImage:
+                      description: Overrides the container image used in the PostgreSQL
+                        database deployment. This includes the image tag. Omit it
+                        or leave it empty to use the default container image provided
+                        by the Operator.
+                      type: string
+                    postgresImagePullPolicy:
+                      description: Overrides the image pull policy used in the PostgreSQL
+                        database deployment. Default value is `Always` for `nightly`
+                        or `latest` images, and `IfNotPresent` in other cases.
+                      type: string
+                  type: object
+                devWorkspace:
+                  description: Dev Workspace operator configuration
+                  properties:
+                    controllerImage:
+                      description: Overrides the container image used in the DevWorkspace
+                        controller deployment. This includes the image tag. Omit it
+                        or leave it empty to use the default container image provided
+                        by the Operator.
+                      type: string
+                    enable:
+                      description: Deploys the DevWorkspace Operator in the cluster.
+                        Does nothing when a matching version of the Operator is already
+                        installed. Fails when a non-matching version of the Operator
+                        is already installed.
+                      type: boolean
+                  required:
+                    - enable
+                  type: object
+                imagePuller:
+                  description: Kubernetes Image Puller configuration
+                  properties:
+                    enable:
+                      description: Install and configure the Community Supported Kubernetes
+                        Image Puller Operator. When set to `true` and no spec is provided,
+                        it will create a default KubernetesImagePuller object to be
+                        managed by the Operator. When set to `false`, the KubernetesImagePuller
+                        object will be deleted, and the Operator will be uninstalled,
+                        regardless of whether a spec is provided. If the `spec.images`
+                        field is empty, a set of recommended workspace-related images
+                        will be automatically detected and pre-pulled after installation.
+                        Note that while this Operator and its behavior is community-supported,
+                        its payload may be commercially-supported for pulling commercially-supported
+                        images.
+                      type: boolean
+                    spec:
+                      description: A KubernetesImagePullerSpec to configure the image
+                        puller in the CheCluster
+                      properties:
+                        cachingCPULimit:
+                          type: string
+                        cachingCPURequest:
+                          type: string
+                        cachingIntervalHours:
+                          type: string
+                        cachingMemoryLimit:
+                          type: string
+                        cachingMemoryRequest:
+                          type: string
+                        configMapName:
+                          type: string
+                        daemonsetName:
+                          type: string
+                        deploymentName:
+                          type: string
+                        images:
+                          description: If empty, a set of recommended workspace-related
+                            images will be automatically detected and pre-pulled after
+                            installation.
+                          type: string
+                        nodeSelector:
+                          type: string
+                      type: object
+                  required:
+                    - enable
+                  type: object
+                k8s:
+                  description: Configuration settings specific to Che installations
+                    made on upstream Kubernetes.
+                  properties:
+                    ingressClass:
+                      description: 'Ingress class that will define the which controller
+                        will manage ingresses. Defaults to `nginx`. NB: This drives
+                        the `kubernetes.io/ingress.class` annotation on Che-related
+                        ingresses.'
+                      type: string
+                    ingressDomain:
+                      description: 'Global ingress domain for a Kubernetes cluster.
+                        This MUST be explicitly specified: there are no defaults.'
+                      type: string
+                    ingressStrategy:
+                      description: 'Strategy for ingress creation. Options are: `multi-host`
+                        (host is explicitly provided in ingress), `single-host` (host
+                        is provided, path-based rules) and `default-host` (no host
+                        is provided, path-based rules). Defaults to `multi-host` Deprecated
+                        in favor of `serverExposureStrategy` in the `server` section,
+                        which defines this regardless of the cluster type. When both
+                        are defined, the `serverExposureStrategy` option takes precedence.'
+                      type: string
+                    securityContextFsGroup:
+                      description: The FSGroup in which the Che Pod and workspace
+                        Pods containers runs in. Default value is `1724`.
+                      type: string
+                    securityContextRunAsUser:
+                      description: ID of the user the Che Pod and workspace Pods containers
+                        run as. Default value is `1724`.
+                      type: string
+                    singleHostExposureType:
+                      description: When the serverExposureStrategy is set to `single-host`,
+                        the way the server, registries and workspaces are exposed
+                        is further configured by this property. The possible values
+                        are `native`, which means that the server and workspaces are
+                        exposed using ingresses on K8s or `gateway` where the server
+                        and workspaces are exposed using a custom gateway based on
+                        link:https://doc.traefik.io/traefik/[Traefik]. All the endpoints
+                        whether backed by the ingress or gateway `route` always point
+                        to the subpaths on the same domain. Defaults to `native`.
+                      type: string
+                    tlsSecretName:
+                      description: Name of a secret that will be used to setup ingress
+                        TLS termination when TLS is enabled. When the field is empty
+                        string, the default cluster certificate will be used. See
+                        also the `tlsSupport` field.
+                      type: string
+                  type: object
+                metrics:
+                  description: Configuration settings related to the metrics collection
+                    used by the Che installation.
+                  properties:
+                    enable:
+                      description: Enables `metrics` the Che server endpoint. Default
+                        to `true`.
+                      type: boolean
+                  type: object
+                server:
+                  description: General configuration settings related to the Che server
+                    and the plugin and devfile registries
+                  properties:
+                    airGapContainerRegistryHostname:
+                      description: Optional host name, or URL, to an alternate container
+                        registry to pull images from. This value overrides the container
+                        registry host name defined in all the default container images
+                        involved in a Che deployment. This is particularly useful
+                        to install Che in a restricted environment.
+                      type: string
+                    airGapContainerRegistryOrganization:
+                      description: Optional repository name of an alternate container
+                        registry to pull images from. This value overrides the container
+                        registry organization defined in all the default container
+                        images involved in a Che deployment. This is particularly
+                        useful to install Eclipse Che in a restricted environment.
+                      type: string
+                    allowUserDefinedWorkspaceNamespaces:
+                      description: Deprecated. The value of this flag is ignored.
+                        Defines that a user is allowed to specify a Kubernetes namespace,
+                        or an OpenShift project, which differs from the default. It's
+                        NOT RECOMMENDED to set to `true` without OpenShift OAuth configured.
+                        The OpenShift infrastructure also uses this property.
+                      type: boolean
+                    cheClusterRoles:
+                      description: A comma-separated list of ClusterRoles that will
+                        be assigned to Che ServiceAccount. Be aware that the Che Operator
+                        has to already have all permissions in these ClusterRoles
+                        to grant them.
+                      type: string
+                    cheDebug:
+                      description: Enables the debug mode for Che server. Defaults
+                        to `false`.
+                      type: string
+                    cheFlavor:
+                      description: Specifies a variation of the installation. The
+                        options are `che` for upstream Che installations, or `codeready`
+                        for link:https://developers.redhat.com/products/codeready-workspaces/overview[CodeReady
+                        Workspaces] installation. Override the default value only
+                        on necessary occasions.
+                      type: string
+                    cheHost:
+                      description: Public host name of the installed Che server. When
+                        value is omitted, the value it will be automatically set by
+                        the Operator. See the `cheHostTLSSecret` field.
+                      type: string
+                    cheHostTLSSecret:
+                      description: Name of a secret containing certificates to secure
+                        ingress or route for the custom host name of the installed
+                        Che server. See the `cheHost` field.
+                      type: string
+                    cheImage:
+                      description: Overrides the container image used in Che deployment.
+                        This does NOT include the container image tag. Omit it or
+                        leave it empty to use the default container image provided
+                        by the Operator.
+                      type: string
+                    cheImagePullPolicy:
+                      description: Overrides the image pull policy used in Che deployment.
+                        Default value is `Always` for `nightly` or `latest` images,
+                        and `IfNotPresent` in other cases.
+                      type: string
+                    cheImageTag:
+                      description: Overrides the tag of the container image used in
+                        Che deployment. Omit it or leave it empty to use the default
+                        image tag provided by the Operator.
+                      type: string
+                    cheLogLevel:
+                      description: 'Log level for the Che server: `INFO` or `DEBUG`.
+                        Defaults to `INFO`.'
+                      type: string
+                    cheServerIngress:
+                      description: The Che server ingress custom settings.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Unstructured key value map stored with a resource
+                            that may be set by external tools to store and retrieve
+                            arbitrary metadata.
+                          type: object
+                        labels:
+                          description: Comma separated list of labels that can be
+                            used to organize and categorize objects by scoping and
+                            selecting.
+                          type: string
+                      type: object
+                    cheServerRoute:
+                      description: The Che server route custom settings.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Unstructured key value map stored with a resource
+                            that may be set by external tools to store and retrieve
+                            arbitrary metadata.
+                          type: object
+                        domain:
+                          description: 'Operator uses the domain to generate a hostname
+                            for a route. In a conjunction with labels it creates a
+                            route, which is served by a non-default Ingress controller.
+                            The generated host name will follow this pattern: `<route-name>-<route-namespace>.<domain>`.'
+                          type: string
+                        labels:
+                          description: Comma separated list of labels that can be
+                            used to organize and categorize objects by scoping and
+                            selecting.
+                          type: string
+                      type: object
+                    cheWorkspaceClusterRole:
+                      description: Custom cluster role bound to the user for the Che
+                        workspaces. The default roles are used when omitted or left
+                        blank.
+                      type: string
+                    customCheProperties:
+                      additionalProperties:
+                        type: string
+                      description: Map of additional environment variables that will
+                        be applied in the generated `che` ConfigMap to be used by
+                        the Che server, in addition to the values already generated
+                        from other fields of the `CheCluster` custom resource (CR).
+                        When `customCheProperties` contains a property that would
+                        be normally generated in `che` ConfigMap from other CR fields,
+                        the value defined in the `customCheProperties` is used instead.
+                      type: object
+                    dashboardCpuLimit:
+                      description: Overrides the CPU limit used in the dashboard deployment.
+                        In cores. (500m = .5 cores). Default to 500m.
+                      type: string
+                    dashboardCpuRequest:
+                      description: Overrides the CPU request used in the dashboard
+                        deployment. In cores. (500m = .5 cores). Default to 100m.
+                      type: string
+                    dashboardImage:
+                      description: Overrides the container image used in the dashboard
+                        deployment. This includes the image tag. Omit it or leave
+                        it empty to use the default container image provided by the
+                        Operator.
+                      type: string
+                    dashboardImagePullPolicy:
+                      description: Overrides the image pull policy used in the dashboard
+                        deployment. Default value is `Always` for `nightly` or `latest`
+                        images, and `IfNotPresent` in other cases.
+                      type: string
+                    dashboardIngress:
+                      description: Dashboard ingress custom settings.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Unstructured key value map stored with a resource
+                            that may be set by external tools to store and retrieve
+                            arbitrary metadata.
+                          type: object
+                        labels:
+                          description: Comma separated list of labels that can be
+                            used to organize and categorize objects by scoping and
+                            selecting.
+                          type: string
+                      type: object
+                    dashboardMemoryLimit:
+                      description: Overrides the memory limit used in the dashboard
+                        deployment. Defaults to 256Mi.
+                      type: string
+                    dashboardMemoryRequest:
+                      description: Overrides the memory request used in the dashboard
+                        deployment. Defaults to 16Mi.
+                      type: string
+                    dashboardRoute:
+                      description: Dashboard route custom settings.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Unstructured key value map stored with a resource
+                            that may be set by external tools to store and retrieve
+                            arbitrary metadata.
+                          type: object
+                        domain:
+                          description: 'Operator uses the domain to generate a hostname
+                            for a route. In a conjunction with labels it creates a
+                            route, which is served by a non-default Ingress controller.
+                            The generated host name will follow this pattern: `<route-name>-<route-namespace>.<domain>`.'
+                          type: string
+                        labels:
+                          description: Comma separated list of labels that can be
+                            used to organize and categorize objects by scoping and
+                            selecting.
+                          type: string
+                      type: object
+                    devfileRegistryCpuLimit:
+                      description: Overrides the CPU limit used in the devfile registry
+                        deployment. In cores. (500m = .5 cores). Default to 500m.
+                      type: string
+                    devfileRegistryCpuRequest:
+                      description: Overrides the CPU request used in the devfile registry
+                        deployment. In cores. (500m = .5 cores). Default to 100m.
+                      type: string
+                    devfileRegistryImage:
+                      description: Overrides the container image used in the devfile
+                        registry deployment. This includes the image tag. Omit it
+                        or leave it empty to use the default container image provided
+                        by the Operator.
+                      type: string
+                    devfileRegistryIngress:
+                      description: The devfile registry ingress custom settings.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Unstructured key value map stored with a resource
+                            that may be set by external tools to store and retrieve
+                            arbitrary metadata.
+                          type: object
+                        labels:
+                          description: Comma separated list of labels that can be
+                            used to organize and categorize objects by scoping and
+                            selecting.
+                          type: string
+                      type: object
+                    devfileRegistryMemoryLimit:
+                      description: Overrides the memory limit used in the devfile
+                        registry deployment. Defaults to 256Mi.
+                      type: string
+                    devfileRegistryMemoryRequest:
+                      description: Overrides the memory request used in the devfile
+                        registry deployment. Defaults to 16Mi.
+                      type: string
+                    devfileRegistryPullPolicy:
+                      description: Overrides the image pull policy used in the devfile
+                        registry deployment. Default value is `Always` for `nightly`
+                        or `latest` images, and `IfNotPresent` in other cases.
+                      type: string
+                    devfileRegistryRoute:
+                      description: The devfile registry route custom settings.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Unstructured key value map stored with a resource
+                            that may be set by external tools to store and retrieve
+                            arbitrary metadata.
+                          type: object
+                        domain:
+                          description: 'Operator uses the domain to generate a hostname
+                            for a route. In a conjunction with labels it creates a
+                            route, which is served by a non-default Ingress controller.
+                            The generated host name will follow this pattern: `<route-name>-<route-namespace>.<domain>`.'
+                          type: string
+                        labels:
+                          description: Comma separated list of labels that can be
+                            used to organize and categorize objects by scoping and
+                            selecting.
+                          type: string
+                      type: object
+                    devfileRegistryUrl:
+                      description: Deprecated in favor of `externalDevfileRegistries`
+                        fields.
+                      type: string
+                    externalDevfileRegistries:
+                      description: External devfile registries, that serves sample,
+                        ready-to-use devfiles. Configure this in addition to a dedicated
+                        devfile registry (when `externalDevfileRegistry` is `false`)
+                        or instead of it (when `externalDevfileRegistry` is `true`)
+                      items:
+                        description: Settings for a configuration of the external
+                          devfile registries.
+                        properties:
+                          url:
+                            description: Public URL of the devfile registry.
+                            type: string
+                        type: object
+                      type: array
+                    externalDevfileRegistry:
+                      description: Instructs the Operator on whether to deploy a dedicated
+                        devfile registry server. By default, a dedicated devfile registry
+                        server is started. When `externalDevfileRegistry` is `true`,
+                        no such dedicated server will be started by the Operator and
+                        configure at least one devfile registry with `externalDevfileRegistries`
+                        field.
+                      type: boolean
+                    externalPluginRegistry:
+                      description: Instructs the Operator on whether to deploy a dedicated
+                        plugin registry server. By default, a dedicated plugin registry
+                        server is started. When `externalPluginRegistry` is `true`,
+                        no such dedicated server will be started by the Operator and
+                        you will have to manually set the `pluginRegistryUrl` field.
+                      type: boolean
+                    gitSelfSignedCert:
+                      description: When enabled, the certificate from `che-git-self-signed-cert`
+                        ConfigMap will be propagated to the Che components and provide
+                        particular configuration for Git.
+                      type: boolean
+                    nonProxyHosts:
+                      description: 'List of hosts that will be reached directly, bypassing
+                        the proxy. Specify wild card domain use the following form
+                        `.<DOMAIN>` and `|` as delimiter, for example: `localhost|.my.host.com|123.42.12.32`
+                        Only use when configuring a proxy is required. Operator respects
+                        OpenShift cluster wide proxy configuration and no additional
+                        configuration is required, but defining `nonProxyHosts` in
+                        a custom resource leads to merging non proxy hosts lists from
+                        the cluster proxy configuration and ones defined in the custom
+                        resources. See the doc https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html.
+                        See also the `proxyURL` fields.'
+                      type: string
+                    pluginRegistryCpuLimit:
+                      description: Overrides the CPU limit used in the plugin registry
+                        deployment. In cores. (500m = .5 cores). Default to 500m.
+                      type: string
+                    pluginRegistryCpuRequest:
+                      description: Overrides the CPU request used in the plugin registry
+                        deployment. In cores. (500m = .5 cores). Default to 100m.
+                      type: string
+                    pluginRegistryImage:
+                      description: Overrides the container image used in the plugin
+                        registry deployment. This includes the image tag. Omit it
+                        or leave it empty to use the default container image provided
+                        by the Operator.
+                      type: string
+                    pluginRegistryIngress:
+                      description: Plugin registry ingress custom settings.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Unstructured key value map stored with a resource
+                            that may be set by external tools to store and retrieve
+                            arbitrary metadata.
+                          type: object
+                        labels:
+                          description: Comma separated list of labels that can be
+                            used to organize and categorize objects by scoping and
+                            selecting.
+                          type: string
+                      type: object
+                    pluginRegistryMemoryLimit:
+                      description: Overrides the memory limit used in the plugin registry
+                        deployment. Defaults to 256Mi.
+                      type: string
+                    pluginRegistryMemoryRequest:
+                      description: Overrides the memory request used in the plugin
+                        registry deployment. Defaults to 16Mi.
+                      type: string
+                    pluginRegistryPullPolicy:
+                      description: Overrides the image pull policy used in the plugin
+                        registry deployment. Default value is `Always` for `nightly`
+                        or `latest` images, and `IfNotPresent` in other cases.
+                      type: string
+                    pluginRegistryRoute:
+                      description: Plugin registry route custom settings.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Unstructured key value map stored with a resource
+                            that may be set by external tools to store and retrieve
+                            arbitrary metadata.
+                          type: object
+                        domain:
+                          description: 'Operator uses the domain to generate a hostname
+                            for a route. In a conjunction with labels it creates a
+                            route, which is served by a non-default Ingress controller.
+                            The generated host name will follow this pattern: `<route-name>-<route-namespace>.<domain>`.'
+                          type: string
+                        labels:
+                          description: Comma separated list of labels that can be
+                            used to organize and categorize objects by scoping and
+                            selecting.
+                          type: string
+                      type: object
+                    pluginRegistryUrl:
+                      description: Public URL of the plugin registry that serves sample
+                        ready-to-use devfiles. Set this ONLY when a use of an external
+                        devfile registry is needed. See the `externalPluginRegistry`
+                        field. By default, this will be automatically calculated by
+                        the Operator.
+                      type: string
+                    proxyPassword:
+                      description: Password of the proxy server. Only use when proxy
+                        configuration is required. See the `proxyURL`, `proxyUser`
+                        and `proxySecret` fields.
+                      type: string
+                    proxyPort:
+                      description: Port of the proxy server. Only use when configuring
+                        a proxy is required. See also the `proxyURL` and `nonProxyHosts`
+                        fields.
+                      type: string
+                    proxySecret:
+                      description: The secret that contains `user` and `password`
+                        for a proxy server. When the secret is defined, the `proxyUser`
+                        and `proxyPassword` are ignored.
+                      type: string
+                    proxyURL:
+                      description: URL (protocol+host name) of the proxy server. This
+                        drives the appropriate changes in the `JAVA_OPTS` and `https(s)_proxy`
+                        variables in the Che server and workspaces containers. Only
+                        use when configuring a proxy is required. Operator respects
+                        OpenShift cluster wide proxy configuration and no additional
+                        configuration is required, but defining `proxyUrl` in a custom
+                        resource leads to overrides the cluster proxy configuration
+                        with fields `proxyUrl`, `proxyPort`, `proxyUser` and `proxyPassword`
+                        from the custom resource. See the doc https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html.
+                        See also the `proxyPort` and `nonProxyHosts` fields.
+                      type: string
+                    proxyUser:
+                      description: User name of the proxy server. Only use when configuring
+                        a proxy is required. See also the `proxyURL`, `proxyPassword`
+                        and `proxySecret` fields.
+                      type: string
+                    selfSignedCert:
+                      description: Deprecated. The value of this flag is ignored.
+                        The Che Operator will automatically detect whether the router
+                        certificate is self-signed and propagate it to other components,
+                        such as the Che server.
+                      type: boolean
+                    serverCpuLimit:
+                      description: Overrides the CPU limit used in the Che server
+                        deployment In cores. (500m = .5 cores). Default to 1.
+                      type: string
+                    serverCpuRequest:
+                      description: Overrides the CPU request used in the Che server
+                        deployment In cores. (500m = .5 cores). Default to 100m.
+                      type: string
+                    serverExposureStrategy:
+                      description: Sets the server and workspaces exposure type. Possible
+                        values are `multi-host`, `single-host`, `default-host`. Defaults
+                        to `multi-host`, which creates a separate ingress, or OpenShift
+                        routes, for every required endpoint. `single-host` makes Che
+                        exposed on a single host name with workspaces exposed on subpaths.
+                        Read the docs to learn about the limitations of this approach.
+                        Also consult the `singleHostExposureType` property to further
+                        configure how the Operator and the Che server make that happen
+                        on Kubernetes. `default-host` exposes the Che server on the
+                        host of the cluster. Read the docs to learn about the limitations
+                        of this approach.
+                      type: string
+                    serverMemoryLimit:
+                      description: Overrides the memory limit used in the Che server
+                        deployment. Defaults to 1Gi.
+                      type: string
+                    serverMemoryRequest:
+                      description: Overrides the memory request used in the Che server
+                        deployment. Defaults to 512Mi.
+                      type: string
+                    serverTrustStoreConfigMapName:
+                      description: Name of the ConfigMap with public certificates
+                        to add to Java trust store of the Che server. This is often
+                        required when adding the OpenShift OAuth provider, which has
+                        HTTPS endpoint signed with self-signed cert. The Che server
+                        must be aware of its CA cert to be able to request it. This
+                        is disabled by default.
+                      type: string
+                    singleHostGatewayConfigMapLabels:
+                      additionalProperties:
+                        type: string
+                      description: The labels that need to be present in the ConfigMaps
+                        representing the gateway configuration.
+                      type: object
+                    singleHostGatewayConfigSidecarImage:
+                      description: The image used for the gateway sidecar that provides
+                        configuration to the gateway. Omit it or leave it empty to
+                        use the default container image provided by the Operator.
+                      type: string
+                    singleHostGatewayImage:
+                      description: The image used for the gateway in the single host
+                        mode. Omit it or leave it empty to use the default container
+                        image provided by the Operator.
+                      type: string
+                    tlsSupport:
+                      description: Deprecated. Instructs the Operator to deploy Che
+                        in TLS mode. This is enabled by default. Disabling TLS sometimes
+                        cause malfunction of some Che components.
+                      type: boolean
+                    useInternalClusterSVCNames:
+                      description: Use internal cluster SVC names to communicate between
+                        components to speed up the traffic and avoid proxy issues.
+                        The default value is `true`.
+                      type: boolean
+                    workspaceNamespaceDefault:
+                      description: Defines Kubernetes default namespace in which user's
+                        workspaces are created for a case when a user does not override
+                        it. It's possible to use `<username>`, `<userid>` and `<workspaceid>`
+                        placeholders, such as che-workspace-<username>. In that case,
+                        a new namespace will be created for each user or workspace.
+                      type: string
+                  type: object
+                storage:
+                  description: Configuration settings related to the persistent storage
+                    used by the Che installation.
+                  properties:
+                    postgresPVCStorageClassName:
+                      description: Storage class for the Persistent Volume Claim dedicated
+                        to the PostgreSQL database. When omitted or left blank, a
+                        default storage class is used.
+                      type: string
+                    preCreateSubPaths:
+                      description: Instructs the Che server to start a special Pod
+                        to pre-create a sub-path in the Persistent Volumes. Defaults
+                        to `false`, however it will need to enable it according to
+                        the configuration of your Kubernetes cluster.
+                      type: boolean
+                    pvcClaimSize:
+                      description: Size of the persistent volume claim for workspaces.
+                        Defaults to `10Gi`.
+                      type: string
+                    pvcJobsImage:
+                      description: Overrides the container image used to create sub-paths
+                        in the Persistent Volumes. This includes the image tag. Omit
+                        it or leave it empty to use the default container image provided
+                        by the Operator. See also the `preCreateSubPaths` field.
+                      type: string
+                    pvcStrategy:
+                      description: Persistent volume claim strategy for the Che server.
+                        This Can be:`common` (all workspaces PVCs in one volume),
+                        `per-workspace` (one PVC per workspace for all declared volumes)
+                        and `unique` (one PVC per declared volume). Defaults to `common`.
+                      type: string
+                    workspacePVCStorageClassName:
+                      description: Storage class for the Persistent Volume Claims
+                        dedicated to the Che workspaces. When omitted or left blank,
+                        a default storage class is used.
+                      type: string
+                  type: object
+              type: object
+            status:
+              description: CheClusterStatus defines the observed state of Che installation
+              properties:
+                cheClusterRunning:
+                  description: Status of a Che installation. Can be `Available`, `Unavailable`,
+                    or `Available, Rolling Update in Progress`.
+                  type: string
+                cheURL:
+                  description: Public URL to the Che server.
+                  type: string
+                cheVersion:
+                  description: Current installed Che version.
+                  type: string
+                dbProvisioned:
+                  description: Indicates that a PostgreSQL instance has been correctly
+                    provisioned or not.
+                  type: boolean
+                devfileRegistryURL:
+                  description: Public URL to the devfile registry.
+                  type: string
+                devworkspaceStatus:
+                  description: The status of the Devworkspace subsystem
+                  properties:
+                    gatewayHost:
+                      description: GatewayHost is the resolved host of the ingress/route.
+                        This is equal to the Host in the spec on Kubernetes but contains
+                        the actual host name of the route if Host is unspecified on
+                        OpenShift.
+                      type: string
+                    gatewayPhase:
+                      description: GatewayPhase specifies the phase in which the gateway
+                        deployment currently is. If the gateway is disabled, the phase
+                        is "Inactive".
+                      type: string
+                    message:
+                      description: Message contains further human-readable info for
+                        why the Che cluster is in the phase it currently is.
+                      type: string
+                    phase:
+                      description: Phase is the phase in which the Che cluster as
+                        a whole finds itself in.
+                      type: string
+                    reason:
+                      description: A brief CamelCase message indicating details about
+                        why the Che cluster is in this state.
+                      type: string
+                    workspaceBaseDomain:
+                      description: The resolved workspace base domain. This is either
+                        the copy of the explicitly defined property of the same name
+                        in the spec or, if it is undefined in the spec and we're running
+                        on OpenShift, the automatically resolved basedomain for routes.
+                      type: string
+                  type: object
+                gitHubOAuthProvisioned:
+                  description: Indicates whether an Identity Provider instance, Keycloak
+                    or RH-SSO, has been configured to integrate with the GitHub OAuth.
+                  type: boolean
+                helpLink:
+                  description: A URL that points to some URL where to find help related
+                    to the current Operator status.
+                  type: string
+                keycloakProvisioned:
+                  description: Indicates whether an Identity Provider instance, Keycloak
+                    or RH-SSO, has been provisioned with realm, client and user.
+                  type: boolean
+                keycloakURL:
+                  description: Public URL to the Identity Provider server, Keycloak
+                    or RH-SSO,.
+                  type: string
+                message:
+                  description: A human readable message indicating details about why
+                    the Pod is in this condition.
+                  type: string
+                openShiftOAuthUserCredentialsSecret:
+                  description: OpenShift OAuth secret in `openshift-config` namespace
+                    that contains user credentials for HTPasswd identity provider.
+                  type: string
+                openShiftoAuthProvisioned:
+                  description: Indicates whether an Identity Provider instance, Keycloak
+                    or RH-SSO, has been configured to integrate with the OpenShift
+                    OAuth.
+                  type: boolean
+                pluginRegistryURL:
+                  description: Public URL to the plugin registry.
+                  type: string
+                reason:
+                  description: A brief CamelCase message indicating details about
+                    why the Pod is in this state.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
@@ -11,6 +11,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
   name: checlusters.org.eclipse.che
 spec:
   group: org.eclipse.che
@@ -19,14 +22,11 @@ spec:
     listKind: CheClusterList
     plural: checlusters
     singular: checluster
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: The `CheCluster` custom resource allows defining and managing
-            a Che server installation
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation
@@ -75,8 +75,8 @@ spec:
                         or link:https://github.com/openshift/kube-rbac-proxy[openshift/kube-rbac-proxy]
                       type: string
                     gatewayHeaderRewriteSidecarImage:
-                      description: Header Rewrite Proxy sidecar image is used to properly
-                        set authorization header. See link:https://github.com/che-incubator/header-rewrite-proxy[header-rewrite-proxy]
+                      description: Deprecated. The value of this flag is ignored.
+                        Sidecar functionality is now implemented in Traefik plugin.
                       type: string
                     identityProviderAdminUserName:
                       description: Overrides the name of the Identity Provider administrator
@@ -402,10 +402,9 @@ spec:
                           type: string
                         deploymentName:
                           type: string
+                        imagePullSecrets:
+                          type: string
                         images:
-                          description: If empty, a set of recommended workspace-related
-                            images will be automatically detected and pre-pulled after
-                            installation.
                           type: string
                         nodeSelector:
                           type: string
@@ -731,6 +730,11 @@ spec:
                       description: Deprecated in favor of `externalDevfileRegistries`
                         fields.
                       type: string
+                    disableInternalClusterSVCNames:
+                      description: Disable internal cluster SVC names usage to communicate
+                        between components to speed up the traffic and avoid proxy
+                        issues.
+                      type: boolean
                     externalDevfileRegistries:
                       description: External devfile registries, that serves sample,
                         ready-to-use devfiles. Configure this in addition to a dedicated
@@ -946,9 +950,7 @@ spec:
                         cause malfunction of some Che components.
                       type: boolean
                     useInternalClusterSVCNames:
-                      description: Use internal cluster SVC names to communicate between
-                        components to speed up the traffic and avoid proxy issues.
-                        The default value is `true`.
+                      description: Deprecated in favor of `disableInternalClusterSVCNames`.
                       type: boolean
                     workspaceNamespaceDefault:
                       description: Defines Kubernetes default namespace in which user's
@@ -1091,3 +1093,10 @@ spec:
       storage: true
       subresources:
         status: {}
+  preserveUnknownFields: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/metadata/annotations.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/metadata/annotations.yaml
@@ -1,0 +1,9 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable-all-namespaces
+  operators.operatorframework.io.bundle.channels.v1: stable-all-namespaces
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: eclipse-che-preview-openshift
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/metadata/annotations.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/metadata/annotations.yaml
@@ -1,9 +1,15 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: stable-all-namespaces
-  operators.operatorframework.io.bundle.channels.v1: stable-all-namespaces
-  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: eclipse-che-preview-openshift
+  operators.operatorframework.io.bundle.channels.v1: stable-all-namespaces
+  operators.operatorframework.io.bundle.channel.default.v1: stable-all-namespaces
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.6.1+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
-  operators.operatorframework.io.metrics.project_layout: go
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/metadata/dependencies.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/metadata/dependencies.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- type: olm.package
+  value:
+    packageName: devworkspace-operator
+    version: ">=0.6.0"

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/metadata/dependencies.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/metadata/dependencies.yaml
@@ -2,4 +2,4 @@ dependencies:
 - type: olm.package
   value:
     packageName: devworkspace-operator
-    version: ">=0.6.0"
+    version: ">=0.8.0"

--- a/bundle/stable-all-namespaces/eclipse-che-preview-openshift/tests/scorecard/config.yaml
+++ b/bundle/stable-all-namespaces/eclipse-che-preview-openshift/tests/scorecard/config.yaml
@@ -1,0 +1,49 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test

--- a/make-release.sh
+++ b/make-release.sh
@@ -235,10 +235,11 @@ releaseOlmFiles() {
     local openshift=$RELEASE_DIR/bundle/$channel/eclipse-che-preview-openshift/manifests
 
     echo "[INFO] releaseOlmFiles :: Validate changes"
-    #grep -q "version: "$RELEASE $openshift/che-operator.clusterserviceversion.yaml
+    grep -q "version: "$RELEASE $openshift/che-operator.clusterserviceversion.yaml
     if [[ $channel == "stable" ]];then
       local kubernetes=$RELEASE_DIR/bundle/$channel/eclipse-che-preview-kubernetes/manifests
-      #grep -q "version: "$RELEASE $kubernetes/che-operator.clusterserviceversion.yaml
+      grep -q "version: "$RELEASE $kubernetes/che-operator.clusterserviceversion.yaml
+
       test -f $kubernetes/org_v1_che_crd.yaml
       test -f $kubernetes/org.eclipse.che_chebackupserverconfigurations_crd.yaml
       test -f $kubernetes/org.eclipse.che_checlusterbackups_crd.yaml

--- a/make-release.sh
+++ b/make-release.sh
@@ -29,6 +29,7 @@ init() {
   BUILDX_PLATFORMS="linux/amd64,linux/ppc64le"
   DEV_WORKSPACE_CONTROLLER_VERSION="main"
   DEV_WORKSPACE_CHE_OPERATOR_VERSION="main"
+  STABLE_CHANNELS="stable-all-namespaces,stable"
 
   if [[ $# -lt 1 ]]; then usage; exit; fi
 
@@ -48,7 +49,6 @@ init() {
     esac
     shift 1
   done
-
   [ -z "$QUAY_ECLIPSE_CHE_USERNAME" ] && echo "[ERROR] QUAY_ECLIPSE_CHE_USERNAME is not set" && exit 1
   [ -z "$QUAY_ECLIPSE_CHE_PASSWORD" ] && echo "[ERROR] QUAY_ECLIPSE_CHE_PASSWORD is not set" && exit 1
   command -v operator-courier >/dev/null 2>&1 || { echo "[ERROR] operator-courier is not installed. Abort."; exit 1; }
@@ -227,27 +227,29 @@ updateVersionFile() {
 releaseOlmFiles() {
   echo "[INFO] releaseOlmFiles :: Release OLM files"
   echo "[INFO] releaseOlmFiles :: Launch 'olm/release-olm-files.sh' script"
-  cd $RELEASE_DIR/olm
-  . release-olm-files.sh --release-version $RELEASE --dev-workspace-controller-version $DEV_WORKSPACE_CONTROLLER_VERSION --dev-workspace-che-operator-version $DEV_WORKSPACE_CHE_OPERATOR_VERSION
-  cd $RELEASE_DIR
+  for channel in $(echo $STABLE_CHANNELS | tr "," " ")
+  do
+    cd $RELEASE_DIR/olm
+    . release-olm-files.sh --release-version $RELEASE --channel $channel --dev-workspace-controller-version $DEV_WORKSPACE_CONTROLLER_VERSION --dev-workspace-che-operator-version $DEV_WORKSPACE_CHE_OPERATOR_VERSION
+    cd $RELEASE_DIR
+    local openshift=$RELEASE_DIR/bundle/$channel/eclipse-che-preview-openshift/manifests
 
-  local openshift=$RELEASE_DIR/bundle/stable/eclipse-che-preview-openshift/manifests
-  local kubernetes=$RELEASE_DIR/bundle/stable/eclipse-che-preview-kubernetes/manifests
+    echo "[INFO] releaseOlmFiles :: Validate changes"
+    #grep -q "version: "$RELEASE $openshift/che-operator.clusterserviceversion.yaml
+    if [[ $channel == "stable" ]];then
+      local kubernetes=$RELEASE_DIR/bundle/$channel/eclipse-che-preview-kubernetes/manifests
+      #grep -q "version: "$RELEASE $kubernetes/che-operator.clusterserviceversion.yaml
+      test -f $kubernetes/org_v1_che_crd.yaml
+      test -f $kubernetes/org.eclipse.che_chebackupserverconfigurations_crd.yaml
+      test -f $kubernetes/org.eclipse.che_checlusterbackups_crd.yaml
+      test -f $kubernetes/org.eclipse.che_checlusterrestores_crd.yaml
+    fi
 
-  echo "[INFO] releaseOlmFiles :: Validate changes"
-  grep -q "version: "$RELEASE $openshift/che-operator.clusterserviceversion.yaml
-  grep -q "version: "$RELEASE $kubernetes/che-operator.clusterserviceversion.yaml
-
-  test -f $kubernetes/org_v1_che_crd.yaml
-  test -f $kubernetes/org.eclipse.che_chebackupserverconfigurations_crd.yaml
-  test -f $kubernetes/org.eclipse.che_checlusterbackups_crd.yaml
-  test -f $kubernetes/org.eclipse.che_checlusterrestores_crd.yaml
-
-  test -f $openshift/org_v1_che_crd.yaml
-  test -f $openshift/org.eclipse.che_chebackupserverconfigurations_crd.yaml
-  test -f $openshift/org.eclipse.che_checlusterbackups_crd.yaml
-  test -f $openshift/org.eclipse.che_checlusterrestores_crd.yaml
-
+    test -f $openshift/org_v1_che_crd.yaml
+    test -f $openshift/org.eclipse.che_chebackupserverconfigurations_crd.yaml
+    test -f $openshift/org.eclipse.che_checlusterbackups_crd.yaml
+    test -f $openshift/org.eclipse.che_checlusterrestores_crd.yaml
+  done
   echo "[INFO] releaseOlmFiles :: Commit changes"
   if git status --porcelain; then
     git add -A || true # add new generated CSV files in olm/ folder
@@ -259,6 +261,7 @@ pushOlmBundlesToQuayIo() {
   echo "[INFO] releaseOperatorCode :: Login to quay.io..."
   docker login quay.io -u "${QUAY_ECLIPSE_CHE_USERNAME}" -p "${QUAY_ECLIPSE_CHE_PASSWORD}"
   echo "[INFO] Push OLM bundles to quay.io"
+  . ${RELEASE_DIR}/olm/buildAndPushBundleImages.sh -c "stable-all-namespaces" -p "openshift" -f "true"
   . ${RELEASE_DIR}/olm/buildAndPushBundleImages.sh -c "stable" -p "kubernetes" -f "true"
   . ${RELEASE_DIR}/olm/buildAndPushBundleImages.sh -c "stable" -p "openshift" -f "true"
 }

--- a/make-release.sh
+++ b/make-release.sh
@@ -29,7 +29,7 @@ init() {
   BUILDX_PLATFORMS="linux/amd64,linux/ppc64le"
   DEV_WORKSPACE_CONTROLLER_VERSION="main"
   DEV_WORKSPACE_CHE_OPERATOR_VERSION="main"
-  STABLE_CHANNELS="stable-all-namespaces,stable"
+  STABLE_CHANNELS=("stable-all-namespaces" "stable")
 
   if [[ $# -lt 1 ]]; then usage; exit; fi
 
@@ -227,7 +227,7 @@ updateVersionFile() {
 releaseOlmFiles() {
   echo "[INFO] releaseOlmFiles :: Release OLM files"
   echo "[INFO] releaseOlmFiles :: Launch 'olm/release-olm-files.sh' script"
-  for channel in $(echo $STABLE_CHANNELS | tr "," " ")
+  for channel in "${STABLE_CHANNELS[@]}"
   do
     cd $RELEASE_DIR/olm
     . release-olm-files.sh --release-version $RELEASE --channel $channel --dev-workspace-controller-version $DEV_WORKSPACE_CONTROLLER_VERSION --dev-workspace-che-operator-version $DEV_WORKSPACE_CHE_OPERATOR_VERSION

--- a/olm/prepare-community-operators-update.sh
+++ b/olm/prepare-community-operators-update.sh
@@ -16,6 +16,7 @@ CURRENT_DIR=$(pwd)
 SCRIPT=$(readlink -f "${BASH_SOURCE[0]}")
 BASE_DIR=$(cd "$(dirname "$0")"; pwd)
 PLATFORMS="kubernetes,openshift"
+STABLE_CHANNELS="stable-all-namespaces,stable"
 source "${BASE_DIR}/check-yq.sh"
 
 base_branch="main"
@@ -52,7 +53,7 @@ Options:
 "
 }
 
-. ${BASE_DIR}/olm/olm.sh
+. ${BASE_DIR}/olm.sh
 installOPM
 
 for platform in $(echo $PLATFORMS | tr "," " ")
@@ -108,38 +109,58 @@ do
   folderToUpdate="${communityOperatorsLocalGitFolder}/${platformSubFolder}/eclipse-che"
   destinationPackageFilePath="${folderToUpdate}/eclipse-che.package.yaml"
 
-  lastPublishedPackageVersion=$(yq -r '.channels[] | select(.name == "stable") | .currentCSV' "${destinationPackageFilePath}" | sed -e "s/eclipse-che.v//")
-  echo
-  echo "   - Last package pre-release version of local package: ${lastPackagePreReleaseVersion}"
-  echo "   - Last package release version of cloned 'community-operators' repository: ${lastPublishedPackageVersion}"
-  if [[ "${lastPackagePreReleaseVersion}" == "${lastPublishedPackageVersion}" ]] && [[ "${FORCE}" == "" ]]; then
-    echo "#### ERROR ####"
-    echo "Release ${lastPackagePreReleaseVersion} already exists in the '${platformSubFolder}/eclipse-che' package !"
-    exit 1
-  fi
+  for channel in $(echo $STABLE_CHANNELS | tr "," " ")
+  do
+    if [[ $channel == "stable-all-namespaces" && $platform == "kubernetes" ]];then
+      continue
+    fi
+    lastPackagePreReleaseVersion=$(yq -r '.channels[] | select(.name == "'$channel'") | .currentCSV' "${sourcePackageFilePath}" | sed -e "s/${packageName}.v//")
+    lastPublishedPackageVersion=$(yq -r '.channels[] | select(.name == "'$channel'") | .currentCSV' "${destinationPackageFilePath}" | sed -e "s/eclipse-che.v//") 
+    if [[ $channel == "stable-all-namespaces" && -z $lastPublishedPackageVersion ]];then
+      lastPublishedPackageVersion=$lastPackagePreReleaseVersion
+    fi
 
-  echo "     => will create release '${lastPackagePreReleaseVersion}' in the following package folder :'${folderToUpdate}'"
+    echo
+    echo "   - Last package pre-release version of local package: ${lastPackagePreReleaseVersion}"
+    echo "   - Last package release version of cloned 'community-operators' repository: ${lastPublishedPackageVersion}"
+    if [[ "${lastPackagePreReleaseVersion}" == "${lastPublishedPackageVersion}" ]] && [[ "${FORCE}" == "" ]]; then
+      echo "#### ERROR ####"
+      echo "Release ${lastPackagePreReleaseVersion} already exists in the '${platformSubFolder}/eclipse-che' package !"
+      #exit 1
+    fi
+    echo $lastPackagePreReleaseVersion
+    echo $platform
+    echo "     => will create release '${lastPackagePreReleaseVersion}' in the following package folder :'${folderToUpdate}'"
 
-  mkdir -p "${folderToUpdate}/${lastPackagePreReleaseVersion}"
-  sed \
-  -e "/^  replaces: ${packageName}.v.*/d" \
-  -e "/^  version: ${lastPackagePreReleaseVersion}/i\ \ replaces: eclipse-che.v${lastPublishedPackageVersion}" \
-  -e "s/${packageName}/eclipse-che/" \
-  "${packageBaseFolderPath}/${lastPackagePreReleaseVersion}/che-operator.clusterserviceversion.yaml" \
-  > "${folderToUpdate}/${lastPackagePreReleaseVersion}/eclipse-che.v${lastPackagePreReleaseVersion}.clusterserviceversion.yaml"
+    mkdir -p "${folderToUpdate}/${lastPackagePreReleaseVersion}"
+    sed \
+    -e "/^  replaces: ${packageName}.v.*/d" \
+    -e "/^  version: ${lastPackagePreReleaseVersion}/i\ \ replaces: eclipse-che.v${lastPublishedPackageVersion}" \
+    -e "s/${packageName}/eclipse-che/" \
+    "${packageBaseFolderPath}/${lastPackagePreReleaseVersion}/che-operator.clusterserviceversion.yaml" \
+    > "${folderToUpdate}/${lastPackagePreReleaseVersion}/eclipse-che.v${lastPackagePreReleaseVersion}.clusterserviceversion.yaml"
 
-  echo
-  echo "   - Update the CRD files"
-  cp "${packageBaseFolderPath}/${lastPackagePreReleaseVersion}/org_v1_che_crd.yaml" \
-  "${folderToUpdate}/${lastPackagePreReleaseVersion}/checlusters.org.eclipse.che.crd.yaml"
-  cp "${packageBaseFolderPath}/${lastPackagePreReleaseVersion}/org.eclipse.che_chebackupserverconfigurations_crd.yaml" "${folderToUpdate}/${lastPackagePreReleaseVersion}/org.eclipse.che_chebackupserverconfigurations_crd.yaml"
-  cp "${packageBaseFolderPath}/${lastPackagePreReleaseVersion}/org.eclipse.che_checlusterbackups_crd.yaml" "${folderToUpdate}/${lastPackagePreReleaseVersion}/org.eclipse.che_checlusterbackups_crd.yaml"
-  cp "${packageBaseFolderPath}/${lastPackagePreReleaseVersion}/org.eclipse.che_checlusterrestores_crd.yaml" "${folderToUpdate}/${lastPackagePreReleaseVersion}/org.eclipse.che_checlusterrestores_crd.yaml"
-  echo
-  echo "   - Update 'stable' channel with new release in the package descriptor: ${destinationPackageFilePath}"
-  sed -e "s/${lastPublishedPackageVersion}/${lastPackagePreReleaseVersion}/" "${destinationPackageFilePath}" > "${destinationPackageFilePath}.new"
-  mv "${destinationPackageFilePath}.new" "${destinationPackageFilePath}"
-  echo
+    echo
+    echo "   - Update the CRD files"
+    cp "${packageBaseFolderPath}/${lastPackagePreReleaseVersion}/org_v1_che_crd.yaml" \
+    "${folderToUpdate}/${lastPackagePreReleaseVersion}/checlusters.org.eclipse.che.crd.yaml"
+    cp "${packageBaseFolderPath}/${lastPackagePreReleaseVersion}/org.eclipse.che_chebackupserverconfigurations_crd.yaml" "${folderToUpdate}/${lastPackagePreReleaseVersion}/org.eclipse.che_chebackupserverconfigurations_crd.yaml"
+    cp "${packageBaseFolderPath}/${lastPackagePreReleaseVersion}/org.eclipse.che_checlusterbackups_crd.yaml" "${folderToUpdate}/${lastPackagePreReleaseVersion}/org.eclipse.che_checlusterbackups_crd.yaml"
+    cp "${packageBaseFolderPath}/${lastPackagePreReleaseVersion}/org.eclipse.che_checlusterrestores_crd.yaml" "${folderToUpdate}/${lastPackagePreReleaseVersion}/org.eclipse.che_checlusterrestores_crd.yaml"
+    echo
+    echo "   - Update 'stable' channel with new release in the package descriptor: ${destinationPackageFilePath}"
+    sed -e "s/${lastPublishedPackageVersion}/${lastPackagePreReleaseVersion}/" "${destinationPackageFilePath}" > "${destinationPackageFilePath}.new"
+    echo
+
+    if [[ $channel == "stable" ]]; then
+      mv "${destinationPackageFilePath}.new" "${destinationPackageFilePath}"
+    fi
+
+    if [[ $channel == "stable-all-namespaces" ]]; then
+      yq -riY ".channels[1] = { \"currentCSV\": \"eclipse-che.v${lastPackagePreReleaseVersion}\", \"name\": \"$channel\"}" $destinationPackageFilePath
+    fi
+  done
+  yq -Yi '.defaultChannel |= "stable"' ${destinationPackageFilePath}
 
   # NOTE: if you update this file, you need to submit a PR against these two files:
   # https://github.com/redhat-openshift-ecosystem/community-operators-prod/blob/main/operators/eclipse-che/ci.yaml

--- a/olm/prepare-community-operators-update.sh
+++ b/olm/prepare-community-operators-update.sh
@@ -16,7 +16,7 @@ CURRENT_DIR=$(pwd)
 SCRIPT=$(readlink -f "${BASH_SOURCE[0]}")
 BASE_DIR=$(cd "$(dirname "$0")"; pwd)
 PLATFORMS="kubernetes,openshift"
-STABLE_CHANNELS="stable-all-namespaces,stable"
+STABLE_CHANNELS=("stable-all-namespaces" "stable")
 source "${BASE_DIR}/check-yq.sh"
 
 base_branch="main"
@@ -53,7 +53,7 @@ Options:
 "
 }
 
-. ${BASE_DIR}/olm.sh
+. ${BASE_DIR}/olm/olm.sh
 installOPM
 
 for platform in $(echo $PLATFORMS | tr "," " ")
@@ -109,7 +109,7 @@ do
   folderToUpdate="${communityOperatorsLocalGitFolder}/${platformSubFolder}/eclipse-che"
   destinationPackageFilePath="${folderToUpdate}/eclipse-che.package.yaml"
 
-  for channel in $(echo $STABLE_CHANNELS | tr "," " ")
+  for channel in "${STABLE_CHANNELS[@]}"
   do
     if [[ $channel == "stable-all-namespaces" && $platform == "kubernetes" ]];then
       continue

--- a/olm/prepare-community-operators-update.sh
+++ b/olm/prepare-community-operators-update.sh
@@ -126,7 +126,7 @@ do
     if [[ "${lastPackagePreReleaseVersion}" == "${lastPublishedPackageVersion}" ]] && [[ "${FORCE}" == "" ]]; then
       echo "#### ERROR ####"
       echo "Release ${lastPackagePreReleaseVersion} already exists in the '${platformSubFolder}/eclipse-che' package !"
-      #exit 1
+      exit 1
     fi
     echo $lastPackagePreReleaseVersion
     echo $platform
@@ -152,14 +152,17 @@ do
     sed -e "s/${lastPublishedPackageVersion}/${lastPackagePreReleaseVersion}/" "${destinationPackageFilePath}" > "${destinationPackageFilePath}.new"
     echo
 
+    # Append to community operators the stable channel csv version: https://github.com/operator-framework/community-operators/blob/master/community-operators/eclipse-che/eclipse-che.package.yaml
     if [[ $channel == "stable" ]]; then
       mv "${destinationPackageFilePath}.new" "${destinationPackageFilePath}"
     fi
 
+    # Append to community operators the stable-all-namespaces channel csv version: https://github.com/operator-framework/community-operators/blob/master/community-operators/eclipse-che/eclipse-che.package.yaml
     if [[ $channel == "stable-all-namespaces" ]]; then
       yq -riY ".channels[1] = { \"currentCSV\": \"eclipse-che.v${lastPackagePreReleaseVersion}\", \"name\": \"$channel\"}" $destinationPackageFilePath
     fi
   done
+  # Make by default stable channel in the community operators eclipse-che.package.yaml
   yq -Yi '.defaultChannel |= "stable"' ${destinationPackageFilePath}
 
   # NOTE: if you update this file, you need to submit a PR against these two files:

--- a/olm/release-olm-files.sh
+++ b/olm/release-olm-files.sh
@@ -15,6 +15,7 @@ set -e
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     '--release-version') RELEASE=$2; shift 1;;
+    '--channel') CHANNEL=$2; shift 1;;
     '--dev-workspace-controller-version') DEV_WORKSPACE_CONTROLLER_VERSION=$2; shift 1;;
     '--dev-workspace-che-operator-version') DEV_WORKSPACE_CHE_OPERATOR_VERSION=$2; shift 1;;
   esac
@@ -84,18 +85,22 @@ if [[ -z "$RELEASE" ]] || [[ -z "$RELEASE" ]] || [[ -z "$RELEASE" ]]; then
   exit 1
 fi
 
+
 for platform in 'kubernetes' 'openshift'
 do
   source ${BASE_DIR}/olm.sh
-
   echo "[INFO] Creating release '${RELEASE}' for platform '${platform}'"
+
+  if [[ ${CHANNEL} == "stable-all-namespaces" ]] && [[ ${platform} == "kubernetes" ]];then
+    continue
+  fi
 
   NIGHTLY_BUNDLE_PATH=$(getBundlePath "${platform}" "nightly")
   LAST_NIGHTLY_CSV="${NIGHTLY_BUNDLE_PATH}/manifests/che-operator.clusterserviceversion.yaml"
   lastPackageNightlyVersion=$(yq -r ".spec.version" "${LAST_NIGHTLY_CSV}")
   echo "[INFO] Last package nightly version: ${lastPackageNightlyVersion}"
 
-  STABLE_BUNDLE_PATH=$(getBundlePath "${platform}" "stable")
+  STABLE_BUNDLE_PATH=$(getBundlePath "${platform}" $CHANNEL)
   RELEASE_CSV="${STABLE_BUNDLE_PATH}/manifests/che-operator.clusterserviceversion.yaml"
   RELEASE_CHE_CRD="${STABLE_BUNDLE_PATH}/manifests/org_v1_che_crd.yaml"
   RELEASE_CHE_BACKUP_SERVER_CONFIGURATION_CRD="${STABLE_BUNDLE_PATH}/manifests/org.eclipse.che_chebackupserverconfigurations_crd.yaml"
@@ -125,32 +130,52 @@ do
   -e "s/${lastPackageNightlyVersion}/${RELEASE}/" \
   -e "s/createdAt:.*$/createdAt: \"$(date -u +%FT%TZ)\"/" "${LAST_NIGHTLY_CSV}" > "${RELEASE_CSV}"
 
+  if [[ ${CHANNEL} == "stable-all-namespaces" ]];then
+    # Set by default devworkspace enabled
+    CR_SAMPLE=$(yq -r ".metadata.annotations.\"alm-examples\"" "${RELEASE_CSV}" | yq -r ".[0] | .spec.devWorkspace.enable |= true | [.]" | sed -r 's/"/\\"/g')
+    yq -rY " (.metadata.annotations.\"alm-examples\") = \"${CR_SAMPLE}\"" "${RELEASE_CSV}" > "${RELEASE_CSV}.old"
+    mv "${RELEASE_CSV}.old" "${RELEASE_CSV}"
+
+    # Move the suggested namespace to openshift-operators.
+    sed -ri 's|operatorframework.io/suggested-namespace: eclipse-che|operatorframework.io/suggested-namespace: openshift-operators|' "${RELEASE_CSV}"
+
+    # Set stable-all-namespaces versions
+    yq -Yi '.spec.replaces |= "'${packageName}'.v'$LAST_RELEASE_VERSION'-all-namespaces"' ${RELEASE_CSV}
+    yq -Yi '.spec.version |= "'${RELEASE}'-all-namespaces"' ${RELEASE_CSV}
+    yq -Yi '.metadata.name |= "eclipse-che-preview-openshift.v'${RELEASE}'-all-namespaces"' ${RELEASE_CSV}
+
+    # Change the install Mode to AllNamespaces by default
+    yq -Yi '.spec.installModes[] |= if .type=="OwnNamespace" then .supported |= false else . end' ${RELEASE_CSV}
+    yq -Yi '.spec.installModes[] |= if .type=="SingleNamespace" then .supported |= false else . end' ${RELEASE_CSV}
+    yq -Yi '.spec.installModes[] |= if .type=="MultiNamespace" then .supported |= false else . end' ${RELEASE_CSV}
+    yq -Yi '.spec.installModes[] |= if .type=="AllNamespaces" then .supported |= true else . end' ${RELEASE_CSV}
+  fi
+
   cp "${NIGHTLY_BUNDLE_PATH}/manifests/org_v1_che_crd.yaml" "${RELEASE_CHE_CRD}"
-  cp "${NIGHTLY_BUNDLE_PATH}/manifests/org.eclipse.che_chebackupserverconfigurations_crd.yaml" "${RELEASE_CHE_BACKUP_SERVER_CONFIGURATION_CRD}"
-  cp "${NIGHTLY_BUNDLE_PATH}/manifests/org.eclipse.che_checlusterbackups_crd.yaml" "${RELEASE_CHE_BACKUP_CRD}"
-  cp "${NIGHTLY_BUNDLE_PATH}/manifests/org.eclipse.che_checlusterrestores_crd.yaml" "${RELEASE_CHE_RESTORE_CRD}"
+  cp "${NIGHTLY_BUNDLE_PATH}/manifests/org.eclipse.che_chebackupserverconfigurations.yaml" "${RELEASE_CHE_BACKUP_SERVER_CONFIGURATION_CRD}"
+  cp "${NIGHTLY_BUNDLE_PATH}/manifests/org.eclipse.che_checlusterbackups.yaml" "${RELEASE_CHE_BACKUP_CRD}"
+  cp "${NIGHTLY_BUNDLE_PATH}/manifests/org.eclipse.che_checlusterrestores.yaml" "${RELEASE_CHE_RESTORE_CRD}"
   cp -rf "${NIGHTLY_BUNDLE_PATH}/bundle.Dockerfile" "${STABLE_BUNDLE_PATH}"
   cp -rf "${NIGHTLY_BUNDLE_PATH}/metadata" "${STABLE_BUNDLE_PATH}"
+  cp -rf "${NIGHTLY_BUNDLE_PATH}/tests" "${STABLE_BUNDLE_PATH}"
 
   ANNOTATION_METADATA_YAML="${STABLE_BUNDLE_PATH}/metadata/annotations.yaml"
   sed \
-  -e 's/operators.operatorframework.io.bundle.channels.v1: *nightly/operators.operatorframework.io.bundle.channels.v1: stable/' \
-  -e 's/operators.operatorframework.io.bundle.channel.default.v1: *nightly/operators.operatorframework.io.bundle.channel.default.v1: stable/' \
+  -e 's/operators.operatorframework.io.bundle.channels.v1: *nightly/operators.operatorframework.io.bundle.channels.v1: '$CHANNEL'/' \
+  -e 's/operators.operatorframework.io.bundle.channel.default.v1: *nightly/operators.operatorframework.io.bundle.channel.default.v1: '$CHANNEL'/' \
   -i "${ANNOTATION_METADATA_YAML}"
 
   BUNDLE_DOCKERFILE="${STABLE_BUNDLE_PATH}/bundle.Dockerfile"
   sed \
-  -e 's/LABEL operators.operatorframework.io.bundle.channels.v1=nightly/LABEL operators.operatorframework.io.bundle.channels.v1=stable/' \
-  -e 's/LABEL operators.operatorframework.io.bundle.channel.default.v1=nightly/LABEL operators.operatorframework.io.bundle.channel.default.v1=stable/' \
+  -e 's/LABEL operators.operatorframework.io.bundle.channels.v1=nightly/LABEL operators.operatorframework.io.bundle.channels.v1='$CHANNEL'/' \
+  -e 's/LABEL operators.operatorframework.io.bundle.channel.default.v1=nightly/LABEL operators.operatorframework.io.bundle.channel.default.v1='$CHANNEL'/' \
   -i "${BUNDLE_DOCKERFILE}"
 
   pushd "${CURRENT_DIR}" || true
-
   source ${BASE_DIR}/addDigests.sh -w ${BASE_DIR} \
                 -t "${RELEASE}" \
                 -s "${STABLE_BUNDLE_PATH}/manifests/che-operator.clusterserviceversion.yaml" \
-                -o "${OPERATOR_DIR}/deploy/operator.yaml"
-
+                -o "${OPERATOR_DIR}/config/manager/manager.yaml"
   popd || true
 
   if [[ -n "${PRE_RELEASE_CSV}" ]] && [[ -n "${PRE_RELEASE_CHE_CRD}" ]]; then

--- a/olm/release-olm-files.sh
+++ b/olm/release-olm-files.sh
@@ -24,6 +24,7 @@ done
 
 OPERATOR_DIR=$(dirname $(dirname $(readlink -f "${BASH_SOURCE[0]}")))
 BASE_DIR="${OPERATOR_DIR}/olm"
+
 source ${BASE_DIR}/check-yq.sh
 
 command -v pysemver >/dev/null 2>&1 || { echo "[ERROR] pysemver is not installed. Abort."; exit 1; }

--- a/pkg/deploy/dev-workspace/dev_workspace.go
+++ b/pkg/deploy/dev-workspace/dev_workspace.go
@@ -39,12 +39,12 @@ import (
 )
 
 var (
-	DevWorkspaceNamespace             = "devworkspace-controller"
-	DevWorkspaceCheNamespace          = "devworkspace-che"
-	DevWorkspaceWebhookName           = "controller.devfile.io"
-	DevWorkspaceServiceAccount        = "devworkspace-controller-serviceaccount"
-	DevWorkspaceService               = "devworkspace-controller-manager-service"
-	DevWorkspaceDeploymentName        = "devworkspace-controller-manager"
+	DevWorkspaceNamespace      = "devworkspace-controller"
+	DevWorkspaceWebhookName    = "controller.devfile.io"
+	DevWorkspaceServiceAccount = "devworkspace-controller-serviceaccount"
+	DevWorkspaceService        = "devworkspace-controller-manager-service"
+	DevWorkspaceDeploymentName = "devworkspace-controller-manager"
+
 	SubscriptionResourceName          = "subscriptions"
 	CheManagerResourcename            = "chemanagers"
 	ClusterServiceVersionResourceName = "clusterserviceversions"
@@ -117,7 +117,7 @@ func ReconcileDevWorkspace(deployContext *deploy.DeployContext) (bool, error) {
 	}
 
 	// Check if exists devworkspace operator csv is already installed
-	devWorkspaceOperatorCSVExists := isDevWorkspaceControllerCSVExists(deployContext)
+	devWorkspaceOperatorCSVExists := isDevWorkspaceOperatorCSVExists(deployContext)
 	if devWorkspaceOperatorCSVExists {
 		return true, nil
 	}
@@ -161,7 +161,7 @@ func ReconcileDevWorkspace(deployContext *deploy.DeployContext) (bool, error) {
 	return true, nil
 }
 
-func isDevWorkspaceControllerCSVExists(deployContext *deploy.DeployContext) bool {
+func isDevWorkspaceOperatorCSVExists(deployContext *deploy.DeployContext) bool {
 	// If clusterserviceversions resource doesn't exist in cluster DWO as well will not be present
 	if !util.HasK8SResourceObject(deployContext.ClusterAPI.DiscoveryClient, ClusterServiceVersionResourceName) {
 		return false

--- a/pkg/deploy/dev-workspace/dev_workspace.go
+++ b/pkg/deploy/dev-workspace/dev_workspace.go
@@ -117,7 +117,7 @@ func ReconcileDevWorkspace(deployContext *deploy.DeployContext) (bool, error) {
 	}
 
 	// Check if exists devworkspace operator csv is already installed
-	devWorkspaceOperatorCSVExists := devWorkspaceControllerCSVExists(deployContext)
+	devWorkspaceOperatorCSVExists := isDevWorkspaceControllerCSVExists(deployContext)
 	if devWorkspaceOperatorCSVExists {
 		return true, nil
 	}
@@ -161,14 +161,14 @@ func ReconcileDevWorkspace(deployContext *deploy.DeployContext) (bool, error) {
 	return true, nil
 }
 
-func devWorkspaceControllerCSVExists(deployContext *deploy.DeployContext) bool {
+func isDevWorkspaceControllerCSVExists(deployContext *deploy.DeployContext) bool {
 	// If clusterserviceversions resource doesn't exist in cluster DWO as well will not be present
 	if !util.HasK8SResourceObject(deployContext.ClusterAPI.DiscoveryClient, ClusterServiceVersionResourceName) {
 		return false
 	}
 
 	csvList := &operatorsv1alpha1.ClusterServiceVersionList{}
-	err := deployContext.ClusterAPI.NonCachedClient.List(context.TODO(), csvList, &client.ListOptions{})
+	err := deployContext.ClusterAPI.Client.List(context.TODO(), csvList, &client.ListOptions{})
 	if err != nil {
 		return false
 	}

--- a/pkg/deploy/dev-workspace/dev_workspace.go
+++ b/pkg/deploy/dev-workspace/dev_workspace.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	orgv1 "github.com/eclipse-che/che-operator/api/v1"
 	"github.com/eclipse-che/che-operator/pkg/deploy"
@@ -38,14 +39,16 @@ import (
 )
 
 var (
-	DevWorkspaceNamespace      = "devworkspace-controller"
-	DevWorkspaceCheNamespace   = "devworkspace-che"
-	DevWorkspaceWebhookName    = "controller.devfile.io"
-	DevWorkspaceServiceAccount = "devworkspace-controller-serviceaccount"
-	DevWorkspaceService        = "devworkspace-controller-manager-service"
-	DevWorkspaceDeploymentName = "devworkspace-controller-manager"
-	SubscriptionResourceName   = "subscriptions"
-	CheManagerResourcename     = "chemanagers"
+	DevWorkspaceNamespace             = "devworkspace-controller"
+	DevWorkspaceCheNamespace          = "devworkspace-che"
+	DevWorkspaceWebhookName           = "controller.devfile.io"
+	DevWorkspaceServiceAccount        = "devworkspace-controller-serviceaccount"
+	DevWorkspaceService               = "devworkspace-controller-manager-service"
+	DevWorkspaceDeploymentName        = "devworkspace-controller-manager"
+	SubscriptionResourceName          = "subscriptions"
+	CheManagerResourcename            = "chemanagers"
+	ClusterServiceVersionResourceName = "clusterserviceversions"
+	DevWorkspaceCSVNameWithouVersion  = "devworkspace-operator"
 
 	OpenshiftDevWorkspaceTemplatesPath     = "/tmp/devworkspace-operator/templates/deployment/openshift/objects"
 	OpenshiftDevWorkspaceCheTemplatesPath  = "/tmp/devworkspace-che-operator/templates/deployment/openshift/objects"
@@ -113,6 +116,12 @@ func ReconcileDevWorkspace(deployContext *deploy.DeployContext) (bool, error) {
 		return true, nil
 	}
 
+	// Check if exists devworkspace operator csv is already installed
+	devWorkspaceOperatorCSVExists := devWorkspaceControllerCSVExists(deployContext)
+	if devWorkspaceOperatorCSVExists {
+		return true, nil
+	}
+
 	// do nothing if dev workspace is disabled
 	if !deployContext.CheCluster.Spec.DevWorkspace.Enable {
 		return true, nil
@@ -150,6 +159,27 @@ func ReconcileDevWorkspace(deployContext *deploy.DeployContext) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func devWorkspaceControllerCSVExists(deployContext *deploy.DeployContext) bool {
+	// If clusterserviceversions resource doesn't exist in cluster DWO as well will not be present
+	if !util.HasK8SResourceObject(deployContext.ClusterAPI.DiscoveryClient, ClusterServiceVersionResourceName) {
+		return false
+	}
+
+	csvList := &operatorsv1alpha1.ClusterServiceVersionList{}
+	err := deployContext.ClusterAPI.NonCachedClient.List(context.TODO(), csvList, &client.ListOptions{})
+	if err != nil {
+		return false
+	}
+
+	for _, csv := range csvList.Items {
+		if strings.Contains(csv.Name, DevWorkspaceCSVNameWithouVersion) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func checkWebTerminalSubscription(deployContext *deploy.DeployContext) error {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Create a new channel to install Che Operator in AllNamespace Mode:

1. Install Che using stable-all-namespaces channel

  To install Eclipse Che in cluster wide availability after uploading the new bundles for `stable-all-namespaces` we need to go to OperatorHub, select Eclipse Che and then select the new channel `stable-all-namespaces`. By default the che operator will be installed in AllNamespace mode and will start to listen for all CheCluster APIS in all cluster.

2. Migrate che from single Namespace mode to all Namespace mode

If you already have an Eclipse Che installed from stable/nightly channel and you want to try the new channel you need to consider the following:

- It is not possible to have Eclipse Che installed in single Namespace (currently the default one) and then try to install Che in All Namespace mode using the new channel stable-all-namespaces.

- To update to stable-all-namespaces channel you need first to remove all subscriptions created for che installed from nightly or stable channels. IMPORTANT: Removing subscriptions doesn’t mean Eclipse Che operands(che-server, keycloak or roles) will be removed from the cluster.

- DevWorkspace engine will be by default enabled in the new channel.

In case if you have already installed Che with devWorkspace enabled from channels nightly or stable you need to uninstall DevWorkspace completely from the cluster and then install the Che Operator using stable-all-namespaces channel.

- If you already have all these considerations done you can proceed to install the Che Operator from the OperatorHub using the new channel and the operator will start to manage the resources previously created by the old operators.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->

https://github.com/eclipse/che/issues/19891
### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
1. Create a new Catalog Source with the new channel and Devworkspace Operator:
```bash
export CRW_CATALOG_SOURCE=$(
      oc create -f - -o jsonpath='{.metadata.name}' <<EOF
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  generateName: che-catalog-
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/flacatus/eclipse-che-openshift-opm-catalog:preview
  displayName: Eclipse Che Catalog
  publisher: Eclipse Che
  updateStrategy:
    registryPoll: 
      interval: 30m
EOF
)
​
echo "Che Catalog: ${CRW_CATALOG_SOURCE}"
​
export DWO_CATALOG_SOURCE=$(
      oc create -f - -o jsonpath='{.metadata.name}' <<EOF
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  generateName: dwo-catalog-
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/devfile/devworkspace-operator-index:next
  displayName: DevWorkspace Catalog
  publisher: DevWorkspace
  updateStrategy:
    registryPoll: 
      interval: 30m
EOF
)
```

2. Install The new `stable-all-namespaces` channel from Operator Hub:
![image](https://user-images.githubusercontent.com/59865209/126977567-98348f83-a6a2-4ace-8bda-0f2e41fa5bf2.png)

Installation Results:
![image](https://user-images.githubusercontent.com/59865209/126977655-0d55b19b-4fa1-43c3-a405-e0f6974b64a8.png)


### PR Checklist
          
[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
