### PR TITLE
feat: secure workspace services

### DIFF
--- a/api/conversion.go
+++ b/api/conversion.go
@@ -3,6 +3,7 @@ package org
 import (
 	v1 "github.com/eclipse-che/che-operator/api/v1"
 	"github.com/eclipse-che/che-operator/api/v2alpha1"
+	"github.com/eclipse-che/che-operator/pkg/deploy"
 	"github.com/eclipse-che/che-operator/pkg/util"
 	"sigs.k8s.io/yaml"
 )
@@ -145,7 +146,7 @@ func v1ToV2alpha1_GatewayEnabled(v1 *v1.CheCluster, v2 *v2alpha1.CheCluster) {
 }
 
 func v1ToV2alpha1_GatewayImage(v1 *v1.CheCluster, v2 *v2alpha1.CheCluster) {
-	v2.Spec.Gateway.Image = v1.Spec.Server.SingleHostGatewayImage
+	v2.Spec.Gateway.Image = util.GetValue(v1.Spec.Server.SingleHostGatewayImage, deploy.DefaultSingleHostGatewayImage(v1))
 }
 
 func v1ToV2alpha1_GatewayConfigurerImage(v1 *v1.CheCluster, v2 *v2alpha1.CheCluster) {

--- a/controllers/devworkspace/defaults/defaults.go
+++ b/controllers/devworkspace/defaults/defaults.go
@@ -43,8 +43,8 @@ var (
 	}
 )
 
-func GetGatewayWorkpaceConfigMapName(workspaceID string) string {
-	return workspaceID
+func GetGatewayWorkspaceConfigMapName(workspaceID string) string {
+	return workspaceID + "-route"
 }
 
 func GetLabelsForComponent(cluster *v2alpha1.CheCluster, component string) map[string]string {

--- a/controllers/devworkspace/solver/che_routing.go
+++ b/controllers/devworkspace/solver/che_routing.go
@@ -171,6 +171,8 @@ func (c *CheRoutingSolver) provisionPodAdditions(objs *solvers.RoutingObjects, c
 		},
 	})
 
