### PR TITLE
feat: set default image puller images to custom resource on release

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -168,3 +168,15 @@ spec:
     # Does nothing when a matching version of the Operator is already installed.
     # Fails when a non-matching version of the Operator is already installed.
     enable: false
+  imagePuller:
+    # Install and configure the Community Supported Kubernetes Image Puller Operator. When set to `true` and no spec is provided,
+    # it will create a default KubernetesImagePuller object to be managed by the Operator.
+    # When set to `false`, the KubernetesImagePuller object will be deleted, and the Operator will be uninstalled,
+    # regardless of whether a spec is provided.
+    # Note that while this the Operator and its behavior is community-supported, its payload may be commercially-supported
+    # for pulling commercially-supported images.
+    # By default, the `spec.images` field contains a set of recommended workspace images to be prepulled.
+    enable: false
+    spec:
+      # By default, this field contains a set of recommended workspace images to be prepulled
+      images: "che-workspace-plugin-broker-metadata=quay.io/eclipse/che-plugin-metadata-broker@sha256:df1ea2eadb28dbc97761adf4ea984af5ca941025a67b39c6abe373816a84bba9;che-workspace-plugin-broker-artifacts=quay.io/eclipse/che-plugin-artifacts-broker@sha256:4891a6e19be9eae59372f4b31144653f9bd1284e0301ecfe896a099ca6a12b58;che-theia-plugin-registry-image-ibzwqyjsgu3dumjvgbqtsm3dgeztmmt=quay.io/eclipse/che-theia@sha256:150a93c1362cbc6837e6aeeb644a91a70a5fb63031e23552f01d936a2b312ed7;che-theia-endpoint-runtime-binary-plugin-registry-image-ibzwqyj=quay.io/eclipse/che-theia-endpoint-runtime-binary@sha256:ed0bc2a3b1a9cef67d84b052ed248fd48fdc93b384f80af80446d526be4e4751;che-cpp-rhel7-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-cpp-rhel7@sha256:8182090bbe5f2f0d3d1469dde5e9a6f62d9ba22d297702cc26b88fcf671409b2;che-dotnet-2-2-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-dotnet-2.2@sha256:61ddb07608a1761b119a3a6388a821ab59db94961857e8df141003d1bd618e4e;che-dotnet-3-1-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-dotnet-3.1@sha256:a06b17b761c880bc5cf5fef65028303ff684c9b517593e8c71896cdf78eb4fae;che-golang-1-14-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-golang-1.14@sha256:3d6039fde76a7e09cbc6f4825ed1ad7c2d960eb054b05f7220ecfe55aa75b1e6;che-java11-maven-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-java11-maven@sha256:e4be1573efd37a8b8da4b34d23dbbe82ae29932de83d7c530a46bc2d958a726c;che-java8-maven-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-java8-maven@sha256:bcd1d1af6cec19fae9372e984b1664283eca4517ce7a4dec923e4c49c8b7a5d8;che-php-7-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-php-7@sha256:9b4ab7a151283006a983ff20f204d4739e3a9fef7b81bbab7205dbcaac4cab04;"

--- a/deploy/crds/org_v1_che_crd-v1beta1.yaml
+++ b/deploy/crds/org_v1_che_crd-v1beta1.yaml
@@ -367,7 +367,9 @@ spec:
  Note that while this
                     the Operator and its behavior is community-supported, its payload
                     may be commercially-supported for pulling commercially-supported
-                    images."
+                    images. 
+ By default, the `spec.images` field contains a set
+                    of recommended workspace images to be prepulled."
                   type: boolean
                 spec:
                   description: A KubernetesImagePullerSpec to configure the image
@@ -390,6 +392,8 @@ spec:
                     deploymentName:
                       type: string
                     images:
+                      description: By default, this field contains a set of recommended
+                        workspace images to be prepulled
                       type: string
                     nodeSelector:
                       type: string

--- a/deploy/crds/org_v1_che_crd.yaml
+++ b/deploy/crds/org_v1_che_crd.yaml
@@ -373,7 +373,9 @@ spec:
  Note that while
                       this the Operator and its behavior is community-supported, its
                       payload may be commercially-supported for pulling commercially-supported
-                      images."
+                      images. 
+ By default, the `spec.images` field contains a set
+                      of recommended workspace images to be prepulled."
                     type: boolean
                   spec:
                     description: A KubernetesImagePullerSpec to configure the image
