### PR TITLE
feat: update traefik to 2.5.0

### DIFF
--- a/bundle/next/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.35.0-284.next
+  name: eclipse-che-preview-kubernetes.v7.36.0-286.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -885,6 +885,8 @@ spec:
                         value: quay.io/eclipse/che-jwtproxy:0.10.0
                       - name: RELATED_IMAGE_single_host_gateway
                         value: quay.io/eclipse/che--traefik:v2.5.0-eb30f9f09a65cee1fab5ef9c64cb4ec91b800dc3fdd738d62a9d4334f0114683
+                      - name: RELATED_IMAGE_single_host_gateway_native_user_mode
+                        value: quay.io/eclipse/che--traefik:v2.5.0-rc2-df90799aaca1ad6fb9e06d311140035d2a0c2295a4f8f508f6b55ee056bb677e
                       - name: RELATED_IMAGE_single_host_gateway_config_sidecar
                         value: quay.io/che-incubator/configbump:0.1.4
                       - name: RELATED_IMAGE_devworkspace_controller
@@ -1174,4 +1176,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.35.0-284.next
+  version: 7.36.0-286.next

--- a/bundle/next/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.35.0-281.next
+  name: eclipse-che-preview-kubernetes.v7.35.0-284.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -884,9 +884,7 @@ spec:
                       - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
                         value: quay.io/eclipse/che-jwtproxy:0.10.0
                       - name: RELATED_IMAGE_single_host_gateway
-                        value: quay.io/eclipse/che--traefik:v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
-                      - name: RELATED_IMAGE_single_host_gateway_native_user_mode
-                        value: quay.io/eclipse/che--traefik:v2.5.0-rc2-df90799aaca1ad6fb9e06d311140035d2a0c2295a4f8f508f6b55ee056bb677e
+                        value: quay.io/eclipse/che--traefik:v2.5.0-eb30f9f09a65cee1fab5ef9c64cb4ec91b800dc3fdd738d62a9d4334f0114683
                       - name: RELATED_IMAGE_single_host_gateway_config_sidecar
                         value: quay.io/che-incubator/configbump:0.1.4
                       - name: RELATED_IMAGE_devworkspace_controller
@@ -1176,4 +1174,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.35.0-281.next
+  version: 7.35.0-284.next

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.35.0-284.next
+  name: eclipse-che-preview-openshift.v7.36.0-286.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -932,6 +932,8 @@ spec:
                         value: quay.io/eclipse/che-jwtproxy:0.10.0
                       - name: RELATED_IMAGE_single_host_gateway
                         value: quay.io/eclipse/che--traefik:v2.5.0-eb30f9f09a65cee1fab5ef9c64cb4ec91b800dc3fdd738d62a9d4334f0114683
+                      - name: RELATED_IMAGE_single_host_gateway_native_user_mode
+                        value: quay.io/eclipse/che--traefik:v2.5.0-rc2-df90799aaca1ad6fb9e06d311140035d2a0c2295a4f8f508f6b55ee056bb677e
                       - name: RELATED_IMAGE_single_host_gateway_config_sidecar
                         value: quay.io/che-incubator/configbump:0.1.4
                       - name: RELATED_IMAGE_devworkspace_controller
@@ -1243,4 +1245,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.35.0-284.next
+  version: 7.36.0-286.next

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.35.0-281.next
+  name: eclipse-che-preview-openshift.v7.35.0-284.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -931,9 +931,7 @@ spec:
                       - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
                         value: quay.io/eclipse/che-jwtproxy:0.10.0
                       - name: RELATED_IMAGE_single_host_gateway
-                        value: quay.io/eclipse/che--traefik:v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
-                      - name: RELATED_IMAGE_single_host_gateway_native_user_mode
-                        value: quay.io/eclipse/che--traefik:v2.5.0-rc2-df90799aaca1ad6fb9e06d311140035d2a0c2295a4f8f508f6b55ee056bb677e
+                        value: quay.io/eclipse/che--traefik:v2.5.0-eb30f9f09a65cee1fab5ef9c64cb4ec91b800dc3fdd738d62a9d4334f0114683
                       - name: RELATED_IMAGE_single_host_gateway_config_sidecar
                         value: quay.io/che-incubator/configbump:0.1.4
                       - name: RELATED_IMAGE_devworkspace_controller
