### PR TITLE
fix: Improve Che presentation on the OperatorHub ui.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -655,6 +655,10 @@ bundle: generate manifests kustomize ## Generate bundle manifests and metadata, 
 		yq -riSY  '(.spec.install.spec.deployments[0].spec.template.spec.containers[0].securityContext."runAsNonRoot") = true' "$${NEW_CSV}"
 	fi
 
+	# Base cluster service version file has got correctly sorted CRDs.
+	# They are sorted with help of annotation markers in the api type files ("api/v1" folder).
+	# Example such annotation: +operator-sdk:csv:customresourcedefinitions:order=0
+	# Let's copy this sorted CRDs to the bundle cluster service version file.
 	BASE_CSV="config/manifests/bases/che-operator.clusterserviceversion.yaml"
 	CRD_API=$$(yq -c '.spec.customresourcedefinitions.owned' $${BASE_CSV})
 	yq -riSY ".spec.customresourcedefinitions.owned = $$CRD_API" "$${NEW_CSV}"

--- a/Makefile
+++ b/Makefile
@@ -655,6 +655,8 @@ bundle: generate manifests kustomize ## Generate bundle manifests and metadata, 
 		yq -riSY  '(.spec.install.spec.deployments[0].spec.template.spec.containers[0].securityContext."runAsNonRoot") = true' "$${NEW_CSV}"
 	fi
 
+	yq -riSY '.spec.customresourcedefinitions.owned = (.spec.customresourcedefinitions.owned | "Eclipse Che instance Specification" as $$displayName | [(.[] | select(.displayName == $$displayName) )] as $$firstElement | del(.[] | select(.displayName == $$displayName)) as $$remainingElements | $$firstElement + $$remainingElements)' "$${NEW_CSV}"
+
 	# Format code.
 	yq -rY "." "$${NEW_CSV}" > "$${NEW_CSV}.old"
 	mv "$${NEW_CSV}.old" "$${NEW_CSV}"

--- a/Makefile
+++ b/Makefile
@@ -655,7 +655,10 @@ bundle: generate manifests kustomize ## Generate bundle manifests and metadata, 
 		yq -riSY  '(.spec.install.spec.deployments[0].spec.template.spec.containers[0].securityContext."runAsNonRoot") = true' "$${NEW_CSV}"
 	fi
 
-	yq -riSY '.spec.customresourcedefinitions.owned = (.spec.customresourcedefinitions.owned | "Eclipse Che instance Specification" as $$displayName | [(.[] | select(.displayName == $$displayName) )] as $$firstElement | del(.[] | select(.displayName == $$displayName)) as $$remainingElements | $$firstElement + $$remainingElements)' "$${NEW_CSV}"
+	BASE_CSV="config/manifests/bases/che-operator.clusterserviceversion.yaml"
+	CRD_API=$$(yq -c '.spec.customresourcedefinitions.owned' $${BASE_CSV})
+	yq -riSY ".spec.customresourcedefinitions.owned = $$CRD_API" "$${NEW_CSV}"
+	yq -riSY "del(.spec.customresourcedefinitions.owned[] | select(.version == \"v2alpha1\"))" "$${NEW_CSV}"
 
 	# Format code.
 	yq -rY "." "$${NEW_CSV}" > "$${NEW_CSV}.old"

--- a/PROJECT
+++ b/PROJECT
@@ -35,7 +35,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  domain: org.eclipse.che
+  domain: eclipse.che
   group: org
   kind: CheClusterRestore
   path: github.com/eclipse-che/che-operator/api/v1

--- a/api/v1/chebackupserverconfiguration_types.go
+++ b/api/v1/chebackupserverconfiguration_types.go
@@ -111,12 +111,12 @@ type CheBackupServerConfigurationStatus struct {
 }
 
 // The `CheBackupServerConfiguration` custom resource allows defining and managing Eclipse Che Backup Server Configurations