@@ -396,6 +398,8 @@ spec:
                       deploymentName:
                         type: string
                       images:
+                        description: By default, this field contains a set of recommended
+                          workspace images to be prepulled
                         type: string
                       nodeSelector:
                         type: string

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -43,6 +43,12 @@ metadata:
             "devWorkspace": {
               "enable": false
             },
+            "imagePuller": {
+              "enable": false,
+              "spec": {
+                "images": "che-workspace-plugin-broker-metadata=quay.io/eclipse/che-plugin-metadata-broker@sha256:df1ea2eadb28dbc97761adf4ea984af5ca941025a67b39c6abe373816a84bba9;che-workspace-plugin-broker-artifacts=quay.io/eclipse/che-plugin-artifacts-broker@sha256:4891a6e19be9eae59372f4b31144653f9bd1284e0301ecfe896a099ca6a12b58;che-theia-plugin-registry-image-ibzwqyjsgu3dumjvgbqtsm3dgeztmmt=quay.io/eclipse/che-theia@sha256:150a93c1362cbc6837e6aeeb644a91a70a5fb63031e23552f01d936a2b312ed7;che-theia-endpoint-runtime-binary-plugin-registry-image-ibzwqyj=quay.io/eclipse/che-theia-endpoint-runtime-binary@sha256:ed0bc2a3b1a9cef67d84b052ed248fd48fdc93b384f80af80446d526be4e4751;che-cpp-rhel7-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-cpp-rhel7@sha256:8182090bbe5f2f0d3d1469dde5e9a6f62d9ba22d297702cc26b88fcf671409b2;che-dotnet-2-2-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-dotnet-2.2@sha256:61ddb07608a1761b119a3a6388a821ab59db94961857e8df141003d1bd618e4e;che-dotnet-3-1-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-dotnet-3.1@sha256:a06b17b761c880bc5cf5fef65028303ff684c9b517593e8c71896cdf78eb4fae;che-golang-1-14-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-golang-1.14@sha256:3d6039fde76a7e09cbc6f4825ed1ad7c2d960eb054b05f7220ecfe55aa75b1e6;che-java11-maven-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-java11-maven@sha256:e4be1573efd37a8b8da4b34d23dbbe82ae29932de83d7c530a46bc2d958a726c;che-java8-maven-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-java8-maven@sha256:bcd1d1af6cec19fae9372e984b1664283eca4517ce7a4dec923e4c49c8b7a5d8;che-php-7-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-php-7@sha256:9b4ab7a151283006a983ff20f204d4739e3a9fef7b81bbab7205dbcaac4cab04;"
+              }
+            },
             "k8s": {
               "ingressClass": "",
               "ingressDomain": "",
@@ -86,13 +92,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2021-07-07T09:30:36Z"
+    createdAt: "2021-07-07T18:36:05Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.33.0-250.nightly
+  name: eclipse-che-preview-kubernetes.v7.33.0-252.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1241,4 +1247,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.33.0-250.nightly
+  version: 7.33.0-252.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/org_v1_che_crd.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-kubernetes/manifests/org_v1_che_crd.yaml
@@ -373,7 +373,9 @@ spec:
  Note that while
                       this the Operator and its behavior is community-supported, its
                       payload may be commercially-supported for pulling commercially-supported
-                      images."
+                      images. 
+ By default, the `spec.images` field contains a set
+                      of recommended workspace images to be prepulled."
                     type: boolean
                   spec:
                     description: A KubernetesImagePullerSpec to configure the image
@@ -396,6 +398,8 @@ spec:
                       deploymentName:
                         type: string
                       images:
+                        description: By default, this field contains a set of recommended
+                          workspace images to be prepulled
                         type: string
                       nodeSelector:
                         type: string

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -43,6 +43,12 @@ metadata:
             "devWorkspace": {
               "enable": false
             },
+            "imagePuller": {
+              "enable": false,
+              "spec": {
+                "images": "che-workspace-plugin-broker-metadata=quay.io/eclipse/che-plugin-metadata-broker@sha256:df1ea2eadb28dbc97761adf4ea984af5ca941025a67b39c6abe373816a84bba9;che-workspace-plugin-broker-artifacts=quay.io/eclipse/che-plugin-artifacts-broker@sha256:4891a6e19be9eae59372f4b31144653f9bd1284e0301ecfe896a099ca6a12b58;che-theia-plugin-registry-image-ibzwqyjsgu3dumjvgbqtsm3dgeztmmt=quay.io/eclipse/che-theia@sha256:150a93c1362cbc6837e6aeeb644a91a70a5fb63031e23552f01d936a2b312ed7;che-theia-endpoint-runtime-binary-plugin-registry-image-ibzwqyj=quay.io/eclipse/che-theia-endpoint-runtime-binary@sha256:ed0bc2a3b1a9cef67d84b052ed248fd48fdc93b384f80af80446d526be4e4751;che-cpp-rhel7-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-cpp-rhel7@sha256:8182090bbe5f2f0d3d1469dde5e9a6f62d9ba22d297702cc26b88fcf671409b2;che-dotnet-2-2-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-dotnet-2.2@sha256:61ddb07608a1761b119a3a6388a821ab59db94961857e8df141003d1bd618e4e;che-dotnet-3-1-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-dotnet-3.1@sha256:a06b17b761c880bc5cf5fef65028303ff684c9b517593e8c71896cdf78eb4fae;che-golang-1-14-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-golang-1.14@sha256:3d6039fde76a7e09cbc6f4825ed1ad7c2d960eb054b05f7220ecfe55aa75b1e6;che-java11-maven-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-java11-maven@sha256:e4be1573efd37a8b8da4b34d23dbbe82ae29932de83d7c530a46bc2d958a726c;che-java8-maven-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-java8-maven@sha256:bcd1d1af6cec19fae9372e984b1664283eca4517ce7a4dec923e4c49c8b7a5d8;che-php-7-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-php-7@sha256:9b4ab7a151283006a983ff20f204d4739e3a9fef7b81bbab7205dbcaac4cab04;"
+              }
+            },
             "metrics": {
               "enable": true
             },
@@ -77,13 +83,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2021-07-07T09:30:48Z"
+    createdAt: "2021-07-07T18:36:17Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.33.0-250.nightly
+  name: eclipse-che-preview-openshift.v7.33.0-252.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1318,4 +1324,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.33.0-250.nightly
+  version: 7.33.0-252.nightly

--- a/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
+++ b/deploy/olm-catalog/nightly/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
@@ -378,7 +378,9 @@ spec:
                         \ Operator will be uninstalled, regardless of whether a spec\
                         \ is provided. Note that while this the Operator and its behavior\
                         \ is community-supported, its payload may be commercially-supported\
-                        \ for pulling commercially-supported images."
+                        \ for pulling commercially-supported images. By default, the\
+                        \ `spec.images` field contains a set of recommended workspace\
+                        \ images to be prepulled."
                       type: boolean
                     spec:
                       description: A KubernetesImagePullerSpec to configure the image
@@ -401,6 +403,8 @@ spec:
                         deploymentName:
                           type: string
                         images:
+                          description: By default, this field contains a set of recommended
+                            workspace images to be prepulled
                           type: string
                         nodeSelector:
                           type: string

--- a/make-release.sh
+++ b/make-release.sh
@@ -255,6 +255,13 @@ releaseOlmFiles() {
   fi
 }
 
+setImagePullerDefaultImages() {
+  echo "[INFO] setImagePullerDefaultImages :: Set default images for the image puller"
+  local CSV=${RELEASE_DIR}/deploy/olm-catalog/stable/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+  local CR=${RELEASE_DIR}/deploy/crds/org_v1_che_cr.yaml
+  ${RELEASE_DIR}/olm/setImagePullerDefaultImages.sh $CSV $CR
+}
+
 pushOlmBundlesToQuayIo() {
   echo "[INFO] releaseOperatorCode :: Login to quay.io..."
   docker login quay.io -u "${QUAY_ECLIPSE_CHE_USERNAME}" -p "${QUAY_ECLIPSE_CHE_PASSWORD}"
@@ -314,6 +321,7 @@ run() {
   checkoutToReleaseBranch
   updateVersionFile
   releaseOperatorCode
+  setImagePullerDefaultImages
   if [[ $RELEASE_OLM_FILES == "true" ]]; then
     releaseOlmFiles
   fi

--- a/olm/setImagePullerDefaultImages.sh
+++ b/olm/setImagePullerDefaultImages.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+
+CSV="$1" # Path to CSV file
+CR="$2" # Path to custom resource
+
+# Bash array of related images patterns to collect
+patterns=(
+    ^RELATED_IMAGE_.*_plugin_java8$
+    ^RELATED_IMAGE_.*_plugin_java11$
+    ^RELATED_IMAGE_.*_plugin_kubernetes$
+    ^RELATED_IMAGE_.*_plugin_openshift$
+    ^RELATED_IMAGE_.*_plugin_broker.*
+    ^RELATED_IMAGE_.*_theia.*
+    ^RELATED_IMAGE_.*_stacks_cpp$
+    ^RELATED_IMAGE_.*_stacks_dotnet$
+    ^RELATED_IMAGE_.*_stacks_golang$
+    ^RELATED_IMAGE_.*_stacks_php$
+    ^RELATED_IMAGE_.*_cpp_.*_devfile_registry_image.*
+    ^RELATED_IMAGE_.*_dotnet_.*_devfile_registry_image.*
+    ^RELATED_IMAGE_.*_golang_.*_devfile_registry_image.*
+    ^RELATED_IMAGE_.*_php_.*_devfile_registry_image.*
+    ^RELATED_IMAGE_.*_java.*_maven_devfile_registry_image.*
+)
+
+# Accumulate each pattern into one large pattern
+pattern=${patterns[0]}
+patterns=("${patterns[@]:1}")
+for i in ${patterns[@]}; do
+    pattern=$pattern"|"$i
+done
+
+
+RELATED_IMAGES=$(yq -r '.spec.install.spec.deployments[0].spec.template.spec.containers[0].env' $CSV | jq -rc ".[] | select(.name | test(\"$pattern\"))")
+PREFIX="RELATED_IMAGE_"
+PREFIX_LENGTH=$(echo ${#PREFIX})
+MAX_NAME_LENGTH=63
+RFC1123_PATTERN="[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+
+# Gather a semi-colon-seperated list of images in this format:
+# image_name=image_url;image_name=image_url;image_name=image_url ...
+for image in ${RELATED_IMAGES}; do
+    value=$(echo $image | jq -r '.value')
+
+    # names must be in RFC 1123 format
+    name=$(echo $image | jq -r '.name')
+
+    # remove prefix
+    name=$(echo ${name:$PREFIX_LENGTH:MAX_NAME_LENGTH})
+
+    # convert to lowercase, remove dashes
+    name=$(echo $name | tr '[:upper:]' '[:lower:]')
+    name=$(echo $name | sed 's/_/-/g')
+
+    # capture the start of the string that matches the RFC 1123 format
+    name=$([[ $name =~ (${RFC1123_PATTERN})(.*) ]] && echo ${BASH_REMATCH[1]})
+
+    images=$images$name"="$value";"
+done
+
+# Write images to custom resource
+sed -ri 's|(images: ).*|\1"'"$images"'"|g' $CR

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -595,6 +595,8 @@ type CheClusterSpecImagePuller struct {
 	//
 	// Note that while this the Operator and its behavior is community-supported, its payload may be commercially-supported
 	// for pulling commercially-supported images.
+	//
+	// By default, the `spec.images` field contains a set of recommended workspace images to be prepulled.
 	Enable bool `json:"enable"`
 	// A KubernetesImagePullerSpec to configure the image puller in the CheCluster
 	// +optional

--- a/vendor/github.com/che-incubator/kubernetes-image-puller-operator/pkg/apis/che/v1alpha1/kubernetesimagepuller_types.go
+++ b/vendor/github.com/che-incubator/kubernetes-image-puller-operator/pkg/apis/che/v1alpha1/kubernetesimagepuller_types.go
@@ -8,12 +8,14 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+// +k8s:openapi-gen=true
 // KubernetesImagePullerSpec defines the desired state of KubernetesImagePuller
 type KubernetesImagePullerSpec struct {
+	// By default, this field contains a set of recommended workspace images to be prepulled
+	Images               string `json:"images,omitempty"`
 	ConfigMapName        string `json:"configMapName,omitempty"`
 	DaemonsetName        string `json:"daemonsetName,omitempty"`
 	DeploymentName       string `json:"deploymentName,omitempty"`
-	Images               string `json:"images,omitempty"`
 	CachingIntervalHours string `json:"cachingIntervalHours,omitempty"`
 	CachingMemoryRequest string `json:"cachingMemoryRequest,omitempty"`
 	CachingMemoryLimit   string `json:"cachingMemoryLimit,omitempty"`


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
This PR reads the RELATED_IMAGES environment variables from the che-operator CSV file and sets default images to the image puller spec from the custom resource.

This PR is an alternative solution to https://github.com/eclipse-che/che-operator/pull/880. One benefit to this approach compared to https://github.com/eclipse-che/che-operator/pull/880, is that this approach is able to display the list of default images in the OpenShift console UI before installation.

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19657

### How to test this PR?
**Step 1.** Since the CSV/CR is read/written to from the `make-release.sh` script, the following patch comments out some release-specific functions to make it easier to test this PR. The patch also clears the default images in the custom resource file, in order to confirm that the script correctly sets the images in step 2. 

`patch.txt`:
```
diff --git a/deploy/crds/org_v1_che_cr.yaml b/deploy/crds/org_v1_che_cr.yaml
index 7570fcd2..1834e484 100644
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -179,4 +179,4 @@ spec:
     enable: false
     spec:
       # By default, this field contains a set of recommended workspace images to be prepulled
-      images: "che-workspace-plugin-broker-metadata=quay.io/eclipse/che-plugin-metadata-broker@sha256:df1ea2eadb28dbc97761adf4ea984af5ca941025a67b39c6abe373816a84bba9;che-workspace-plugin-broker-artifacts=quay.io/eclipse/che-plugin-artifacts-broker@sha256:4891a6e19be9eae59372f4b31144653f9bd1284e0301ecfe896a099ca6a12b58;che-theia-plugin-registry-image-ibzwqyjsgu3dumjvgbqtsm3dgeztmmt=quay.io/eclipse/che-theia@sha256:150a93c1362cbc6837e6aeeb644a91a70a5fb63031e23552f01d936a2b312ed7;che-theia-endpoint-runtime-binary-plugin-registry-image-ibzwqyj=quay.io/eclipse/che-theia-endpoint-runtime-binary@sha256:ed0bc2a3b1a9cef67d84b052ed248fd48fdc93b384f80af80446d526be4e4751;che-cpp-rhel7-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-cpp-rhel7@sha256:8182090bbe5f2f0d3d1469dde5e9a6f62d9ba22d297702cc26b88fcf671409b2;che-dotnet-2-2-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-dotnet-2.2@sha256:61ddb07608a1761b119a3a6388a821ab59db94961857e8df141003d1bd618e4e;che-dotnet-3-1-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-dotnet-3.1@sha256:a06b17b761c880bc5cf5fef65028303ff684c9b517593e8c71896cdf78eb4fae;che-golang-1-14-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-golang-1.14@sha256:3d6039fde76a7e09cbc6f4825ed1ad7c2d960eb054b05f7220ecfe55aa75b1e6;che-java11-maven-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-java11-maven@sha256:e4be1573efd37a8b8da4b34d23dbbe82ae29932de83d7c530a46bc2d958a726c;che-java8-maven-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-java8-maven@sha256:bcd1d1af6cec19fae9372e984b1664283eca4517ce7a4dec923e4c49c8b7a5d8;che-php-7-devfile-registry-image-g4xdgmrogi=quay.io/eclipse/che-php-7@sha256:9b4ab7a151283006a983ff20f204d4739e3a9fef7b81bbab7205dbcaac4cab04;"
+      images: ""
diff --git a/make-release.sh b/make-release.sh
index 3240d8ce..ed9dffe4 100755
--- a/make-release.sh
+++ b/make-release.sh
@@ -318,9 +318,9 @@ run() {
     . ${RELEASE_DIR}/.github/bin/check-resources.sh
   fi
 
-  checkoutToReleaseBranch
-  updateVersionFile
-  releaseOperatorCode
+  # checkoutToReleaseBranch
+  # updateVersionFile
+  # releaseOperatorCode
   setImagePullerDefaultImages
   if [[ $RELEASE_OLM_FILES == "true" ]]; then
     releaseOlmFiles

```

```
git apply patch.txt
```



**Step 2.** Run `./make-release --release`. After the script finishes running, the CR file (https://github.com/eclipse-che/che-operator/blob/main/deploy/crds/org_v1_che_cr.yaml) should now contain the list of default images, reversing what step 1 did to clear the default images. In other words, at this point `git diff deploy/crds/org_v1_che_cr.yaml` should detect no changes.

**Step 3.** Deploy with `chectl` using the `--installer olm` flag as described here: https://github.com/eclipse-che/che-operator#deploy-che-operator-with-chectl-using---installer-olm-flag

**Step 4.** When creating a new instance of CheCluster in the OpenShift console, the default images should appear in the UI as a semi-colon-separated string :
![image](https://user-images.githubusercontent.com/83611742/124804461-543e7f80-df28-11eb-92e8-c7994a0cddce.png)


### PR Checklist
          
[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
