### PR TITLE
Create backup on each update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ COPY config/ config/
 # build operator
 RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi && \
     export MOCK_API=true && \
-    go mod vendor && \
     go test -mod=vendor -v ./... && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=on go build -mod=vendor -a -o che-operator main.go
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ COPY config/ config/
 # build operator
 RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi && \
     export MOCK_API=true && \
+    go mod vendor && \
     go test -mod=vendor -v ./... && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=on go build -mod=vendor -a -o che-operator main.go
 

--- a/api/v1/checlusterbackup_types.go
+++ b/api/v1/checlusterbackup_types.go
@@ -42,7 +42,7 @@ type CheClusterBackupStatus struct {
 	// Last backup snapshot ID
 	// +optional
 	SnapshotId string `json:"snapshotId,omitempty"`
-	// Version that was back upped
+	// Version that was backed up
 	// +optional
 	CheVersion string `json:"cheVersion,omitempty"`
 }

--- a/api/v1/checlusterbackup_types.go
+++ b/api/v1/checlusterbackup_types.go
@@ -42,6 +42,9 @@ type CheClusterBackupStatus struct {
 	// Last backup snapshot ID
 	// +optional
 	SnapshotId string `json:"snapshotId,omitempty"`
+	// Version that was back upped
+	// +optional
+	CheVersion string `json:"cheVersion,omitempty"`
 }
 
 // The `CheClusterBackup` custom resource allows defining and managing Eclipse Che backup

--- a/bundle/next/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.37.0-302.next
+  name: eclipse-che-preview-kubernetes.v7.37.0-303.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1191,4 +1191,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.37.0-302.next
+  version: 7.37.0-303.next

--- a/bundle/next/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.37.0-301.next
+  name: eclipse-che-preview-kubernetes.v7.37.0-302.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1191,4 +1191,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.37.0-301.next
+  version: 7.37.0-302.next

--- a/bundle/next/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -83,7 +83,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.37.0-300.next
+  name: eclipse-che-preview-kubernetes.v7.37.0-301.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1191,4 +1191,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.37.0-300.next
+  version: 7.37.0-301.next

--- a/bundle/next/eclipse-che-preview-kubernetes/manifests/org.eclipse.che_checlusterbackups.yaml
+++ b/bundle/next/eclipse-che-preview-kubernetes/manifests/org.eclipse.che_checlusterbackups.yaml
@@ -40,6 +40,9 @@ spec:
           status:
             description: CheClusterBackupStatus defines the observed state of CheClusterBackup
             properties:
+              cheVersion:
+                description: Version that was back upped
+                type: string
               message:
                 description: Message explaining the state of the backup or an error message
                 type: string

--- a/bundle/next/eclipse-che-preview-kubernetes/manifests/org.eclipse.che_checlusterbackups.yaml
+++ b/bundle/next/eclipse-che-preview-kubernetes/manifests/org.eclipse.che_checlusterbackups.yaml
@@ -41,7 +41,7 @@ spec:
             description: CheClusterBackupStatus defines the observed state of CheClusterBackup
             properties:
               cheVersion:
-                description: Version that was back upped
+                description: Version that was backed up
                 type: string
               message:
                 description: Message explaining the state of the backup or an error message

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.37.0-311.next
+  name: eclipse-che-preview-openshift.v7.37.0-312.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1260,4 +1260,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.37.0-311.next
+  version: 7.37.0-312.next

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.37.0-312.next
+  name: eclipse-che-preview-openshift.v7.37.0-313.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1260,4 +1260,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.37.0-312.next
+  version: 7.37.0-313.next

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.37.0-310.next
+  name: eclipse-che-preview-openshift.v7.37.0-311.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1260,4 +1260,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.37.0-310.next
+  version: 7.37.0-311.next

--- a/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterbackups.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterbackups.yaml
@@ -40,6 +40,9 @@ spec:
           status:
             description: CheClusterBackupStatus defines the observed state of CheClusterBackup
             properties:
+              cheVersion:
+                description: Version that was back upped
+                type: string
               message:
                 description: Message explaining the state of the backup or an error message
                 type: string

--- a/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterbackups.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusterbackups.yaml
@@ -41,7 +41,7 @@ spec:
             description: CheClusterBackupStatus defines the observed state of CheClusterBackup
             properties:
               cheVersion:
