### PR TITLE
fix: Set `GroupVersionKind` to object after getting it from a cluster

### DIFF
--- a/pkg/deploy/sync.go
+++ b/pkg/deploy/sync.go
@@ -55,6 +55,8 @@ func Sync(deployContext *DeployContext, blueprint metav1.Object, diffOpts ...cmp
 		return false, err
 	}
 
+	// fix GroupVersionKind (it might be empty)
+	actual.GetObjectKind().SetGroupVersionKind(runtimeObject.GetObjectKind().GroupVersionKind())
 	if !exists {
 		return Create(deployContext, blueprint)
 	}
@@ -239,7 +241,7 @@ func Update(deployContext *DeployContext, actual runtime.Object, blueprint metav
 		blueprint.SetLabels(targetLabels)
 
 		client := getClientForObject(actualMeta.GetNamespace(), deployContext)
-		if isUpdateUsingDeleteCreate(blueprint.(runtime.Object).GetObjectKind().GroupVersionKind().Kind) {
+		if isUpdateUsingDeleteCreate(actual.GetObjectKind().GroupVersionKind().Kind) {
 			logrus.Infof("Recreating existing object: %s, name: %s", getObjectType(actualMeta), actualMeta.GetName())
 			done, err := doDelete(client, actual)
 			if !done {

--- a/pkg/deploy/sync.go
+++ b/pkg/deploy/sync.go
@@ -55,7 +55,7 @@ func Sync(deployContext *DeployContext, blueprint metav1.Object, diffOpts ...cmp
 		return false, err
 	}
 
-	// fix GroupVersionKind (it might be empty)
+	// set GroupVersionKind (it might be empty)
 	actual.GetObjectKind().SetGroupVersionKind(runtimeObject.GetObjectKind().GroupVersionKind())
 	if !exists {
 		return Create(deployContext, blueprint)

--- a/pkg/deploy/sync.go
+++ b/pkg/deploy/sync.go
@@ -58,6 +58,7 @@ func Sync(deployContext *DeployContext, blueprint metav1.Object, diffOpts ...cmp
 	if !exists {
 		return Create(deployContext, blueprint)
 	}
+
 	return Update(deployContext, actual, blueprint, diffOpts...)
 }
 
@@ -212,8 +213,6 @@ func Update(deployContext *DeployContext, actual runtime.Object, blueprint metav
 
 	diff := cmp.Diff(actual, blueprint, diffOpts...)
 	if len(diff) > 0 {
-		logrus.Infof("Updating existing object: %s, name: %s", getObjectType(actualMeta), actualMeta.GetName())
-
 		// don't print difference if there are no diffOpts mainly to avoid huge output
 		if len(diffOpts) != 0 {
 			fmt.Printf("Difference:\n%s", diff)
@@ -240,7 +239,8 @@ func Update(deployContext *DeployContext, actual runtime.Object, blueprint metav
 		blueprint.SetLabels(targetLabels)
 
 		client := getClientForObject(actualMeta.GetNamespace(), deployContext)
-		if isUpdateUsingDeleteCreate(actual.GetObjectKind().GroupVersionKind().Kind) {
+		if isUpdateUsingDeleteCreate(blueprint.(runtime.Object).GetObjectKind().GroupVersionKind().Kind) {
+			logrus.Infof("Recreating existing object: %s, name: %s", getObjectType(actualMeta), actualMeta.GetName())
 			done, err := doDelete(client, actual)
 			if !done {
 				return false, err
@@ -253,6 +253,7 @@ func Update(deployContext *DeployContext, actual runtime.Object, blueprint metav
 
 			return doCreate(client, blueprint.(runtime.Object), false)
 		} else {
+			logrus.Infof("Updating existing object: %s, name: %s", getObjectType(actualMeta), actualMeta.GetName())
 			err := setOwnerReferenceIfNeeded(deployContext, blueprint)
 			if err != nil {
 				return false, err


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Set `GroupVersionKind` to object after getting it from a cluster

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
```
level=info msg="Recreating existing object: v1.Service, name: devworkspace-controller-manager-service"
```

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20278

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
