### PR TITLE
feat: Add ability to rebuild OLM images manully

### DIFF
--- a/.github/workflows/build-catalog-and-bundle-images.yaml
+++ b/.github/workflows/build-catalog-and-bundle-images.yaml
@@ -18,9 +18,9 @@ on:
         description: 'Reason to trigger a build'
         required: false
   schedule:
-  - cron:  '0 21 * * *'
-    branches:
-      - main
+    - cron:  '0 21 * * *'
+      branches:
+        - main
 jobs:
   build-images:
     name: Build

--- a/.github/workflows/build-catalog-and-bundle-images.yaml
+++ b/.github/workflows/build-catalog-and-bundle-images.yaml
@@ -11,10 +11,16 @@
 #
 name: Build catalog and bundle images
 on:
+  # manual trigger if required
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason to trigger a build'
+        required: false
   schedule:
-    - cron:  '0 21 * * *'
-      branches:
-        - main
+  - cron:  '0 21 * * *'
+    branches:
+      - main
 jobs:
   build-images:
     name: Build


### PR DESCRIPTION
### What does this PR do?
Add ability to rebuild nightly OLM images manually.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19466


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist
          
[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