-                description: Version that was back upped
+                description: Version that was backed up
                 type: string
               message:
                 description: Message explaining the state of the backup or an error message

--- a/config/crd/bases/org.eclipse.che_checlusterbackups_crd-v1beta1.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusterbackups_crd-v1beta1.yaml
@@ -59,6 +59,9 @@ spec:
         status:
           description: CheClusterBackupStatus defines the observed state of CheClusterBackup
           properties:
+            cheVersion:
+              description: Version that was back upped
+              type: string
             message:
               description: Message explaining the state of the backup or an error
                 message

--- a/config/crd/bases/org.eclipse.che_checlusterbackups_crd-v1beta1.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusterbackups_crd-v1beta1.yaml
@@ -60,7 +60,7 @@ spec:
           description: CheClusterBackupStatus defines the observed state of CheClusterBackup
           properties:
             cheVersion:
-              description: Version that was back upped
+              description: Version that was backed up
               type: string
             message:
               description: Message explaining the state of the backup or an error

--- a/config/crd/bases/org.eclipse.che_checlusterbackups_crd.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusterbackups_crd.yaml
@@ -60,6 +60,9 @@ spec:
             status:
               description: CheClusterBackupStatus defines the observed state of CheClusterBackup
               properties:
+                cheVersion:
+                  description: Version that was back upped
+                  type: string
                 message:
                   description: Message explaining the state of the backup or an error
                     message

--- a/config/crd/bases/org.eclipse.che_checlusterbackups_crd.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusterbackups_crd.yaml
@@ -61,7 +61,7 @@ spec:
               description: CheClusterBackupStatus defines the observed state of CheClusterBackup
               properties:
                 cheVersion:
-                  description: Version that was back upped
+                  description: Version that was backed up
                   type: string
                 message:
                   description: Message explaining the state of the backup or an error

