### PR TITLE
fix: CHE-20274 Don't set empty value for Che property CHE_INFRA_OPENSHIFT_ROUTE_HOST_DOMAIN__SUFFIX

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -182,7 +182,8 @@
         "CHE_IDENTITY_SECRET": "che-identity-secret",
         "CHE_IDENTITY_POSTGRES_SECRET": "che-identity-postgres-secret",
         "CHE_POSTGRES_SECRET": "che-postgres-secret",
-        "CHE_SERVER_TRUST_STORE_CONFIGMAP_NAME": "ca-certs"
+        "CHE_SERVER_TRUST_STORE_CONFIGMAP_NAME": "ca-certs",
+        "MAX_CONCURRENT_RECONCILES": 10,
       },
       "envFile": "/tmp/che-operator-debug.env",
       "cwd": "${workspaceFolder}",

--- a/api/conversion.go
+++ b/api/conversion.go
@@ -191,7 +191,9 @@ func v2alpha1ToV1_WorkspaceDomainEndpointsBaseDomain(v1 *v1.CheCluster, v2 *v2al
 		if v1.Spec.Server.CustomCheProperties == nil {
 			v1.Spec.Server.CustomCheProperties = map[string]string{}
 		}
-		v1.Spec.Server.CustomCheProperties[routeDomainSuffixPropertyKey] = v2.Spec.WorkspaceDomainEndpoints.BaseDomain
+		if len(v2.Spec.WorkspaceDomainEndpoints.BaseDomain) > 0 {
+			v1.Spec.Server.CustomCheProperties[routeDomainSuffixPropertyKey] = v2.Spec.WorkspaceDomainEndpoints.BaseDomain
+		}
 	} else {
 		v1.Spec.K8s.IngressDomain = v2.Spec.WorkspaceDomainEndpoints.BaseDomain
 	}

--- a/api/conversion_test.go
+++ b/api/conversion_test.go
@@ -353,6 +353,22 @@ func TestV2alpha1ToV1(t *testing.T) {
 		})
 	})
 
+	t.Run("WorkspaceDomainEndpointsBaseDomain-openshift-should-not-be-set-empty-value", func(t *testing.T) {
+		onFakeOpenShift(func() {
+			v1 := &v1.CheCluster{}
+			v2apha := v2Obj.DeepCopy()
+			v2apha.Spec.WorkspaceDomainEndpoints.BaseDomain = ""
+			err := V2alpha1ToV1(v2apha, v1)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if _, ok := v1.Spec.Server.CustomCheProperties[routeDomainSuffixPropertyKey]; ok {
+				t.Errorf("Unexpected value. We shouldn't set key with empty value for %s custom Che property", routeDomainSuffixPropertyKey)
+			}
+		})
+	})
+
 	t.Run("WorkspaceDomainEndpointsTlsSecretName_k8s", func(t *testing.T) {
 		onFakeKubernetes(func() {
 			v1 := &v1.CheCluster{}


### PR DESCRIPTION
### What does this PR do?
Fix: CHE-20274 Don't set empty value for Che property CHE_INFRA_OPENSHIFT_ROUTE_HOST_DOMAIN__SUFFIX.
Fix debug execution, when dev workspace controller enabled.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20274

### How to test this PR?
1. Install latest Che using operator installer
2. Enable DevWorkspace
3. Disable DevWorkspace
4. chek CR.spec.server.customCheProperties:
CHE_INFRA_OPENSHIFT_ROUTE_HOST_DOMAIN__SUFFIX property shouldn't be present
5. Create and start wrokspace


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
