### PR TITLE
fix: add slash to the end of urls

### DIFF
--- a/pkg/deploy/devfileregistry/devfileregistry.go
+++ b/pkg/deploy/devfileregistry/devfileregistry.go
@@ -12,6 +12,8 @@
 package devfileregistry
 
 import (
+	"strings"
+
 	"github.com/eclipse-che/che-operator/pkg/deploy"
 	"github.com/eclipse-che/che-operator/pkg/deploy/expose"
 )
@@ -86,6 +88,10 @@ func (p *DevfileRegistry) UpdateStatus(endpoint string) (bool, error) {
 		devfileRegistryURL = "https://" + endpoint
 	} else {
 		devfileRegistryURL = "http://" + endpoint
+	}
+
+	if !strings.HasSuffix(devfileRegistryURL, "/") {
+		devfileRegistryURL += "/"
 	}
 
 	if devfileRegistryURL != p.deployContext.CheCluster.Status.DevfileRegistryURL {

--- a/pkg/deploy/devfileregistry/devfileregistry_test.go
+++ b/pkg/deploy/devfileregistry/devfileregistry_test.go
@@ -22,6 +22,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -88,5 +89,19 @@ func TestDevfileRegistrySyncAll(t *testing.T) {
 
 	if cheCluster.Status.DevfileRegistryURL == "" {
 		t.Fatalf("Status wasn't updated")
+	}
+}
+
+func TestUpdateStatus(t *testing.T) {
+	deployContext := deploy.GetTestDeployContext(nil, []runtime.Object{})
+
+	devfileregistry := NewDevfileRegistry(deployContext)
+	done, err := devfileregistry.UpdateStatus("endpoint")
+	if !done {
+		t.Fatalf("Failed to sync Devfile Registry: %v", err)
+	}
+
+	if deployContext.CheCluster.Status.DevfileRegistryURL != "http://endpoint/" {
+		t.Fatalf("Status wasn't updated properly")
 	}
 }

--- a/pkg/deploy/identity-provider/identity_provider_test.go
+++ b/pkg/deploy/identity-provider/identity_provider_test.go
@@ -196,3 +196,16 @@ func TestSyncGitHubOAuth(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateStatus(t *testing.T) {
+	deployContext := deploy.GetTestDeployContext(nil, []runtime.Object{})
+
+	done, err := updateStatus(deployContext, "endpoint/auth")
+	if !done {
+		t.Fatalf("Failed to sync Identity Provider: %v", err)
+	}
+
+	if deployContext.CheCluster.Status.KeycloakURL != "http://endpoint/auth/" {
+		t.Fatalf("Status wasn't updated properly")
+	}
+}

--- a/pkg/deploy/pluginregistry/pluginregistry.go
+++ b/pkg/deploy/pluginregistry/pluginregistry.go
@@ -100,9 +100,9 @@ func (p *PluginRegistry) UpdateStatus(endpoint string) (bool, error) {
 
 	// append the API version to plugin registry
 	if !strings.HasSuffix(pluginRegistryURL, "/") {
-		pluginRegistryURL = pluginRegistryURL + "/v3"
+		pluginRegistryURL = pluginRegistryURL + "/v3/"
 	} else {
-		pluginRegistryURL = pluginRegistryURL + "v3"
+		pluginRegistryURL = pluginRegistryURL + "v3/"
 	}
 
 	if pluginRegistryURL != p.deployContext.CheCluster.Status.PluginRegistryURL {

--- a/pkg/deploy/pluginregistry/pluginregistry_test.go
+++ b/pkg/deploy/pluginregistry/pluginregistry_test.go
@@ -22,6 +22,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -81,5 +82,20 @@ func TestPluginRegistrySyncAll(t *testing.T) {
 
 	if cheCluster.Status.PluginRegistryURL == "" {
 		t.Fatalf("Status wasn't updated")
+	}
+}
+
+func TestUpdateStatus(t *testing.T) {
+	expectedPluginRegistryURL := "http://endpoint/v3/"
+	deployContext := deploy.GetTestDeployContext(nil, []runtime.Object{})
+
+	pluginregistry := NewPluginRegistry(deployContext)
+	done, err := pluginregistry.UpdateStatus("endpoint")
+	if !done {
+		t.Fatalf("Failed to sync Plugin Registry: %v", err)
+	}
+
+	if deployContext.CheCluster.Status.PluginRegistryURL != expectedPluginRegistryURL {
+		t.Fatalf("Expected %s, but found: %s", expectedPluginRegistryURL, deployContext.CheCluster.Status.PluginRegistryURL)
 	}
 }

--- a/pkg/deploy/server/server_configmap.go
+++ b/pkg/deploy/server/server_configmap.go
@@ -95,11 +95,15 @@ func (s *Server) getCheConfigMapData() (cheEnv map[string]string, err error) {
 
 	// Adds `/auth` for external identity providers.
 	// If identity provide is deployed by operator then `/auth` is already added.
-	if s.deployContext.CheCluster.Spec.Auth.ExternalIdentityProvider && !strings.HasSuffix(keycloakURL, "/auth") {
-		if strings.HasSuffix(keycloakURL, "/") {
-			keycloakURL = keycloakURL + "auth"
-		} else {
-			keycloakURL = keycloakURL + "/auth"
+	if s.deployContext.CheCluster.Spec.Auth.ExternalIdentityProvider {
+		if strings.HasSuffix(keycloakURL, "/auth") {
+			keycloakURL += "/"
+		} else if !strings.HasSuffix(keycloakURL, "/auth/") {
+			if strings.HasSuffix(keycloakURL, "/") {
+				keycloakURL = keycloakURL + "auth/"
+			} else {
+				keycloakURL = keycloakURL + "/auth/"
+			}
 		}
 	}
 

--- a/pkg/deploy/server/server_configmap_test.go
+++ b/pkg/deploy/server/server_configmap_test.go
@@ -637,11 +637,11 @@ func TestShouldSetUpCorrectlyInternalPluginRegistryServiceURL(t *testing.T) {
 					},
 				},
 				Status: orgv1.CheClusterStatus{
-					PluginRegistryURL: "http://plugin-registry/v3",
+					PluginRegistryURL: "http://plugin-registry/v3/",
 				},
 			},
 			expectedData: map[string]string{
-				"CHE_WORKSPACE_PLUGIN__REGISTRY__INTERNAL__URL": "http://plugin-registry/v3",
+				"CHE_WORKSPACE_PLUGIN__REGISTRY__INTERNAL__URL": "http://plugin-registry/v3/",
 			},
 		},
 		{
@@ -801,8 +801,8 @@ func TestShouldSetUpCorrectlyInternalIdentityProviderServiceURL(t *testing.T) {
 				},
 			},
 			expectedData: map[string]string{
-				"CHE_KEYCLOAK_AUTH__INTERNAL__SERVER__URL": "http://external-keycloak/auth",
-				"CHE_KEYCLOAK_AUTH__SERVER__URL":           "http://external-keycloak/auth",
+				"CHE_KEYCLOAK_AUTH__INTERNAL__SERVER__URL": "http://external-keycloak/auth/",
+				"CHE_KEYCLOAK_AUTH__SERVER__URL":           "http://external-keycloak/auth/",
 			},
 		},
 		{
@@ -822,13 +822,13 @@ func TestShouldSetUpCorrectlyInternalIdentityProviderServiceURL(t *testing.T) {
 					Auth: orgv1.CheClusterSpecAuth{
 						OpenShiftoAuth:           util.NewBoolPointer(false),
 						ExternalIdentityProvider: true,
-						IdentityProviderURL:      "http://external-keycloak/auth",
+						IdentityProviderURL:      "http://external-keycloak/auth/",
 					},
 				},
 			},
 			expectedData: map[string]string{
-				"CHE_KEYCLOAK_AUTH__INTERNAL__SERVER__URL": "http://external-keycloak/auth",
-				"CHE_KEYCLOAK_AUTH__SERVER__URL":           "http://external-keycloak/auth",
+				"CHE_KEYCLOAK_AUTH__INTERNAL__SERVER__URL": "http://external-keycloak/auth/",
+				"CHE_KEYCLOAK_AUTH__SERVER__URL":           "http://external-keycloak/auth/",
 			},
 		},
 		{
@@ -853,8 +853,8 @@ func TestShouldSetUpCorrectlyInternalIdentityProviderServiceURL(t *testing.T) {
 				},
 			},
 			expectedData: map[string]string{
-				"CHE_KEYCLOAK_AUTH__INTERNAL__SERVER__URL": "http://external-keycloak/auth",
-				"CHE_KEYCLOAK_AUTH__SERVER__URL":           "http://external-keycloak/auth",
+				"CHE_KEYCLOAK_AUTH__INTERNAL__SERVER__URL": "http://external-keycloak/auth/",
+				"CHE_KEYCLOAK_AUTH__SERVER__URL":           "http://external-keycloak/auth/",
 			},
 		},
 		{
@@ -874,13 +874,13 @@ func TestShouldSetUpCorrectlyInternalIdentityProviderServiceURL(t *testing.T) {
 					Auth: orgv1.CheClusterSpecAuth{
 						OpenShiftoAuth:           util.NewBoolPointer(false),
 						ExternalIdentityProvider: false,
-						IdentityProviderURL:      "http://keycloak/auth",
+						IdentityProviderURL:      "http://keycloak/auth/",
 					},
 				},
 			},
 			expectedData: map[string]string{
-				"CHE_KEYCLOAK_AUTH__INTERNAL__SERVER__URL": "http://keycloak/auth",
-				"CHE_KEYCLOAK_AUTH__SERVER__URL":           "http://keycloak/auth",
+				"CHE_KEYCLOAK_AUTH__INTERNAL__SERVER__URL": "http://keycloak/auth/",
+				"CHE_KEYCLOAK_AUTH__SERVER__URL":           "http://keycloak/auth/",
 			},
 		},
 		{
@@ -900,13 +900,13 @@ func TestShouldSetUpCorrectlyInternalIdentityProviderServiceURL(t *testing.T) {
 					Auth: orgv1.CheClusterSpecAuth{
 						OpenShiftoAuth:           util.NewBoolPointer(false),
 						ExternalIdentityProvider: false,
-						IdentityProviderURL:      "http://keycloak/auth",
+						IdentityProviderURL:      "http://keycloak/auth/",
 					},
 				},
 			},
 			expectedData: map[string]string{
 				"CHE_KEYCLOAK_AUTH__INTERNAL__SERVER__URL": "http://keycloak.eclipse-che.svc:8080/auth",
-				"CHE_KEYCLOAK_AUTH__SERVER__URL":           "http://keycloak/auth",
+				"CHE_KEYCLOAK_AUTH__SERVER__URL":           "http://keycloak/auth/",
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Add slash to the end of URLs

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
```
  ✔ Show important messages
    ✔ Eclipse Che 7.33.0-SNAPSHOT has been successfully deployed.
    ✔ Documentation             : https://www.eclipse.org/che/docs/
    ✔ -------------------------------------------------------------------------------
    ✔ Users Dashboard           : https://192.168.99.100.nip.io
    ✔ Admin user login          : "admin:admin". NOTE: must change after first login.
    ✔ -------------------------------------------------------------------------------
    ✔ Plug-in Registry          : https://192.168.99.100.nip.io/plugin-registry/v3/
    ✔ Devfile Registry          : https://192.168.99.100.nip.io/devfile-registry/
    ✔ -------------------------------------------------------------------------------
    ✔ Identity Provider URL     : https://192.168.99.100.nip.io/auth/
    ✔ Identity Provider login   : "admin:n8RKyKpoSIYH".
    ✔ -------------------------------------------------------------------------------
```

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19995

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist
          
[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
