### PR TITLE
fix: adds nginx.org/websocket-services annotation for che ingress

### DIFF
--- a/pkg/deploy/ingres_test.go
+++ b/pkg/deploy/ingres_test.go
@@ -51,10 +51,10 @@ func TestIngressSpec(t *testing.T) {
 		{
 			name:             "Test custom host",
 			ingressName:      "test",
-			ingressComponent: "test-component",
+			ingressComponent: "che",
 			ingressHost:      "test-host",
 			ingressPath:      "",
-			serviceName:      "che",
+			serviceName:      "che-host",
 			servicePort:      8080,
 			ingressCustomSettings: orgv1.IngressCustomSettings{
 				Labels:      "type=default",
@@ -66,7 +66,7 @@ func TestIngressSpec(t *testing.T) {
 					Namespace: "eclipse-che",
 					Labels: map[string]string{
 						"type":                         "default",
-						"app.kubernetes.io/component":  "test-component",
+						"app.kubernetes.io/component":  "che",
 						"app.kubernetes.io/instance":   DefaultCheFlavor(cheCluster),
 						"app.kubernetes.io/managed-by": DefaultCheFlavor(cheCluster) + "-operator",
 						"app.kubernetes.io/name":       DefaultCheFlavor(cheCluster),
@@ -77,7 +77,8 @@ func TestIngressSpec(t *testing.T) {
 						"nginx.ingress.kubernetes.io/proxy-connect-timeout": "3600",
 						"nginx.ingress.kubernetes.io/proxy-read-timeout":    "3600",
 						"nginx.ingress.kubernetes.io/ssl-redirect":          "false",
-						"annotation-key": "annotation-value",
+						"nginx.org/websocket-services":                      "che-host",
+						"annotation-key":                                    "annotation-value",
 					},
 				},
 				TypeMeta: metav1.TypeMeta{
@@ -93,7 +94,7 @@ func TestIngressSpec(t *testing.T) {
 									Paths: []v1beta1.HTTPIngressPath{
 										{
 											Backend: v1beta1.IngressBackend{
-												ServiceName: "che",
+												ServiceName: "che-host",
 												ServicePort: intstr.FromInt(8080),
 											},
 											Path: "/",

--- a/pkg/deploy/ingress.go
+++ b/pkg/deploy/ingress.go
@@ -160,6 +160,11 @@ func GetIngressSpec(
 		},
 	}
 
+	if component == cheFlavor {
+		// adds annotation, see details https://github.com/eclipse/che/issues/19434#issuecomment-810325262
+		ingress.ObjectMeta.Annotations["nginx.org/websocket-services"] = serviceName
+	}
+
 	if tlsSupport {
 		ingress.Spec.TLS = []v1beta1.IngressTLS{
 			{


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Adds `nginx.org/websocket-services: che-host` annotation for che ingress

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19434

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist
          
[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