-
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +k8s:openapi-gen=true
-// +operator-sdk:csv:customresourcedefinitions:displayName="Eclipse Che Cluster Backup Server Configuration"
+// +operator-sdk:csv:customresourcedefinitions:displayName="Eclipse Che Backup Server"
+// +operator-sdk:csv:customresourcedefinitions:order=1
 type CheBackupServerConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1/checluster_types.go
+++ b/api/v1/checluster_types.go
@@ -711,12 +711,12 @@ type CheClusterStatus struct {
 }
 
 // The `CheCluster` custom resource allows defining and managing a Che server installation
-
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +k8s:openapi-gen=true
-// +operator-sdk:csv:customresourcedefinitions:displayName="Eclipse Che Cluster"
+// +operator-sdk:csv:customresourcedefinitions:displayName="Eclipse Che instance Specification"
+// +operator-sdk:csv:customresourcedefinitions:order=0
 // +kubebuilder:storageversion
 type CheCluster struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1/checlusterbackup_types.go
+++ b/api/v1/checlusterbackup_types.go
@@ -45,12 +45,12 @@ type CheClusterBackupStatus struct {
 }
 
 // The `CheClusterBackup` custom resource allows defining and managing Eclipse Che backup
-
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +k8s:openapi-gen=true
-// +operator-sdk:csv:customresourcedefinitions:displayName="Eclipse Che Cluster Backup"
+// +operator-sdk:csv:customresourcedefinitions:displayName="Eclipse Che instance Backup Specification"
+// +operator-sdk:csv:customresourcedefinitions:order=2
 type CheClusterBackup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1/checlusterrestore_types.go
+++ b/api/v1/checlusterrestore_types.go
@@ -41,12 +41,12 @@ type CheClusterRestoreStatus struct {
 }
 
 // The `CheClusterRestore` custom resource allows defining and managing Eclipse Che restore
-
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +k8s:openapi-gen=true
-// +operator-sdk:csv:customresourcedefinitions:displayName="Eclipse Che Cluster Restore"
+// +operator-sdk:csv:customresourcedefinitions:displayName="Eclipse Che instance Restore Specification"
+// +operator-sdk:csv:customresourcedefinitions:order=3
 type CheClusterRestore struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/next/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -89,24 +89,6 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: The `CheBackupServerConfiguration` custom resource allows defining
-          and managing Eclipse Che Backup Server Configurations
-        displayName: Eclipse Che Backup Server
-        kind: CheBackupServerConfiguration
-        name: chebackupserverconfigurations.org.eclipse.che
-        version: v1
-      - description: The `CheClusterBackup` custom resource allows defining and managing
-          Eclipse Che backup
-        displayName: Eclipse Che instance Backup Specification
-        kind: CheClusterBackup
-        name: checlusterbackups.org.eclipse.che
-        version: v1
-      - description: The `CheClusterRestore` custom resource allows defining and managing
-          Eclipse Che restore
-        displayName: Eclipse Che instance Restore Specification
-        kind: CheClusterRestore
-        name: checlusterrestores.org.eclipse.che
-        version: v1
       - description: The `CheCluster` custom resource allows defining and managing
           a Che server installation
         displayName: Eclipse Che instance Specification
@@ -177,6 +159,24 @@ spec:
             path: reason
             x-descriptors:
               - urn:alm:descriptor:text
+        version: v1
+      - description: The `CheBackupServerConfiguration` custom resource allows defining
+          and managing Eclipse Che Backup Server Configurations
+        displayName: Eclipse Che Backup Server
+        kind: CheBackupServerConfiguration
+        name: chebackupserverconfigurations.org.eclipse.che
+        version: v1
+      - description: The `CheClusterBackup` custom resource allows defining and managing
+          Eclipse Che backup
+        displayName: Eclipse Che instance Backup Specification
+        kind: CheClusterBackup
+        name: checlusterbackups.org.eclipse.che
+        version: v1
+      - description: The `CheClusterRestore` custom resource allows defining and managing
+          Eclipse Che restore
+        displayName: Eclipse Che instance Restore Specification
+        kind: CheClusterRestore
+        name: checlusterrestores.org.eclipse.che
         version: v1
   description: |
     A collaborative Kubernetes-native development solution that delivers Kubernetes workspaces and in-browser IDE for rapid cloud application development.

