### PR TITLE
fix: Start workspace with devfilev2 when devworkspace is enabled in our e2e tests

### DIFF
--- a/.ci/cico_updates_openshift.sh
+++ b/.ci/cico_updates_openshift.sh
@@ -21,7 +21,6 @@ source "${OPERATOR_REPO}"/.github/bin/oauth-provision.sh
 trap "catchFinish" EXIT SIGINT
 
 overrideDefaults() {
-  export DEV_WORKSPACE_ENABLE="true"
   export CHE_EXPOSURE_STRATEGY="single-host"
 }
 
@@ -33,7 +32,9 @@ runTests() {
   waitWorkspaceStart
 
   # Dev Workspace controller tests
+  enableDevWorkspaceEngine
   waitDevWorkspaceControllerStarted
+  waitEclipseCheDeployed ${LAST_PACKAGE_VERSION}
 
   sleep 10s
   createWorkspaceDevWorkspaceController

--- a/.ci/oci-multi-host.sh
+++ b/.ci/oci-multi-host.sh
@@ -31,10 +31,12 @@ overrideDefaults() {
   # CI_CHE_OPERATOR_IMAGE it is che operator image builded in openshift CI job workflow. More info about how works image dependencies in ci:https://github.com/openshift/ci-tools/blob/master/TEMPLATES.md#parameters-available-to-templates
   export OPERATOR_IMAGE=${CI_CHE_OPERATOR_IMAGE}
   export CHE_EXPOSURE_STRATEGY="multi-host"
-  export DEV_WORKSPACE_ENABLE="true"
 }
 
 runTests() {
+    # create namespace
+    oc create namespace eclipse-che || true
+
     # Deploy Eclipse Che applying CR
     applyOlmCR
     waitEclipseCheDeployed "next"
@@ -43,7 +45,9 @@ runTests() {
     waitWorkspaceStart
 
     # Dev Workspace controller tests
+    enableDevWorkspaceEngine
     waitDevWorkspaceControllerStarted
+    waitEclipseCheDeployed "next"
 
     sleep 10s
     createWorkspaceDevWorkspaceController

--- a/.ci/oci-single-host.sh
+++ b/.ci/oci-single-host.sh
@@ -31,10 +31,12 @@ overrideDefaults() {
   # CI_CHE_OPERATOR_IMAGE it is che operator image builded in openshift CI job workflow. More info about how works image dependencies in ci:https://github.com/openshift/ci-tools/blob/master/TEMPLATES.md#parameters-available-to-templates
   export OPERATOR_IMAGE=${CI_CHE_OPERATOR_IMAGE}
   export CHE_EXPOSURE_STRATEGY="single-host"
-  export DEV_WORKSPACE_ENABLE="true"
 }
 
 runTests() {
+    # create namespace
+    oc create namespace eclipse-che || true
+
     # Deploy Eclipse Che applying CR
     applyOlmCR
     waitEclipseCheDeployed "next"
@@ -43,7 +45,9 @@ runTests() {
     waitWorkspaceStart
 
     # Dev Workspace controller tests
+    enableDevWorkspaceEngine
     waitDevWorkspaceControllerStarted
+    waitEclipseCheDeployed "next"
 
     sleep 10s
     createWorkspaceDevWorkspaceController

--- a/.github/bin/common.sh
+++ b/.github/bin/common.sh
@@ -477,3 +477,7 @@ waitWorkspaceStartedDevWorkspaceController() {
 createWorkspaceDevWorkspaceCheOperator() {
   oc apply -f https://raw.githubusercontent.com/che-incubator/devworkspace-che-operator/main/samples/flattened_theia-nodejs.yaml -n ${NAMESPACE}
 }
+
+enableDevWorkspaceEngine() {
+  kubectl patch checluster/eclipse-che -n ${NAMESPACE} --type=merge -p '{"spec":{"devWorkspace":{"enable": true}}}'
+}


### PR DESCRIPTION
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Start devfile v1 when devworkspace is not enabled and start workspace v2 when devworkspace engine it is enabled

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20072

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist
          
[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
