### PR TITLE
feat: add an ability to add localhost to allows list for keycloak

### DIFF
--- a/pkg/deploy/deployment.go
+++ b/pkg/deploy/deployment.go
@@ -53,6 +53,10 @@ func SyncDeploymentSpecToCluster(
 		return false, err
 	}
 
+	if err := MountConfigMaps(deploymentSpec, deployContext); err != nil {
+		return false, err
+	}
+
 	done, err := Sync(deployContext, deploymentSpec, deploymentDiffOpts)
 	if err != nil || !done {
 		return false, err
@@ -165,6 +169,106 @@ func MountSecrets(specDeployment *appsv1.Deployment, deployContext *DeployContex
 							Key: key,
 							LocalObjectReference: corev1.LocalObjectReference{
 								Name: secretObj.Name,
+							},
+						},
+					},
+				}
+				container.Env = append(container.Env, env)
+			}
+		}
+	}
+
+	return nil
+}
+
+// MountConfigMaps mounts configmaps into a container as a file or as environment variable.
+// Configmaps are selected by the following labels:
+// - app.kubernetes.io/part-of=che.eclipse.org
+// - app.kubernetes.io/component=<DEPLOYMENT-NAME>-configmap
+func MountConfigMaps(specDeployment *appsv1.Deployment, deployContext *DeployContext) error {
+	configmaps := &corev1.ConfigMapList{}
+
+	kubernetesPartOfLabelSelectorRequirement, _ := labels.NewRequirement(KubernetesPartOfLabelKey, selection.Equals, []string{CheEclipseOrg})
+	kubernetesComponentLabelSelectorRequirement, _ := labels.NewRequirement(KubernetesComponentLabelKey, selection.Equals, []string{specDeployment.Name + "-configmap"})
+
+	listOptions := &client.ListOptions{
+		LabelSelector: labels.NewSelector().Add(*kubernetesPartOfLabelSelectorRequirement).Add(*kubernetesComponentLabelSelectorRequirement),
+	}
+	if err := deployContext.ClusterAPI.Client.List(context.TODO(), configmaps, listOptions); err != nil {
+		return err
+	}
+
+	// sort configmaps by name first to have the same order every time
+	sort.Slice(configmaps.Items, func(i, j int) bool {
+		return strings.Compare(configmaps.Items[i].Name, configmaps.Items[j].Name) < 0
+	})
+
+	container := &specDeployment.Spec.Template.Spec.Containers[0]
+	for _, configMapObj := range configmaps.Items {
+		switch configMapObj.Annotations[CheEclipseOrgMountAs] {
+		case "file":
+			voluseSource := corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: configMapObj.Name,
+					},
+				},
+			}
+
+			volume := corev1.Volume{
+				Name:         configMapObj.Name,
+				VolumeSource: voluseSource,
+			}
+
+			volumeMount := corev1.VolumeMount{
+				Name:      configMapObj.Name,
+				MountPath: configMapObj.Annotations[CheEclipseOrgMountPath],
+			}
+
+			specDeployment.Spec.Template.Spec.Volumes = append(specDeployment.Spec.Template.Spec.Volumes, volume)
+			container.VolumeMounts = append(container.VolumeMounts, volumeMount)
+
+		case "env":
+			configmap := &corev1.ConfigMap{}
+			exists, err := GetNamespacedObject(deployContext, configMapObj.Name, configmap)
+			if err != nil {
+				return err
+			} else if !exists {
+				return fmt.Errorf("ConfigMap '%s' not found", configMapObj.Name)
+			}
+
+			// grab all keys and sort first to have the same order every time
+			keys := make([]string, 0)
+			for k := range configmap.Data {
+				keys = append(keys, k)
+			}
+			sort.Slice(keys, func(i, j int) bool {
+				return strings.Compare(keys[i], keys[j]) < 0
+			})
+
+			for _, key := range keys {
+				var envName string
+
+				// check if evn name defined explicitly
+				envNameAnnotation := CheEclipseOrg + "/" + key + "_env-name"
+				envName, envNameExists := configMapObj.Annotations[envNameAnnotation]
+				if !envNameExists {
+					// check if there is only one env name to mount
+					envName, envNameExists = configMapObj.Annotations[CheEclipseOrgEnvName]
+					if len(configmap.Data) > 1 {
+						return fmt.Errorf("There are more than one environment variable to mount. Use annotation '%s' to specify a name", envNameAnnotation)
+					} else if !envNameExists {
+						return fmt.Errorf("Environment name to mount configmap key not found. Use annotation '%s' to specify a name", CheEclipseOrgEnvName)
+					}
+				}
+
+				env := corev1.EnvVar{
+					Name: envName,
+					ValueFrom: &corev1.EnvVarSource{
+						ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+							Key: key,
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: configMapObj.Name,
 							},
 						},
 					},