--- a/bundle/next/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -89,18 +89,27 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - displayName: Eclipse Che Cluster Backup Server Configuration
+      - description: The `CheBackupServerConfiguration` custom resource allows defining
+          and managing Eclipse Che Backup Server Configurations
+        displayName: Eclipse Che Backup Server
         kind: CheBackupServerConfiguration
         name: chebackupserverconfigurations.org.eclipse.che
         version: v1
-      - displayName: Eclipse Che Cluster Backup
+      - description: The `CheClusterBackup` custom resource allows defining and managing
+          Eclipse Che backup
+        displayName: Eclipse Che instance Backup Specification
         kind: CheClusterBackup
         name: checlusterbackups.org.eclipse.che
         version: v1
-      - kind: CheClusterRestore
+      - description: The `CheClusterRestore` custom resource allows defining and managing
+          Eclipse Che restore
+        displayName: Eclipse Che instance Restore Specification
+        kind: CheClusterRestore
         name: checlusterrestores.org.eclipse.che
         version: v1
-      - displayName: Eclipse Che Cluster
+      - description: The `CheCluster` custom resource allows defining and managing
+          a Che server installation
+        displayName: Eclipse Che instance Specification
         kind: CheCluster
         name: checlusters.org.eclipse.che
         specDescriptors:

--- a/bundle/next/eclipse-che-preview-kubernetes/manifests/org.eclipse.che_chebackupserverconfigurations.yaml
+++ b/bundle/next/eclipse-che-preview-kubernetes/manifests/org.eclipse.che_chebackupserverconfigurations.yaml
@@ -17,6 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
+        description: The `CheBackupServerConfiguration` custom resource allows defining and managing Eclipse Che Backup Server Configurations
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/bundle/next/eclipse-che-preview-kubernetes/manifests/org.eclipse.che_checlusterbackups.yaml
+++ b/bundle/next/eclipse-che-preview-kubernetes/manifests/org.eclipse.che_checlusterbackups.yaml
@@ -17,6 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
+        description: The `CheClusterBackup` custom resource allows defining and managing Eclipse Che backup
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/bundle/next/eclipse-che-preview-kubernetes/manifests/org.eclipse.che_checlusterrestores.yaml
+++ b/bundle/next/eclipse-che-preview-kubernetes/manifests/org.eclipse.che_checlusterrestores.yaml
@@ -17,6 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
+        description: The `CheClusterRestore` custom resource allows defining and managing Eclipse Che restore
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/bundle/next/eclipse-che-preview-kubernetes/manifests/org_v1_che_crd.yaml
+++ b/bundle/next/eclipse-che-preview-kubernetes/manifests/org_v1_che_crd.yaml
@@ -27,6 +27,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
+        description: The `CheCluster` custom resource allows defining and managing a Che server installation
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -82,18 +82,27 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - displayName: Eclipse Che Cluster Backup Server Configuration
+      - description: The `CheBackupServerConfiguration` custom resource allows defining
+          and managing Eclipse Che Backup Server Configurations
+        displayName: Eclipse Che Backup Server
         kind: CheBackupServerConfiguration
         name: chebackupserverconfigurations.org.eclipse.che
         version: v1
-      - displayName: Eclipse Che Cluster Backup
+      - description: The `CheClusterBackup` custom resource allows defining and managing
+          Eclipse Che backup
+        displayName: Eclipse Che instance Backup Specification
         kind: CheClusterBackup
         name: checlusterbackups.org.eclipse.che
         version: v1