--- a/controllers/che/backup.go
+++ b/controllers/che/backup.go
@@ -46,7 +46,7 @@ func isPreviousVersionDeployed(cheCR *chev1.CheCluster) bool {
 
 func getBackupCR(deployContext *deploy.DeployContext) (*chev1.CheClusterBackup, error) {
 	backupCR := &chev1.CheClusterBackup{}
-	backupCRName := getBackupCRNameForVersion(deployContext.CheCluster.Status.CheVersion)
+	backupCRName := getBackupCRNameForVersion(deploy.DefaultCheVersion())
 	backupCRNamespacedName := types.NamespacedName{Namespace: deployContext.CheCluster.GetNamespace(), Name: backupCRName}
 	if err := deployContext.ClusterAPI.Client.Get(context.TODO(), backupCRNamespacedName, backupCR); err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func getBackupCRSpec(deployContext *deploy.DeployContext) *chev1.CheClusterBacku
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getBackupCRNameForVersion(deployContext.CheCluster.Status.CheVersion),
+			Name:      getBackupCRNameForVersion(deploy.DefaultCheVersion()),
 			Namespace: deployContext.CheCluster.GetNamespace(),
 			Labels:    labels,
 		},

--- a/controllers/che/backup.go
+++ b/controllers/che/backup.go
@@ -115,7 +115,7 @@ func getBackupServerConfigurationNameForBackupBeforeUpdate(deployContext *deploy
 		return backupServerConfigsList.Items[0].GetName(), nil
 	}
 	for _, backupServerConfig := range backupServerConfigsList.Items {
-		if value, exists := backupServerConfig.ObjectMeta.Annotations[DefaultBackupServerConfigLabelKey]; exists && value == "true" {
+		if backupServerConfig.ObjectMeta.Annotations != nil && backupServerConfig.ObjectMeta.Annotations[DefaultBackupServerConfigLabelKey] == "true" {
 			return backupServerConfig.GetName(), nil
 		}
 	}

--- a/controllers/che/backup.go
+++ b/controllers/che/backup.go
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package che
+
+import (
+	"context"
+	"strings"
+
+	semver "github.com/blang/semver/v4"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	chev1 "github.com/eclipse-che/che-operator/api/v1"
+	"github.com/eclipse-che/che-operator/pkg/deploy"
+)
+
+func isPreviousVersionDeployed(cheCR *chev1.CheCluster) bool {
+	deployedVersion := cheCR.Status.CheVersion
+	currentVersion := deploy.DefaultCheVersion()
+	if deployedVersion == "" || deployedVersion == "next" || deployedVersion == currentVersion {
+		return false
+	}
+
+	deployedSemver, err := semver.Make(deployedVersion)
+	if err != nil {
+		logrus.Error(err)
+		return false
+	}
+	currentSemver, err := semver.Make(currentVersion)
+	if err != nil {
+		logrus.Error(err)
+		return false
+	}
+	return currentSemver.GT(deployedSemver)
+}
+
+func getBackupCR(deployContext *deploy.DeployContext) (*chev1.CheClusterBackup, error) {
+	backupCR := &chev1.CheClusterBackup{}
+	backupCRName := getBackupCRNameForVersion(deployContext.CheCluster.Status.CheVersion)
+	backupCRNamespacedName := types.NamespacedName{Namespace: deployContext.CheCluster.GetNamespace(), Name: backupCRName}
+	if err := deployContext.ClusterAPI.Client.Get(context.TODO(), backupCRNamespacedName, backupCR); err != nil {
+		return nil, err
+	}
+	return backupCR, nil
+}
+
+func getBackupCRNameForVersion(version string) string {
+	return "backup-before-update-to-" + strings.Replace(version, ".", "-", -1)
+}
+
+func requestNewBackup(deployContext *deploy.DeployContext) error {
+	backupCR := getBackupCRSpec(deployContext)
+	err := deployContext.ClusterAPI.Client.Create(context.TODO(), backupCR)
+	return err
+}
+
+func getBackupCRSpec(deployContext *deploy.DeployContext) *chev1.CheClusterBackup {
+	labels := deploy.GetLabels(deployContext.CheCluster, "backup-on-update")
+
+	return &chev1.CheClusterBackup{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CheClusterBackup",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getBackupCRNameForVersion(deployContext.CheCluster.Status.CheVersion),
+			Namespace: deployContext.CheCluster.GetNamespace(),
+			Labels:    labels,
+		},
+		Spec: chev1.CheClusterBackupSpec{
+			UseInternalBackupServer: true,
+		},
+	}
+}

--- a/controllers/che/backup_test.go
+++ b/controllers/che/backup_test.go
@@ -1,0 +1,207 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package che
+
+import (
+	"os"
+	"testing"
+
+	chev1 "github.com/eclipse-che/che-operator/api/v1"
+	"github.com/eclipse-che/che-operator/pkg/deploy"
+	"github.com/google/go-cmp/cmp"
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeDiscovery "k8s.io/client-go/discovery/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+func TestGetBackupServerConfigurationNameForBackupBeforeUpdate(t *testing.T) {
+	type testCase struct {
+		name                string
+		cheCluster          *chev1.CheCluster
+		backupServerConfigs *chev1.CheBackupServerConfigurationList
+		initObjects         []runtime.Object
+		expectedResult      string
+	}
+
+	testCases := []testCase{
+		{
+			name: "Should return default backup configuration if no backup server configurations exists",
+			cheCluster: &chev1.CheCluster{
+				Spec: chev1.CheClusterSpec{},
+			},
+			backupServerConfigs: &chev1.CheBackupServerConfigurationList{
+				Items: []chev1.CheBackupServerConfiguration{},
+			},
+			initObjects:    []runtime.Object{},
+			expectedResult: "",
+		},
+		{
+			name: "Should return only one existing configuration",
+			cheCluster: &chev1.CheCluster{
+				Spec: chev1.CheClusterSpec{},
+			},
+			backupServerConfigs: &chev1.CheBackupServerConfigurationList{
+				Items: []chev1.CheBackupServerConfiguration{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "onlyExistingConfiguration",
+							Namespace: "eclipse-che",
+						},
+					},
+				},
+			},
+			initObjects:    []runtime.Object{},
+			expectedResult: "onlyExistingConfiguration",
+		},
+		{
+			name: "Should pick annotated backup server configuration",
+			cheCluster: &chev1.CheCluster{
+				Spec: chev1.CheClusterSpec{},
+			},
+			backupServerConfigs: &chev1.CheBackupServerConfigurationList{
+				Items: []chev1.CheBackupServerConfiguration{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "noAnnotations",
+							Namespace: "eclipse-che",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "otherAnnotations",
+							Namespace: "eclipse-che",
+							Annotations: map[string]string{
+								"foo": "false", "bar": "true",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "annotatedBackupServerConfigurationName",
+							Namespace: "eclipse-che",
+							Annotations: map[string]string{
+								"foo": "false", DefaultBackupServerConfigLabelKey: "true", "bar": "true",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "emptyAnnotations",
+							Namespace:   "eclipse-che",
+							Annotations: map[string]string{},
+						},
+					},
+				},
+			},
+			initObjects:    []runtime.Object{},
+			expectedResult: "annotatedBackupServerConfigurationName",
+		},
+		{
+			name: "Should not pick annotated with false value backup server configuration",
+			cheCluster: &chev1.CheCluster{
+				Spec: chev1.CheClusterSpec{},
+			},
+			backupServerConfigs: &chev1.CheBackupServerConfigurationList{
+				Items: []chev1.CheBackupServerConfiguration{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "annotatedBackupServerConfigurationName",
+							Namespace: "eclipse-che",
+							Annotations: map[string]string{
+								"foo": "false", DefaultBackupServerConfigLabelKey: "false", "bar": "true",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "otherAnnotations",
+							Namespace: "eclipse-che",
+							Annotations: map[string]string{
+								"foo": "1",
+							},
+						},
+					},
+				},
+			},
+			initObjects:    []runtime.Object{},
+			expectedResult: "",
+		},
+		{
+			name: "Should return default backup configuration if more than one configuration exists but no annotated",
+			cheCluster: &chev1.CheCluster{
+				Spec: chev1.CheClusterSpec{},
+			},
+			backupServerConfigs: &chev1.CheBackupServerConfigurationList{
+				Items: []chev1.CheBackupServerConfiguration{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "otherAnnotations",
+							Namespace: "eclipse-che",
+							Annotations: map[string]string{
+								"foo": "false", "bar": "true",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "noAnnotations",
+							Namespace: "eclipse-che",
+						},
+					},
+				},
+			},
+			initObjects:    []runtime.Object{},
+			expectedResult: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			logf.SetLogger(zap.LoggerTo(os.Stdout, true))
+			chev1.SchemeBuilder.AddToScheme(scheme.Scheme)
+			testCase.initObjects = append(testCase.initObjects, testCase.backupServerConfigs, testCase.cheCluster)
+
+			scheme := scheme.Scheme
+			chev1.SchemeBuilder.AddToScheme(scheme)
+			scheme.AddKnownTypes(configv1.SchemeGroupVersion, &configv1.Proxy{})
+
+			cli := fake.NewFakeClientWithScheme(scheme, testCase.initObjects...)
+			clientSet := fakeclientset.NewSimpleClientset()
+			fakeDiscovery, _ := clientSet.Discovery().(*fakeDiscovery.FakeDiscovery)
+			fakeDiscovery.Fake.Resources = []*metav1.APIResourceList{}
+
+			deployContext := &deploy.DeployContext{
+				CheCluster: testCase.cheCluster,
+				ClusterAPI: deploy.ClusterAPI{
+					Client:          cli,
+					NonCachedClient: cli,
+					Scheme:          scheme,
+				},
+			}
+
+			actualResult, err := getBackupServerConfigurationNameForBackupBeforeUpdate(deployContext)
+			if err != nil {
+				t.Fatalf("Error getting backup server configuration name: %v", err)
+			}
+
+			if testCase.expectedResult != actualResult {
+				t.Errorf("Expected backup server configuration name and returned one differ (-want, +got): %v", cmp.Diff(testCase.expectedResult, actualResult))
+			}
+		})
+	}
+}