--- a/templates/keycloak-provision.sh
+++ b/templates/keycloak-provision.sh
@@ -37,12 +37,24 @@ provisionKeycloak() {
     -s adminTheme={{ .KeycloakTheme }} \
     -s emailTheme={{ .KeycloakTheme }}
 
+  DEFAULT_WEBORIGINS='"http://{{ .CheHost }}", "https://{{ .CheHost }}"'
+  # ADDITIONAL_WEBORIGINS is an env var in format '"url1", "url2"'
+  # which if specified, is provisioned to keycloak additionally to Che's URLs ones
+  [ ! -z "$ADDITIONAL_WEBORIGINS" ] && ADDITIONAL_WEBORIGINS=", $ADDITIONAL_WEBORIGINS"
+  WEBORIGINS="[$DEFAULT_WEBORIGINS $ADDITIONAL_WEBORIGINS]"
+
+  DEFAULT_REDIRECT_URIS='"http://{{ .CheHost }}/dashboard/*", "https://{{ .CheHost }}/dashboard/*", "http://{{ .CheHost }}/factory*", "https://{{ .CheHost }}/factory*", "http://{{ .CheHost }}/f*", "https://{{ .CheHost }}/f*", "http://{{ .CheHost }}/_app/*", "https://{{ .CheHost }}/_app/*", "http://{{ .CheHost }}/swagger/*", "https://{{ .CheHost }}/swagger/*"'
+  # ADDITIONAL_REDIRECT_URIS is an env var in format '"url1", "url2"'
+  # which if specified, is provisioned to keycloak additionally to Che's URLs ones
+  [ ! -z "$ADDITIONAL_REDIRECT_URIS" ] && ADDITIONAL_REDIRECT_URIS=", $ADDITIONAL_REDIRECT_URIS"
+  REDIRECT_URIS="[$DEFAULT_REDIRECT_URIS $ADDITIONAL_REDIRECT_URIS]"
+
   {{ .Script }} create clients \
     -r '{{ .KeycloakRealm }}' \
     -s clientId={{ .KeycloakClientId }} \
     -s id={{ .KeycloakClientId }} \
-    -s webOrigins='["http://{{ .CheHost }}", "https://{{ .CheHost }}"]' \
-    -s redirectUris='["http://{{ .CheHost }}/dashboard/*", "https://{{ .CheHost }}/dashboard/*", "http://{{ .CheHost }}/factory*", "https://{{ .CheHost }}/factory*", "http://{{ .CheHost }}/f*", "https://{{ .CheHost }}/f*", "http://{{ .CheHost }}/_app/*", "https://{{ .CheHost }}/_app/*", "http://{{ .CheHost }}/swagger/*", "https://{{ .CheHost }}/swagger/*"]' \
+    -s webOrigins="$WEBORIGINS" \
+    -s redirectUris="$REDIRECT_URIS" \
     -s directAccessGrantsEnabled=true \
     -s publicClient=true
 

--- a/templates/keycloak-update.sh
+++ b/templates/keycloak-update.sh
@@ -15,10 +15,22 @@ connectToKeycloak() {
 }
 
 updateKeycloak() {
+  DEFAULT_WEBORIGINS='"http://{{ .CheHost }}", "https://{{ .CheHost }}"'
+  # ADDITIONAL_WEBORIGINS is an env var in format '"url1", "url2"'
+  # which if specified, is provisioned to keycloak additionally to Che's URLs ones
+  [ ! -z "$ADDITIONAL_WEBORIGINS" ] && ADDITIONAL_WEBORIGINS=", $ADDITIONAL_WEBORIGINS"
+  WEBORIGINS="[$DEFAULT_WEBORIGINS $ADDITIONAL_WEBORIGINS]"
+
+  DEFAULT_REDIRECT_URIS='"http://{{ .CheHost }}/dashboard/*", "https://{{ .CheHost }}/dashboard/*", "http://{{ .CheHost }}/factory*", "https://{{ .CheHost }}/factory*", "http://{{ .CheHost }}/f*", "https://{{ .CheHost }}/f*", "http://{{ .CheHost }}/_app/*", "https://{{ .CheHost }}/_app/*", "http://{{ .CheHost }}/swagger/*", "https://{{ .CheHost }}/swagger/*"'
+  # ADDITIONAL_REDIRECT_URIS is an env var in format '"url1", "url2"'
+  # which if specified, is provisioned to keycloak additionally to Che's URLs ones
+  [ ! -z "$ADDITIONAL_REDIRECT_URIS" ] && ADDITIONAL_REDIRECT_URIS=", $ADDITIONAL_REDIRECT_URIS"
+  REDIRECT_URIS="[$DEFAULT_REDIRECT_URIS $ADDITIONAL_REDIRECT_URIS]"
+
   {{ .Script }} update clients/{{ .KeycloakClientId }} \
     -r '{{ .KeycloakRealm }}' \
-    -s webOrigins='["http://{{ .CheHost }}", "https://{{ .CheHost }}"]' \
-    -s redirectUris='["http://{{ .CheHost }}/dashboard/*", "https://{{ .CheHost }}/dashboard/*", "http://{{ .CheHost }}/factory*", "https://{{ .CheHost }}/factory*", "http://{{ .CheHost }}/f*", "https://{{ .CheHost }}/f*", "http://{{ .CheHost }}/_app/*", "https://{{ .CheHost }}/_app/*", "http://{{ .CheHost }}/swagger/*", "https://{{ .CheHost }}/swagger/*"]'
+    -s webOrigins="$WEBORIGINS" \
+    -s redirectUris="$REDIRECT_URIS"
 }
 
 checkKeycloak() {


### PR DESCRIPTION
### What does this PR do?
It's a draft since some of the corner cases are not tested yet.

The purpose of this PR is adding an ability to add localhost to allow list for keycloak,
but since such kind of data is not secret, it also add a mechanism for mounting additional configmap into deployment.
It's just a copying/pasting mechanism we have for secrets, sorry about that, I did not manage to prepare the better solution in my Hack&Hustle.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
it solves https://github.com/eclipse/che/issues/19158

### How to test this PR?

I did the following two stories

:warning: Known limitation: Che Operator should be rescaled after configmap is created/updated/removed, since update script is executed only on Keycloak host change:
https://github.com/eclipse-che/che-operator/blob/main/pkg/deploy/identity-provider/identity_provider.go#L134
@tolusha is aware of it and is OK to move it out of the scope. Probably it needs to introducing one more field into status.

##### Test provision/update scripts with missing custom settings, and then update script with custom settings

```bash
#deploy che with custom operator image built from this PR
chectl server:deploy --platform=minikube --installer=operator --che-operator-image=sleshchenko/che-operator:keycloak-localhost

# make sure that Che is deployed and working

# create a configmap that would whitelist localhost
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: keycloak-custom-config
  namespace: eclipse-che
  labels:
    app.kubernetes.io/part-of: che.eclipse.org
    app.kubernetes.io/component: keycloak-configmap
  annotations:
    che.eclipse.org/mount-as: env
    che.eclipse.org/ADDITIONAL_REDIRECT_URIS_env-name: ADDITIONAL_REDIRECT_URIS
    che.eclipse.org/ADDITIONAL_WEBORIGINS_env-name: ADDITIONAL_WEBORIGINS
data:
  ADDITIONAL_WEBORIGINS: '"http://localhost:3000"'
  ADDITIONAL_REDIRECT_URIS: '"http://localhost:3000/*"'
EOF

oc rollout restart deployment/che-operator
# after keycloak is che operator did exec, check that keycloak has localhost in weborigin and redirect URLs for che-public client
```

##### Test provision/update scripts with custom settings
```bash
kubectl create namespace eclipse-che || true
# create a configmap that would whitelist localhost
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: keycloak-custom-config
  namespace: eclipse-che
  labels:
    app.kubernetes.io/part-of: che.eclipse.org
    app.kubernetes.io/component: keycloak-configmap
  annotations:
    che.eclipse.org/mount-as: env
    che.eclipse.org/ADDITIONAL_REDIRECT_URIS_env-name: ADDITIONAL_REDIRECT_URIS
    che.eclipse.org/ADDITIONAL_WEBORIGINS_env-name: ADDITIONAL_WEBORIGINS
data:
  ADDITIONAL_WEBORIGINS: '"http://localhost:3000"'
  ADDITIONAL_REDIRECT_URIS: '"http://localhost:3000/*"'
EOF

#deploy che with custom operator image built from this PR
chectl server:deploy --platform=minikube --installer=operator --che-operator-image=sleshchenko/che-operator:keycloak-localhost

# After Che is ready, check that keycloak has localhost in weborigin and redirect URLs for che-public client
```

### PR Checklist
          
[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