-      - kind: CheClusterRestore
+      - description: The `CheClusterRestore` custom resource allows defining and managing
+          Eclipse Che restore
+        displayName: Eclipse Che instance Restore Specification
+        kind: CheClusterRestore
         name: checlusterrestores.org.eclipse.che
         version: v1
-      - displayName: Eclipse Che Cluster
+      - description: The `CheCluster` custom resource allows defining and managing
+          a Che server installation
+        displayName: Eclipse Che instance Specification
         kind: CheCluster
         name: checlusters.org.eclipse.che
         specDescriptors:

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -82,24 +82,6 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: The `CheBackupServerConfiguration` custom resource allows defining
-          and managing Eclipse Che Backup Server Configurations
-        displayName: Eclipse Che Backup Server
-        kind: CheBackupServerConfiguration
-        name: chebackupserverconfigurations.org.eclipse.che
-        version: v1
-      - description: The `CheClusterBackup` custom resource allows defining and managing
-          Eclipse Che backup
-        displayName: Eclipse Che instance Backup Specification
-        kind: CheClusterBackup
-        name: checlusterbackups.org.eclipse.che
-        version: v1
-      - description: The `CheClusterRestore` custom resource allows defining and managing
-          Eclipse Che restore
-        displayName: Eclipse Che instance Restore Specification
-        kind: CheClusterRestore
-        name: checlusterrestores.org.eclipse.che
-        version: v1
       - description: The `CheCluster` custom resource allows defining and managing
           a Che server installation
         displayName: Eclipse Che instance Specification
@@ -170,6 +152,24 @@ spec:
             path: reason
             x-descriptors:
               - urn:alm:descriptor:text
+        version: v1
+      - description: The `CheBackupServerConfiguration` custom resource allows defining
+          and managing Eclipse Che Backup Server Configurations
+        displayName: Eclipse Che Backup Server
+        kind: CheBackupServerConfiguration
+        name: chebackupserverconfigurations.org.eclipse.che
+        version: v1
+      - description: The `CheClusterBackup` custom resource allows defining and managing
+          Eclipse Che backup
+        displayName: Eclipse Che instance Backup Specification
+        kind: CheClusterBackup
+        name: checlusterbackups.org.eclipse.che
+        version: v1
+      - description: The `CheClusterRestore` custom resource allows defining and managing
+          Eclipse Che restore
+        displayName: Eclipse Che instance Restore Specification
+        kind: CheClusterRestore
+        name: checlusterrestores.org.eclipse.che
         version: v1
   description: |
     A collaborative Kubernetes-native development solution that delivers Kubernetes workspaces and in-browser IDE for rapid cloud application development.