+	// Even though DefaultMode is optional in Kubernetes, DevWorkspace Controller needs it to be explicitly defined.
+	// 420 = 0644 = '-rw-r--r--'
 	defaultMode := int32(420)
 	objs.PodAdditions.Volumes = append(objs.PodAdditions.Volumes, corev1.Volume{
 		Name: wsGatewayName,
@@ -321,8 +323,9 @@ func (c *CheRoutingSolver) getInfraSpecificExposer(cheCluster *v2alpha1.CheClust
 }
 
 func getCommonService(objs *solvers.RoutingObjects, dwId string) *corev1.Service {
+	commonServiceName := common.ServiceName(dwId)
 	for i, svc := range objs.Services {
-		if svc.Name == common.ServiceName(dwId) {
+		if svc.Name == commonServiceName {
 			return &objs.Services[i]
 		}
 	}

--- a/controllers/devworkspace/solver/che_routing.go
+++ b/controllers/devworkspace/solver/che_routing.go
@@ -571,11 +571,11 @@ func findServiceForPort(port int32, objs *solvers.RoutingObjects) *corev1.Servic
 	return nil
 }
 
-func findIngressForEndpoint(machineName string, endpoint dw.Endpoint, objs *solvers.RoutingObjects) *networkingv1.Ingress {
+func findIngressForEndpoint(componentName string, endpoint dw.Endpoint, objs *solvers.RoutingObjects) *networkingv1.Ingress {
 	for i := range objs.Ingresses {
 		ingress := &objs.Ingresses[i]
 
-		if ingress.Annotations[defaults.ConfigAnnotationComponentName] != machineName ||
+		if ingress.Annotations[defaults.ConfigAnnotationComponentName] != componentName ||
 			ingress.Annotations[defaults.ConfigAnnotationEndpointName] != endpoint.Name {
 			continue
 		}

--- a/controllers/devworkspace/solver/che_routing_test.go
+++ b/controllers/devworkspace/solver/che_routing_test.go
@@ -267,11 +267,11 @@ func TestCreateRelocatedObjectsK8S(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if len(workspaceConfig.HTTP.Routers) != 3 {
-			t.Fatalf("Expected 3 traefik routers but got %d", len(workspaceConfig.HTTP.Routers))
+		if len(workspaceConfig.HTTP.Routers) != 1 {
+			t.Fatalf("Expected 1 traefik router but got %d", len(workspaceConfig.HTTP.Routers))
 		}
 
-		endpointName := "e1"
+		endpointName := "wsid-m1-9999"
 		if _, ok := workspaceConfig.HTTP.Routers[endpointName]; !ok {
 			t.Fatal("traefik config doesn't contain expected workspace configuration")
 		}
@@ -280,8 +280,8 @@ func TestCreateRelocatedObjectsK8S(t *testing.T) {
 			t.Fatalf("Expected 1 middlewares in router but got '%d'", len(workspaceConfig.HTTP.Routers[endpointName].Middlewares))
 		}
 
-		if len(workspaceConfig.HTTP.Middlewares) != 3 {
-			t.Fatalf("Expected 3 middlewares set but got '%d'", len(workspaceConfig.HTTP.Middlewares))
+		if len(workspaceConfig.HTTP.Middlewares) != 1 {
+			t.Fatalf("Expected 1 middlewares set but got '%d'", len(workspaceConfig.HTTP.Middlewares))
 		}
 
 		mwares := []string{endpointName + "-prefix"}
@@ -367,11 +367,11 @@ func TestCreateRelocatedObjectsOpenshift(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if len(workspaceConfig.HTTP.Routers) != 3 {
-			t.Fatalf("Expected 3 traefik routers but got %d", len(workspaceConfig.HTTP.Routers))
+		if len(workspaceConfig.HTTP.Routers) != 1 {
+			t.Fatalf("Expected 1 traefik routers but got %d", len(workspaceConfig.HTTP.Routers))
 		}
 
-		endpointName := "e1"
+		endpointName := "wsid-m1-9999"
 		if _, ok := workspaceConfig.HTTP.Routers[endpointName]; !ok {
 			t.Fatal("traefik config doesn't contain expected workspace configuration")
 		}

--- a/controllers/devworkspace/solver/che_routing_test.go
+++ b/controllers/devworkspace/solver/che_routing_test.go
@@ -271,26 +271,26 @@ func TestCreateRelocatedObjectsK8S(t *testing.T) {
 			t.Fatalf("Expected 1 traefik router but got %d", len(workspaceConfig.HTTP.Routers))
 		}
 
-		endpointName := "wsid-m1-9999"
-		if _, ok := workspaceConfig.HTTP.Routers[endpointName]; !ok {
+		wsid := "wsid-m1-9999"
+		if _, ok := workspaceConfig.HTTP.Routers[wsid]; !ok {
 			t.Fatal("traefik config doesn't contain expected workspace configuration")
 		}
 
-		if len(workspaceConfig.HTTP.Routers[endpointName].Middlewares) != 1 {
-			t.Fatalf("Expected 1 middlewares in router but got '%d'", len(workspaceConfig.HTTP.Routers[endpointName].Middlewares))
+		if len(workspaceConfig.HTTP.Routers[wsid].Middlewares) != 1 {
+			t.Fatalf("Expected 1 middlewares in router but got '%d'", len(workspaceConfig.HTTP.Routers[wsid].Middlewares))
 		}
 
 		if len(workspaceConfig.HTTP.Middlewares) != 1 {
 			t.Fatalf("Expected 1 middlewares set but got '%d'", len(workspaceConfig.HTTP.Middlewares))
 		}
 
-		mwares := []string{endpointName + "-prefix"}
+		mwares := []string{wsid + "-prefix"}
 		for _, mware := range mwares {
 			if _, ok := workspaceConfig.HTTP.Middlewares[mware]; !ok {
 				t.Fatalf("traefik config doesn't set middleware '%s'", mware)
 			}
 			found := false
-			for _, r := range workspaceConfig.HTTP.Routers[endpointName].Middlewares {
+			for _, r := range workspaceConfig.HTTP.Routers[wsid].Middlewares {
 				if r == mware {
 					found = true
 				}
@@ -371,13 +371,13 @@ func TestCreateRelocatedObjectsOpenshift(t *testing.T) {
 			t.Fatalf("Expected 1 traefik routers but got %d", len(workspaceConfig.HTTP.Routers))
 		}
 
-		endpointName := "wsid-m1-9999"
-		if _, ok := workspaceConfig.HTTP.Routers[endpointName]; !ok {
+		wsid := "wsid-m1-9999"
+		if _, ok := workspaceConfig.HTTP.Routers[wsid]; !ok {
 			t.Fatal("traefik config doesn't contain expected workspace configuration")
 		}
 
-		if len(workspaceConfig.HTTP.Routers[endpointName].Middlewares) != 2 {
-			t.Fatalf("Expected 2 middlewares in router but got '%d'", len(workspaceConfig.HTTP.Routers[endpointName].Middlewares))
+		if len(workspaceConfig.HTTP.Routers[wsid].Middlewares) != 2 {
+			t.Fatalf("Expected 2 middlewares in router but got '%d'", len(workspaceConfig.HTTP.Routers[wsid].Middlewares))
 		}
 
 		workspaceMainConfig := traefikConfig{}
@@ -393,14 +393,14 @@ func TestCreateRelocatedObjectsOpenshift(t *testing.T) {
 			t.Fatalf("Expected 3 middlewares set but got '%d'", len(workspaceConfig.HTTP.Middlewares))
 		}
 
-		endpointName = "wsid"
-		mwares := []string{endpointName + "-auth", endpointName + "-prefix", endpointName + "-header"}
+		wsid = "wsid"
+		mwares := []string{wsid + "-auth", wsid + "-prefix", wsid + "-header"}
 		for _, mware := range mwares {
 			if _, ok := workspaceMainConfig.HTTP.Middlewares[mware]; !ok {
 				t.Fatalf("traefik config doesn't set middleware '%s'", mware)
 			}
 			found := false
-			for _, r := range workspaceMainConfig.HTTP.Routers[endpointName].Middlewares {
+			for _, r := range workspaceMainConfig.HTTP.Routers[wsid].Middlewares {
 				if r == mware {
 					found = true
 				}
@@ -464,6 +464,12 @@ func TestCreateSubDomainObjects(t *testing.T) {
 		}
 		if objs.Ingresses[0].Spec.Rules[0].Host != "wsid-1.down.on.earth" {
 			t.Error("Expected Ingress host 'wsid-1.down.on.earth', but got ", objs.Ingresses[0].Spec.Rules[0].Host)
+		}
+		if objs.Ingresses[1].Spec.Rules[0].Host != "wsid-2.down.on.earth" {
+			t.Error("Expected Ingress host 'wsid-2.down.on.earth', but got ", objs.Ingresses[1].Spec.Rules[0].Host)
+		}
+		if objs.Ingresses[2].Spec.Rules[0].Host != "wsid-3.down.on.earth" {
+			t.Error("Expected Ingress host 'wsid-3.down.on.earth', but got ", objs.Ingresses[2].Spec.Rules[0].Host)
 		}
 	})
 

--- a/controllers/devworkspace/solver/endpoint_exposer.go
+++ b/controllers/devworkspace/solver/endpoint_exposer.go
@@ -220,7 +220,7 @@ func (e *IngressExposer) getIngressForService(endpoint *EndpointInfo) networking
 }
 
 func hostName(order int, workspaceID string, baseDomain string) string {
-	return fmt.Sprintf("%s-%d.%s", workspaceID, order+1, baseDomain)
+	return fmt.Sprintf("%s-%d.%s", workspaceID, order, baseDomain)
 }
 
 func routeAnnotations(machineName string, endpointName string) map[string]string {

--- a/controllers/devworkspace/solver/solver.go
+++ b/controllers/devworkspace/solver/solver.go
@@ -101,7 +101,7 @@ func isGatewayWorkspaceConfig(obj metav1.Object) (bool, types.NamespacedName) {
 	objectName := obj.GetName()
 
 	// bail out quickly if we're not dealing with a configmap with an expected name
-	if objectName != defaults.GetGatewayWorkpaceConfigMapName(workspaceID) {
+	if objectName != defaults.GetGatewayWorkspaceConfigMapName(workspaceID) {
 		return false, types.NamespacedName{}
 	}
 

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -360,7 +360,7 @@ func DefaultPullPolicyFromDockerImage(dockerImage string) string {
 }
 
 func GetSingleHostExposureType(cr *orgv1.CheCluster) string {
-	if util.IsOpenShift {
+	if util.IsOpenShift || cr.Spec.DevWorkspace.Enable {
 		return DefaultOpenShiftSingleHostExposureType
 	}
 

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -79,9 +79,9 @@ const (
 
 	KubernetesImagePullerOperatorCSV = "kubernetes-imagepuller-operator.v0.0.4"
 
-	DefaultServerExposureStrategy           = "multi-host"
-	DefaultKubernetesSingleHostExposureType = "native"
-	DefaultOpenShiftSingleHostExposureType  = "gateway"
+	DefaultServerExposureStrategy = "multi-host"
+	NativeSingleHostExposureType  = "native"
+	GatewaySingleHostExposureType = "gateway"
 
 	// This is only to correctly  manage defaults during the transition
 	// from Upstream 7.0.0 GA to the next version
@@ -361,10 +361,10 @@ func DefaultPullPolicyFromDockerImage(dockerImage string) string {
 
 func GetSingleHostExposureType(cr *orgv1.CheCluster) string {
 	if util.IsOpenShift || cr.Spec.DevWorkspace.Enable {
-		return DefaultOpenShiftSingleHostExposureType
+		return GatewaySingleHostExposureType
 	}
 
-	return util.GetValue(cr.Spec.K8s.SingleHostExposureType, DefaultKubernetesSingleHostExposureType)
+	return util.GetValue(cr.Spec.K8s.SingleHostExposureType, NativeSingleHostExposureType)
 }
 
 func patchDefaultImageName(cr *orgv1.CheCluster, imageName string) string {

--- a/pkg/deploy/expose/expose.go
+++ b/pkg/deploy/expose/expose.go
@@ -52,7 +52,7 @@ func ExposeWithHostPath(
 	}
 
 	singleHostExposureType := deploy.GetSingleHostExposureType(deployContext.CheCluster)
-	useGateway := exposureStrategy == "single-host" && (util.IsOpenShift || singleHostExposureType == "gateway")
+	useGateway := exposureStrategy == "single-host" && (util.IsOpenShift || singleHostExposureType == deploy.GatewaySingleHostExposureType)
 	gatewayConfig := "che-gateway-route-" + component
 	if !util.IsOpenShift {
 		if useGateway {

--- a/pkg/deploy/gateway/gateway.go
+++ b/pkg/deploy/gateway/gateway.go
@@ -59,7 +59,7 @@ var (
 // SyncGatewayToCluster installs or deletes the gateway based on the custom resource configuration
 func SyncGatewayToCluster(deployContext *deploy.DeployContext) error {
 	if (util.GetServerExposureStrategy(deployContext.CheCluster) == "single-host" &&
-		deploy.GetSingleHostExposureType(deployContext.CheCluster) == "gateway") ||
+		deploy.GetSingleHostExposureType(deployContext.CheCluster) == deploy.GatewaySingleHostExposureType) ||
 		deployContext.CheCluster.Spec.DevWorkspace.Enable {
 		return syncAll(deployContext)
 	}

--- a/pkg/deploy/gateway/gateway.go
+++ b/pkg/deploy/gateway/gateway.go
@@ -40,8 +40,10 @@ import (
 const (
 	// GatewayServiceName is the name of the service which through which the gateway can be accessed
 	GatewayServiceName = "che-gateway"
+	GatewayServicePort = 8080
 
 	gatewayServerConfigName    = "che-gateway-route-server"
+	gatewayKubeAuthConfigName  = "che-gateway-route-kube-auth"
 	gatewayConfigComponentName = "che-gateway-config"
 	gatewayOauthSecretName     = "che-gateway-oauth-secret"
 )
@@ -56,8 +58,9 @@ var (
 
 // SyncGatewayToCluster installs or deletes the gateway based on the custom resource configuration
 func SyncGatewayToCluster(deployContext *deploy.DeployContext) error {
-	if util.GetServerExposureStrategy(deployContext.CheCluster) == "single-host" &&
-		(deploy.GetSingleHostExposureType(deployContext.CheCluster) == "gateway") {
+	if (util.GetServerExposureStrategy(deployContext.CheCluster) == "single-host" &&
+		deploy.GetSingleHostExposureType(deployContext.CheCluster) == "gateway") ||
+		deployContext.CheCluster.Spec.DevWorkspace.Enable {
 		return syncAll(deployContext)
 	}
 
@@ -408,7 +411,7 @@ func getGatewayOauthProxyConfigSpec(instance *orgv1.CheCluster, cookieSecret str
 		},
 		Data: map[string]string{
 			"oauth-proxy.cfg": fmt.Sprintf(`
-http_address = ":8080"
+http_address = ":%d"
 https_address = ""
 provider = "openshift"
 redirect_url = "https://%s/oauth/callback"
@@ -424,7 +427,7 @@ cookie_expire = "24h0m0s"
 email_domains = "*"
 cookie_httponly = false
 pass_access_token = true
-skip_provider_button = true`, instance.Spec.Server.CheHost, instance.Spec.Auth.OAuthClientName, instance.Spec.Auth.OAuthSecret, GatewayServiceName, cookieSecret),
+skip_provider_button = true`, GatewayServicePort, instance.Spec.Server.CheHost, instance.Spec.Auth.OAuthClientName, instance.Spec.Auth.OAuthSecret, GatewayServiceName, cookieSecret),
 		},
 	}
 }
@@ -490,7 +493,7 @@ func getGatewayHeaderRewritePluginConfigSpec(instance *orgv1.CheCluster) (*corev
 }
 
 func getGatewayTraefikConfigSpec(instance *orgv1.CheCluster) corev1.ConfigMap {
-	traefikPort := 8080
+	traefikPort := GatewayServicePort
 	if util.IsNativeUserModeEnabled(instance) {
 		traefikPort = 8081
 	}
@@ -639,7 +642,7 @@ func getContainersSpec(instance *orgv1.CheCluster) []corev1.Container {
 					},
 				},
 				Ports: []corev1.ContainerPort{
-					{ContainerPort: 8080, Protocol: "TCP"},
+					{ContainerPort: GatewayServicePort, Protocol: "TCP"},
 				},
 			},
 			corev1.Container{
@@ -647,7 +650,7 @@ func getContainersSpec(instance *orgv1.CheCluster) []corev1.Container {
 				Image:           authzImage,
 				ImagePullPolicy: corev1.PullAlways,
 				Args: []string{
-					"--insecure-listen-address=127.0.0.1:8089",
+					"--insecure-listen-address=0.0.0.0:8089",
 					"--upstream=http://127.0.0.1:8090/ping",
 					"--logtostderr=true",
 					"--config-file=/etc/kube-rbac-proxy/authorization-config.yaml",
@@ -761,9 +764,15 @@ func getGatewayServiceSpec(instance *orgv1.CheCluster) corev1.Service {
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "gateway-http",
-					Port:       8080,
+					Port:       GatewayServicePort,
 					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(8080),
+					TargetPort: intstr.FromInt(GatewayServicePort),
+				},
+				{
+					Name:       "gateway-kube-authz",
+					Port:       8089,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(8089),
 				},
 			},
 		},

--- a/pkg/deploy/server/server.go
+++ b/pkg/deploy/server/server.go
@@ -333,7 +333,7 @@ func (s Server) evaluateCheServerVersion() string {
 }
 
 func GetServerExposingServiceName(cr *orgv1.CheCluster) string {
-	if util.GetServerExposureStrategy(cr) == "single-host" && deploy.GetSingleHostExposureType(cr) == "gateway" {
+	if util.GetServerExposureStrategy(cr) == "single-host" && deploy.GetSingleHostExposureType(cr) == deploy.GatewaySingleHostExposureType {
 		return gateway.GatewayServiceName
 	}
 	return deploy.CheServiceName


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Secures workspace services with devworkspace engine on OpenShift. 

There is a slight change in exposing logic. The ingresses/routes are not merged into one when exposing same port.

Beside that, it also always deploys with gateway on kubernetes when devworkspaces are enabled.

### How it works?

Nowdays, workspace service is open to the cluster. It exposes all workspace ports and communication goes directly to target container, so anyone in the cluster can access it.

This patch adds traefik container into workspace pod and narrows the service to only single port (targeting to the traefik) for all endpoints that exposes on subpath. That means that all communication that is coming to the workspace service, must go through the traefik. The traefik is configured so it checks the requests with kube-rbac-proxy (in main che-gateway) using forwardAuth middleware (https://doc.traefik.io/traefik/middlewares/http/forwardauth/). Kube-rbac-proxy is checking whether token in authorization header can access the service in workspace's namespace. If this check is OK, traefik route the request to correct port inside the workspace pod.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20190


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
1. deploy with che-operator image `quay.io/mvala/che-operator:gh20190-secureWsServicesTraefik`
2. start a workspace with user1 and get the service name
3. start a workspace with user2 and try curl to the service of user1's workspace. It is now not possible without user1's token in authorization header 


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