@@ -1245,4 +1243,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.35.0-281.next
+  version: 7.35.0-284.next

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -81,6 +81,8 @@ spec:
               value: quay.io/eclipse/che-jwtproxy:0.10.0
             - name: RELATED_IMAGE_single_host_gateway
               value: quay.io/eclipse/che--traefik:v2.5.0-eb30f9f09a65cee1fab5ef9c64cb4ec91b800dc3fdd738d62a9d4334f0114683
+            - name: RELATED_IMAGE_single_host_gateway_native_user_mode
+              value: quay.io/eclipse/che--traefik:v2.5.0-rc2-df90799aaca1ad6fb9e06d311140035d2a0c2295a4f8f508f6b55ee056bb677e
             - name: RELATED_IMAGE_single_host_gateway_config_sidecar
               value: quay.io/che-incubator/configbump:0.1.4
             - name: RELATED_IMAGE_devworkspace_controller

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -80,9 +80,7 @@ spec:
             - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
               value: quay.io/eclipse/che-jwtproxy:0.10.0
             - name: RELATED_IMAGE_single_host_gateway
-              value: quay.io/eclipse/che--traefik:v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23
-            - name: RELATED_IMAGE_single_host_gateway_native_user_mode
-              value: quay.io/eclipse/che--traefik:v2.5.0-rc2-df90799aaca1ad6fb9e06d311140035d2a0c2295a4f8f508f6b55ee056bb677e
+              value: quay.io/eclipse/che--traefik:v2.5.0-eb30f9f09a65cee1fab5ef9c64cb4ec91b800dc3fdd738d62a9d4334f0114683
             - name: RELATED_IMAGE_single_host_gateway_config_sidecar
               value: quay.io/che-incubator/configbump:0.1.4
             - name: RELATED_IMAGE_devworkspace_controller