--- a/controllers/che/checluster_controller.go
+++ b/controllers/che/checluster_controller.go
@@ -262,7 +262,7 @@ func (r *CheClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 
 	if isCheGoingToBeUpdated(instance) {
 		// Current operator is newer than deployed Che
-		backupCR, err := getBackupCR(deployContext)
+		backupCR, err := getBackupCRForUpdate(deployContext)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				// Create a backup before updating current installation

--- a/controllers/che/checluster_controller.go
+++ b/controllers/che/checluster_controller.go
@@ -260,7 +260,7 @@ func (r *CheClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 		CheCluster: instance,
 	}
 
-	if isPreviousVersionDeployed(instance) {
+	if isCheGoingToBeUpdated(instance) {
 		// Current operator is newer than deployed Che
 		backupCR, err := getBackupCR(deployContext)
 		if err != nil {

--- a/controllers/che/checluster_controller.go
+++ b/controllers/che/checluster_controller.go
@@ -266,7 +266,7 @@ func (r *CheClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 		if err != nil {
 			if errors.IsNotFound(err) {
 				// Create a backup before updating current installation
-				if err := requestNewBackup(deployContext); err != nil {
+				if err := requestBackup(deployContext); err != nil {
 					return ctrl.Result{}, err
 				}
 				// Backup request is successfully submitted

--- a/controllers/checlusterbackup/checlusterbackup_controller.go
+++ b/controllers/checlusterbackup/checlusterbackup_controller.go
@@ -250,6 +250,7 @@ func (r *ReconcileCheClusterBackup) doReconcile(backupCR *chev1.CheClusterBackup
 	bctx.backupCR.Status.Message = "Backup successfully finished at " + time.Now().String()
 	bctx.backupCR.Status.State = chev1.STATE_SUCCEEDED
 	bctx.backupCR.Status.SnapshotId = snapshotStat.Id
+	bctx.backupCR.Status.CheVersion = bctx.cheCR.Status.CheVersion
 	if err := bctx.r.UpdateCRStatus(bctx.backupCR); err != nil {
 		logrus.Errorf("Failed to update status after successful backup: %v", err)
 		return true, err

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/Shopify/logrus-bugsnag v0.0.0-00010101000000-000000000000 // indirect
 	github.com/bitly/go-simplejson v0.0.0-00010101000000-000000000000 // indirect
+	github.com/blang/semver/v4 v4.0.0
 	github.com/che-incubator/kubernetes-image-puller-operator v0.0.0-20210428110012-14ef54b7dbf4
 	github.com/devfile/api/v2 v2.0.0-20210713124824-03e023e7078b
 	github.com/devfile/devworkspace-operator v0.2.1-0.20210825134510-d99fe14255d3

--- a/pkg/deploy/server/server.go
+++ b/pkg/deploy/server/server.go
@@ -317,19 +317,13 @@ func (s *Server) DetectDefaultCheHost() (bool, error) {
 }
 
 func (s Server) UpdateCheVersion() (bool, error) {
-	cheVersion := s.evaluateCheServerVersion()
+	cheVersion := deploy.DefaultCheVersion()
 	if s.deployContext.CheCluster.Status.CheVersion != cheVersion {
 		s.deployContext.CheCluster.Status.CheVersion = cheVersion
 		err := deploy.UpdateCheCRStatus(s.deployContext, "version", cheVersion)
 		return err == nil, err
 	}
 	return true, nil
-}
-
-// EvaluateCheServerVersion evaluate che version
-// based on Checluster information and image defaults from env variables
-func (s Server) evaluateCheServerVersion() string {
-	return util.GetValue(s.deployContext.CheCluster.Spec.Server.CheImageTag, deploy.DefaultCheVersion())
 }
 
 func GetServerExposingServiceName(cr *orgv1.CheCluster) string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -24,6 +24,7 @@ github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.1+incompatible => github.com/blang/semver v3.5.1+incompatible
 github.com/blang/semver
 # github.com/blang/semver/v4 v4.0.0 => github.com/blang/semver/v4 v4.0.0
+## explicit
 github.com/blang/semver/v4
 # github.com/cespare/xxhash/v2 v2.1.0 => github.com/cespare/xxhash/v2 v2.1.0
 github.com/cespare/xxhash/v2


### PR DESCRIPTION
### What does this PR do?
Makes Che Operator to create a backup of Che installation before upgrading it to newer version.

As operator cannot know when it will be replaced with a newer version, it is the newer operator that does the backup before updating Che to newer version. The backup is sent to internal backup server to have the behavior more predictable (and to not to guess in case several backup servers configured). Backup CRs are named after version to upgrade to: `backup-before-update-to-<version>` (for example: `backup-before-update-to-7-36-2`). Also, to be able to know the version of the operator needed to reastore the backup, `cheVersion` field is added to the backup CRD status.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
Is a part of https://issues.redhat.com/browse/CRW-1497

### How to test this PR?
1. Create a new fake version in stable channel that uses operator image from this PR. To do this modify `./bundle/stable/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml`.
2. Build catalog source image. It cannot be deployed via operator-sdk as it considers CSV not valid after our release scripts changes.
3. Run `./olm/testUpdate.sh` script till `waitCheServerDeploy` line (it should deploy the catalog source built in previous step)
4. Approve  install plan to update to the fake version.
5. Check that internal backup server is created and configured and backup CR is created.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
