### PR TITLE
fix: don't create keycloak credentials if `nativeUserMode: true`

### DIFF
--- a/pkg/deploy/postgres/postgres.go
+++ b/pkg/deploy/postgres/postgres.go
@@ -51,11 +51,13 @@ func (p *Postgres) SyncAll() (bool, error) {
 		return false, err
 	}
 
-	if !p.deployContext.CheCluster.Status.DbProvisoned {
-		if !util.IsTestMode() { // ignore in tests
-			done, err = p.ProvisionDB()
-			if !done {
-				return false, err
+	if !util.IsNativeUserModeEnabled(p.deployContext.CheCluster) {
+		if !p.deployContext.CheCluster.Status.DbProvisoned {
+			if !util.IsTestMode() { // ignore in tests
+				done, err = p.ProvisionDB()
+				if !done {
+					return false, err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Don't create keycloak credentials if `nativeUserMode: true`

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

TODO: Some changes in chectl are required as well.

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20210


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
 
deploy with `chectl server:deploy --platform=openshift --installer=operator --workspace-engine=dev-workspace --che-operator-cr-patch-yaml=auth.patch --che-operator-image <IMAGE_FROM_PR>` where auth.patch is:
```
spec:
  auth:
    nativeUserMode: true
```

Check output, no keycloak credentials are printed. 
``` 
 ✔ Retrieving Keycloak admin credentials...failed.
  ✔ Retrieving Che self-signed CA certificate...OK
  ✔ Prepare post installation output...done
  ✔ Show important messages
    ✔ Eclipse Che 7.35.0-SNAPSHOT has been successfully deployed.
    ✔ Documentation             : https://www.eclipse.org/che/docs/
    ✔ -------------------------------------------------------------------------------
    ✔ Users Dashboard           : https://che-eclipse-che.apps.ci-ln-lzv1012-f76d1.origin-ci-int-gce.dev.openshift.com
    ✔ HTPasswd user credentials : "che:SsTejG".
    ✔ -------------------------------------------------------------------------------
    ✔ Plug-in Registry          : https://che-eclipse-che.apps.ci-ln-lzv1012-f76d1.origin-ci-int-gce.dev.openshift.com/plugin-registry/v3/
    ✔ Devfile Registry          : https://che-eclipse-che.apps.ci-ln-lzv1012-f76d1.origin-ci-int-gce.dev.openshift.com/devfile-registry/
    ✔ -------------------------------------------------------------------------------
    ✔ -------------------------------------------------------------------------------
```
Some changes in chectl are required too (not to print separator)

### PR Checklist
          
[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
