### PR TITLE
chore(debug): Improve debug UX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ VERSION ?= 1.0.2
 
 CHANNELS = "nightly"
 
+ifndef VERBOSE
+MAKEFLAGS += --silent
+endif
+
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 mkfile_dir := $(dir $(mkfile_path))
 


### PR DESCRIPTION
### What does this PR do?
This PR add two features into makefile:
1. Introduce VERBOSE mode, so we see only meaningful output by default, like makefile does not duplicate the whole commands before executing:

```
$ export VERBOSE=true
$ make debug
/home/sleshche/projects/che-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
# Generate CRDs v1beta1
/home/sleshche/projects/che-operator/bin/controller-gen "crd:trivialVersions=true,crdVersions=v1beta1" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
mv """config/crd/bases"/org.eclipse.che_checlusters.yaml"" """config/crd/bases"/org_v1_che_crd-v1beta1.yaml""
mv """config/crd/bases"/org.eclipse.che_chebackupserverconfigurations.yaml"" """config/crd/bases"/org.eclipse.che_chebackupserverconfigurations_crd-v1beta1.yaml""
...
```


```
$ make debug
[INFO] Copying Che Operator ./templates ...
[INFO] Copying Che Operator ./templates completed.
[INFO] Downloading Dev Workspace operator templates ...
[INFO] Downloading Dev Workspace operator templates completed.
[INFO] Downloading Dev Workspace Che operator templates ...
[INFO] Downloading Dev Workspace operator templates completed.
Error from server (AlreadyExists): namespaces "eclipse-che" already exists
customresourcedefinition.apiextensions.k8s.io/checlusters.org.eclipse.che configured
customresourcedefinition.apiextensions.k8s.io/chebackupserverconfigurations.org.eclipse.che configured
customresourcedefinition.apiextensions.k8s.io/checlusterbackups.org.eclipse.che configured
customresourcedefinition.apiextensions.k8s.io/checlusterrestores.org.eclipse.che configured
Che Cluster already exists. Using it.
[INFO] Set up cluster api url: https://api.cluster-bf62.bf62.sandbox1854.opentlc.com:6443
[WARN] Make sure that your CR contains valid ingress domain!```
```

2. I wanted to debug the weird behaviour I had with the current Che Cluster CR, but make debug overridden it. So, now it only init CR but not update.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
N/A

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist
          
[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