--- a/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_chebackupserverconfigurations.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_chebackupserverconfigurations.yaml
@@ -17,6 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
+        description: The `CheBackupServerConfiguration` custom resource allows defining and managing Eclipse Che Backup Server Configurations
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterbackups.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterbackups.yaml
@@ -17,6 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
+        description: The `CheClusterBackup` custom resource allows defining and managing Eclipse Che backup
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterrestores.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterrestores.yaml
@@ -17,6 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
+        description: The `CheClusterRestore` custom resource allows defining and managing Eclipse Che restore
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/bundle/next/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
@@ -27,6 +27,8 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
+          description: The `CheCluster` custom resource allows defining and managing
+            a Che server installation
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/org.eclipse.che_chebackupserverconfigurations_crd-v1beta1.yaml
+++ b/config/crd/bases/org.eclipse.che_chebackupserverconfigurations_crd-v1beta1.yaml
@@ -27,6 +27,8 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      description: The `CheBackupServerConfiguration` custom resource allows defining
+        and managing Eclipse Che Backup Server Configurations
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/org.eclipse.che_chebackupserverconfigurations_crd.yaml
+++ b/config/crd/bases/org.eclipse.che_chebackupserverconfigurations_crd.yaml
@@ -27,6 +27,8 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
+          description: The `CheBackupServerConfiguration` custom resource allows defining
+            and managing Eclipse Che Backup Server Configurations
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/org.eclipse.che_checlusterbackups_crd-v1beta1.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusterbackups_crd-v1beta1.yaml
@@ -27,6 +27,8 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      description: The `CheClusterBackup` custom resource allows defining and managing
+        Eclipse Che backup
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/org.eclipse.che_checlusterbackups_crd.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusterbackups_crd.yaml
@@ -27,6 +27,8 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
+          description: The `CheClusterBackup` custom resource allows defining and
+            managing Eclipse Che backup
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/org.eclipse.che_checlusterrestores_crd-v1beta1.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusterrestores_crd-v1beta1.yaml
@@ -27,6 +27,8 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      description: The `CheClusterRestore` custom resource allows defining and managing
+        Eclipse Che restore
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/org.eclipse.che_checlusterrestores_crd.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusterrestores_crd.yaml
@@ -27,6 +27,8 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
+          description: The `CheClusterRestore` custom resource allows defining and
+            managing Eclipse Che restore
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/org_v1_che_crd-v1beta1.yaml
+++ b/config/crd/bases/org_v1_che_crd-v1beta1.yaml
@@ -25,6 +25,8 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
+      description: The `CheCluster` custom resource allows defining and managing a
+        Che server installation
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/org_v1_che_crd.yaml
+++ b/config/crd/bases/org_v1_che_crd.yaml
@@ -27,6 +27,8 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
+          description: The `CheCluster` custom resource allows defining and managing
+            a Che server installation
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation

--- a/config/manifests/bases/che-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/che-operator.clusterserviceversion.yaml
@@ -19,15 +19,8 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - displayName: Eclipse Che Cluster Backup Server Configuration
-      kind: CheBackupServerConfiguration
-      name: chebackupserverconfigurations.org.eclipse.che
-      version: v1
-    - displayName: Eclipse Che Cluster Backup
-      kind: CheClusterBackup
-      name: checlusterbackups.org.eclipse.che
-      version: v1
-    - displayName: Eclipse Che Cluster
+    - description: The `CheCluster` custom resource allows defining and managing a Che server installation
+      displayName: Eclipse Che instance Specification
       kind: CheCluster
       name: checlusters.org.eclipse.che
       specDescriptors:
@@ -87,6 +80,21 @@ spec:
         path: reason
         x-descriptors:
         - urn:alm:descriptor:text
+      version: v1
+    - description: The `CheBackupServerConfiguration` custom resource allows defining and managing Eclipse Che Backup Server Configurations
+      displayName: Eclipse Che Backup Server
+      kind: CheBackupServerConfiguration
+      name: chebackupserverconfigurations.org.eclipse.che
+      version: v1
+    - description: The `CheClusterBackup` custom resource allows defining and managing Eclipse Che backup
+      displayName: Eclipse Che instance Backup Specification
+      kind: CheClusterBackup
+      name: checlusterbackups.org.eclipse.che
+      version: v1
+    - description: The `CheClusterRestore` custom resource allows defining and managing Eclipse Che restore
+      displayName: Eclipse Che instance Restore Specification
+      kind: CheClusterRestore
+      name: checlusterrestores.org.eclipse.che
       version: v1
     - description: CheCluster is the configuration of the CheCluster layer of Devworkspace.
       displayName: Che Cluster


### PR DESCRIPTION
Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?


### Screenshot/screencast of this PR
![screenshot-console-openshift-console apps-crc testing-2021 09 02-09_58_20](https://user-images.githubusercontent.com/6873095/131797320-e6cfd4ef-0fec-4388-867d-642f0d3bc9f4.png)

![screencapture-console-openshift-console-apps-crc-testing-k8s-ns-eclipse-che-operators-coreos-com-v1alpha1-ClusterServiceVersion-2021-09-02-09_55_42](https://user-images.githubusercontent.com/6873095/131797349-af8d62bb-5b49-4f83-a5c5-cf3011de5a46.png)



### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
