### PR TITLE
feat: Update image puller default images when CSV file is updated

### DIFF
--- a/controllers/che/checluster_controller_test.go
+++ b/controllers/che/checluster_controller_test.go
@@ -199,7 +199,7 @@ var (
 			Name: "cluster",
 		},
 	}
-	defaultImagePullerImages = ""
+	defaultImagePullerImages string
 )
 
 func init() {
@@ -211,7 +211,8 @@ func init() {
 			os.Setenv(env.Name, env.Value)
 		}
 	}
-	defaultImagePullerImages = "che-workspace-plugin-broker-metadata=" + os.Getenv("RELATED_IMAGE_che_workspace_plugin_broker_metadata") + ";che-workspace-plugin-broker-artifacts=" + os.Getenv("RELATED_IMAGE_che_workspace_plugin_broker_artifacts") + ";"
+	defaultImagePullerImages = "che-workspace-plugin-broker-metadata=" + os.Getenv("RELATED_IMAGE_che_workspace_plugin_broker_metadata") +
+		";che-workspace-plugin-broker-artifacts=" + os.Getenv("RELATED_IMAGE_che_workspace_plugin_broker_artifacts") + ";"
 }
 
 func TestCaseAutoDetectOAuth(t *testing.T) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -439,6 +439,39 @@ func GetArchitectureDependentEnv(env string) string {
 	return env
 }
 
+// GetImageNameAndTag returns the image repository and tag name from the provided image
+//
+// Referenced from https://github.com/che-incubator/chectl/blob/main/src/util.ts
+func GetImageNameAndTag(image string) (string, string) {
+	var imageName, imageTag string
+	if strings.Contains(image, "@") {
+		// Image is referenced via a digest
+		index := strings.Index(image, "@")
+		imageName = image[:index]
+		imageTag = image[index+1:]
+	} else {
+		// Image is referenced via a tag
+		lastColonIndex := strings.LastIndex(image, ":")
+		if lastColonIndex == -1 {
+			imageName = image
+			imageTag = "latest"
+		} else {
+			beforeLastColon := image[:lastColonIndex]
+			afterLastColon := image[lastColonIndex+1:]
+			if strings.Contains(afterLastColon, "/") {
+				// The colon is for registry port and not for a tag
+				imageName = image
+				imageTag = "latest"
+			} else {
+				// The colon separates image name from the tag
+				imageName = beforeLastColon
+				imageTag = afterLastColon
+			}
+		}
+	}
+	return imageName, imageTag
+}
+
 // NewBoolPointer returns `bool` pointer to value in the memory.
 // Unfortunately golang hasn't got syntax to create `bool` pointer.
 func NewBoolPointer(value bool) *bool {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -45,3 +45,21 @@ func TestGetValue(t *testing.T) {
 		t.Errorf("Test failed. Expected '%s', but got '%s'", var2, defaultValue)
 	}
 }
+
+func TestGetImageNameAndTag(t *testing.T) {
+	var tests = []struct {
+		input        string
+		expectedName string
+		expectedTag  string
+	}{
+		{"quay.io/test/test:tag", "quay.io/test/test", "tag"},
+		{"quay.io/test/test@sha256:abcdef", "quay.io/test/test", "sha256:abcdef"},
+		{"quay.io/test/test", "quay.io/test/test", "latest"},
+		{"localhost:5000/test", "localhost:5000/test", "latest"},
+	}
+	for _, test := range tests {
+		if actualName, actualTag := GetImageNameAndTag(test.input); actualName != test.expectedName || actualTag != test.expectedTag {
+			t.Errorf("Test Failed. Expected '%s' and '%s', but got '%s' and '%s'", test.expectedName, test.expectedTag, actualName, actualTag)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
If the `spec.imagePuller.spec.images` contains default images, and when the CSV file updates with new default images (i.e. image with different tag), then the new default images will replace the old default images in the `spec.imagePuller.spec.images`. This PR will not add new default images; it only updates default images that already exist in `spec.imagePuller.spec.images`. 

Default images are `RELATED_IMAGE` images that match any of these patterns here: https://github.com/eclipse-che/che-operator/blob/ac0bd56e41a96d797d59414ede24509549cedcd4/pkg/deploy/kubernetes_image_puller.go#L415-L431

Image: `quay.io/dkwon17/che-operator:20081`

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
Updating default images in CSV file (by changing the tag from `v3.4.0` to `nightly`), updates the default images in the KIP daemon set:
![che-20081](https://user-images.githubusercontent.com/83611742/125975933-4175eb23-433b-45be-b1dd-40db533e866e.gif)

After a few minutes, the images are updated in the daemon set:
![image](https://user-images.githubusercontent.com/83611742/125975255-68fb1815-693c-4ab9-9fdf-2b245cfb2f1b.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Fixes: https://github.com/eclipse/che/issues/20081

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->

1. To test on `crc`, deploy with `chectl`:
```
crc start --memory=16192 --cpus=4
```
```
chectl server:deploy -n eclipse-che --olm-channel=nightly -p openshift --che-operator-image=quay.io/dkwon17/che-operator:20081
```
2. Enable Kubernetes image puller by changing `spec.imagePuller.enabled` to `true` in the CheCluster CR instance yaml file, and save the changes:
![image](https://user-images.githubusercontent.com/83611742/125965844-d67882e3-7fbc-41fb-bd5c-15860cf277ef.png)

Enabling the image puller will create a daemonset that lists two default images with a `v3.4.0` tag:
![image](https://user-images.githubusercontent.com/83611742/125970118-bbe300c4-4db1-4783-b5c2-3f71a4b1c8cc.png)
The images above are the default images for the current Che installation.

3. Simulate a `che-operator` update with new default images by updating the CSV file. To update the defaults, find the `RELATED_IMAGE_che_workspace_plugin_broker_metadata` and `RELATED_IMAGE_che_workspace_plugin_broker_artifacts` environment variables and, change the image tag from `v3.4.0` to `nightly` and save changes:
![image](https://user-images.githubusercontent.com/83611742/125971306-119ea3f1-4115-4efb-8e1c-cb5f2f771c72.png)


4. After waiting a few minutes, the image puller daemon set will contain the updated images (`nightly` tag):
![image](https://user-images.githubusercontent.com/83611742/125971917-2292c66f-9577-454e-99a6-ad919f8802fd.png)

### PR Checklist
          
[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
