### PR TITLE
fix: Set Che host url in the CR status when Che server deployment is ready

### DIFF
--- a/controllers/che/checluster_controller_test.go
+++ b/controllers/che/checluster_controller_test.go
@@ -1084,7 +1084,7 @@ func TestCheController(t *testing.T) {
 
 	// get CR
 	cheCR := &orgv1.CheCluster{
-		Spec:       orgv1.CheClusterSpec{
+		Spec: orgv1.CheClusterSpec{
 			Server: orgv1.CheClusterSpecServer{
 				CheHost: "eclipse.org",
 			},

--- a/pkg/deploy/dashboard/deployment_dashboard.go
+++ b/pkg/deploy/dashboard/deployment_dashboard.go
@@ -122,7 +122,7 @@ func (d *Dashboard) getDashboardDeploymentSpec() (*appsv1.Deployment, error) {
 							Env: []corev1.EnvVar{
 								{
 									Name:  "CHE_HOST",
-									Value: d.deployContext.CheCluster.Status.CheURL,
+									Value: util.GetCheURL(d.deployContext.CheCluster),
 								},
 								{
 									Name:  "KEYCLOAK_URL",

--- a/pkg/deploy/server/server.go
+++ b/pkg/deploy/server/server.go
@@ -59,11 +59,6 @@ func (s *Server) ExposeCheServiceAndEndpoint() (bool, error) {
 		return false, err
 	}
 
-	done, err = s.UpdateCheURL()
-	if !done {
-		return false, err
-	}
-
 	return true, nil
 }
 
@@ -96,6 +91,11 @@ func (s *Server) SyncAll() (bool, error) {
 	}
 
 	done, err = s.UpdateAvailabilityStatus()
+	if !done {
+		return false, err
+	}
+
+	done, err = s.UpdateCheURL()
 	if !done {
 		return false, err
 	}
@@ -193,13 +193,7 @@ func (s Server) ExposeCheEndpoint() (bool, error) {
 }
 
 func (s Server) UpdateCheURL() (bool, error) {
-	var cheUrl string
-	if s.deployContext.CheCluster.Spec.Server.TlsSupport {
-		cheUrl = "https://" + s.deployContext.CheCluster.Spec.Server.CheHost
-	} else {
-		cheUrl = "http://" + s.deployContext.CheCluster.Spec.Server.CheHost
-	}
-
+	var cheUrl = util.GetCheURL(s.deployContext.CheCluster)
 	if s.deployContext.CheCluster.Status.CheURL != cheUrl {
 		s.deployContext.CheCluster.Status.CheURL = cheUrl
 		err := deploy.UpdateCheCRStatus(s.deployContext, s.component+" server URL", cheUrl)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -612,3 +612,14 @@ func ClearMetadata(objectMeta *metav1.ObjectMeta) {
 	objectMeta.Finalizers = []string{}
 	objectMeta.ManagedFields = []metav1.ManagedFieldsEntry{}
 }
+
+// GetCheURL returns Che url.
+func GetCheURL(cheCluster *orgv1.CheCluster) string {
+	var cheUrl string
+	if cheCluster.Spec.Server.TlsSupport {
+		cheUrl = "https://" + cheCluster.Spec.Server.CheHost
+	} else {
+		cheUrl = "http://" + cheCluster.Spec.Server.CheHost
+	}
+	return cheUrl;
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -621,5 +621,5 @@ func GetCheURL(cheCluster *orgv1.CheCluster) string {
 	} else {
 		cheUrl = "http://" + cheCluster.Spec.Server.CheHost
 	}
-	return cheUrl;
+	return cheUrl
 }


### PR DESCRIPTION

### What does this PR do?
Set Che host url in the CR status when Che server deployment is ready

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20372


### How to test this PR?
Install Che using OLM. 
```bash
git clone git@github.com:eclipse-che/che-operator.git
cd che-operator
git checkout setCheHostUrlInTheCRStatusWhenCheServerDeploymentIsReady
```

Edit config/manger.yaml set che-operator image: quay.io/aandriienko/che-operator:next-che-host-url

Build and push your bundle image(VSCode task "Build and push custom che-operator image: '${IMAGE_REGISTRY_HOST}/${IMAGE_REGISTRY_USER_NAME}/che-operator:next'"):

```bash
export BUNDLE_IMG="${IMAGE_REGISTRY_HOST}/${IMAGE_REGISTRY_USER_NAME}/che-operator-bundle:v0.0.1"
make bundle IMG=${BUNDLE_IMG} platform="openshift" -s
make bundle-build bundle-push -s BUNDLE_IMG=${BUNDLE_IMG} platform="openshift"
```

Install bundle image:

```bash
export NAMESPACE=eclipse-che

operator-sdk run bundle ${IMAGE_REGISTRY_HOST}/${IMAGE_REGISTRY_USER_NAME}/che-operator-bundle:v0.0.1 --namespace ${NAMESPACE}
```

Create custom resource using Openshift ui. Wait Che installation. When The Che host url appear,  immidiately click it. Browser should open Che login page. 


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>