--- a/controllers/devworkspace/defaults/defaults.go
+++ b/controllers/devworkspace/defaults/defaults.go
@@ -12,7 +12,7 @@ const (
 	gatewayImageEnvVarName           = "RELATED_IMAGE_gateway"
 	gatewayConfigurerImageEnvVarName = "RELATED_IMAGE_gateway_configurer"
 
-	defaultGatewayImage           = "quay.io/eclipse/che--traefik:v2.3.2-6e6d4dc5a19afe06778ca092cdbbb98e31cb9f9c313edafa23f81a0e6ddf8a23"
+	defaultGatewayImage           = "quay.io/eclipse/che--traefik:v2.5.0-eb30f9f09a65cee1fab5ef9c64cb4ec91b800dc3fdd738d62a9d4334f0114683"
 	defaultGatewayConfigurerImage = "quay.io/che-incubator/configbump:0.1.4"
 
 	configAnnotationPrefix                       = "che.routing.controller.devfile.io/"

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -27,23 +27,22 @@ import (
 )
 
 var (
-	defaultCheServerImage                       string
-	defaultCheVersion                           string
-	defaultDashboardImage                       string
-	defaultDevworkspaceControllerImage          string
-	defaultPluginRegistryImage                  string
-	defaultDevfileRegistryImage                 string
-	defaultCheTLSSecretsCreationJobImage        string
-	defaultPvcJobsImage                         string
-	defaultPostgresImage                        string
-	defaultKeycloakImage                        string
-	defaultSingleHostGatewayImage               string
-	defaultSingleHostGatewayImageNativeUserMode string
-	defaultSingleHostGatewayConfigSidecarImage  string
-	defaultInternalRestBackupServerImage        string
-	defaultGatewayAuthenticationSidecarImage    string
-	defaultGatewayAuthorizationSidecarImage     string
-	defaultGatewayHeaderProxySidecarImage       string
+	defaultCheServerImage                      string
+	defaultCheVersion                          string
+	defaultDashboardImage                      string
+	defaultDevworkspaceControllerImage         string
+	defaultPluginRegistryImage                 string
+	defaultDevfileRegistryImage                string
+	defaultCheTLSSecretsCreationJobImage       string
+	defaultPvcJobsImage                        string
+	defaultPostgresImage                       string
+	defaultKeycloakImage                       string
+	defaultSingleHostGatewayImage              string
+	defaultSingleHostGatewayConfigSidecarImage string
+	defaultInternalRestBackupServerImage       string
+	defaultGatewayAuthenticationSidecarImage   string
+	defaultGatewayAuthorizationSidecarImage    string
+	defaultGatewayHeaderProxySidecarImage      string
 
 	defaultCheWorkspacePluginBrokerMetadataImage  string
 	defaultCheWorkspacePluginBrokerArtifactsImage string
@@ -182,7 +181,6 @@ func InitDefaultsFromFile(defaultsPath string) {
 	defaultPostgresImage = util.GetDeploymentEnv(operatorDeployment, util.GetArchitectureDependentEnv("RELATED_IMAGE_postgres"))
 	defaultKeycloakImage = util.GetDeploymentEnv(operatorDeployment, util.GetArchitectureDependentEnv("RELATED_IMAGE_keycloak"))
 	defaultSingleHostGatewayImage = util.GetDeploymentEnv(operatorDeployment, util.GetArchitectureDependentEnv("RELATED_IMAGE_single_host_gateway"))
-	defaultSingleHostGatewayImageNativeUserMode = util.GetDeploymentEnv(operatorDeployment, util.GetArchitectureDependentEnv("RELATED_IMAGE_single_host_gateway_native_user_mode"))
 	defaultSingleHostGatewayConfigSidecarImage = util.GetDeploymentEnv(operatorDeployment, util.GetArchitectureDependentEnv("RELATED_IMAGE_single_host_gateway_config_sidecar"))
 	defaultGatewayAuthenticationSidecarImage = util.GetDeploymentEnv(operatorDeployment, util.GetArchitectureDependentEnv("RELATED_IMAGE_gateway_authentication_sidecar"))
 	defaultGatewayAuthorizationSidecarImage = util.GetDeploymentEnv(operatorDeployment, util.GetArchitectureDependentEnv("RELATED_IMAGE_gateway_authorization_sidecar"))
@@ -325,15 +323,7 @@ func DefaultCheServerSecureExposerJwtProxyImage(cr *orgv1.CheCluster) string {
 }
 
 func DefaultSingleHostGatewayImage(cr *orgv1.CheCluster) string {
-	// `nativeUserMode` uses Traefik local plugins, which is supported from version 2.5 that is
-	// currently in Release Candidate. As we don't want to use RC version in our stable release,
-	// we're using 2 images now. As soon as Traefik 2.5 stable will be releases, we will remove
-	// `defaultSingleHostGatewayImageNativeUserMode` and use single image again.
-	if util.IsNativeUserModeEnabled(cr) {
-		return patchDefaultImageName(cr, defaultSingleHostGatewayImageNativeUserMode)
-	} else {
-		return patchDefaultImageName(cr, defaultSingleHostGatewayImage)
-	}
+	return patchDefaultImageName(cr, defaultSingleHostGatewayImage)
 }
 
 func DefaultSingleHostGatewayConfigSidecarImage(cr *orgv1.CheCluster) string {
@@ -458,7 +448,6 @@ func InitDefaultsFromEnv() {
 	defaultPostgresImage = getDefaultFromEnv(util.GetArchitectureDependentEnv("RELATED_IMAGE_postgres"))
 	defaultKeycloakImage = getDefaultFromEnv(util.GetArchitectureDependentEnv("RELATED_IMAGE_keycloak"))
 	defaultSingleHostGatewayImage = getDefaultFromEnv(util.GetArchitectureDependentEnv("RELATED_IMAGE_single_host_gateway"))
-	defaultSingleHostGatewayImageNativeUserMode = getDefaultFromEnv(util.GetArchitectureDependentEnv("RELATED_IMAGE_single_host_gateway_native_user_mode"))
 	defaultSingleHostGatewayConfigSidecarImage = getDefaultFromEnv(util.GetArchitectureDependentEnv("RELATED_IMAGE_single_host_gateway_config_sidecar"))
 	defaultInternalRestBackupServerImage = getDefaultFromEnv(util.GetArchitectureDependentEnv("RELATED_IMAGE_internal_rest_backup_server"))
 	defaultGatewayAuthenticationSidecarImage = getDefaultFromEnv(util.GetArchitectureDependentEnv("RELATED_IMAGE_gateway_authentication_sidecar"))


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
update traefik to 2.5.0

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20142


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->

Prerequisite: use template from PR branch -> clone `https://github.com/sparkoo/che-operator/tree/gh20142-updateTraefik` and build the templates https://github.com/eclipse-che/che-operator#deploy-che-operator-with-chectl-using---installer-operator-flag. Then always deploy with these templates.

1. deploy Che with `server.serverExposureStrategy: single-host`
2. check that traefik container in gateway is 2.5.0
3. start a workspace

_

1. deploy Che with devworkspaces enabled
2. check that traefik container in gateway is 2.5.0
3. start a workspace


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
