### PR TITLE
Fix devworkspaces gateway rules creation on kubernetes

### DIFF
--- a/controllers/devworkspace/solver/che_routing_test.go
+++ b/controllers/devworkspace/solver/che_routing_test.go
@@ -186,7 +186,7 @@ func relocatableDevWorkspaceRouting() *dwo.DevWorkspaceRouting {
 	}
 }
 
-func TestCreateRelocatedObjects(t *testing.T) {
+func TestCreateRelocatedObjectsK8S(t *testing.T) {
 	infrastructure.InitializeForTesting(infrastructure.Kubernetes)
 	cl, _, objs := getSpecObjects(t, relocatableDevWorkspaceRouting())
 
@@ -224,6 +224,96 @@ func TestCreateRelocatedObjects(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("traefikConfig", func(t *testing.T) {
+		cms := &corev1.ConfigMapList{}
+		cl.List(context.TODO(), cms)
+
+		if len(cms.Items) != 1 {
+			t.Errorf("there should be 1 configmap created for the gateway config of the workspace but there were: %d", len(cms.Items))
+		}
+
+		var workspaceCfg *corev1.ConfigMap
+
+		for _, cfg := range cms.Items {
+			if cfg.Name == "wsid" {
+				workspaceCfg = &cfg
+			}
+		}
+
+		if workspaceCfg == nil {
+			t.Fatalf("traefik configuration for the workspace not found")
+		}
+
+		traefikWorkspaceConfig := workspaceCfg.Data["wsid.yml"]
+
+		if len(traefikWorkspaceConfig) == 0 {
+			t.Fatal("No traefik config file found in the workspace config configmap")
+		}
+
+		workspaceConfig := traefikConfig{}
+		if err := yaml.Unmarshal([]byte(traefikWorkspaceConfig), &workspaceConfig); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(workspaceConfig.HTTP.Routers) != 1 {
+			t.Fatalf("Expected exactly one traefik router but got %d", len(workspaceConfig.HTTP.Routers))
+		}
+
+		wsid := "wsid-m1-9999"
+		if _, ok := workspaceConfig.HTTP.Routers[wsid]; !ok {
+			t.Fatal("traefik config doesn't contain expected workspace configuration")
+		}
+
+		if len(workspaceConfig.HTTP.Routers[wsid].Middlewares) != 1 {
+			t.Fatalf("Expected 1 middlewares in router but got '%d'", len(workspaceConfig.HTTP.Routers[wsid].Middlewares))
+		}
+
+		if len(workspaceConfig.HTTP.Middlewares) != 1 {
+			t.Fatalf("Expected 1 middlewares set but got '%d'", len(workspaceConfig.HTTP.Middlewares))
+		}
+
+		mwares := []string{wsid + "-prefix"}
+		for _, mware := range mwares {
+			if _, ok := workspaceConfig.HTTP.Middlewares[mware]; !ok {
+				t.Fatalf("traefik config doesn't set middleware '%s'", mware)
+			}
+			found := false
+			for _, r := range workspaceConfig.HTTP.Routers[wsid].Middlewares {
+				if r == mware {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("traefik config route doesn't set middleware '%s'", mware)
+			}
+		}
+
+	})
+}
+
+
+func TestCreateRelocatedObjectsOpenshift(t *testing.T) {
+	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
+	cl, _, objs := getSpecObjects(t, relocatableDevWorkspaceRouting())
+
+	t.Run("noIngresses", func(t *testing.T) {
+		if len(objs.Ingresses) != 0 {
+			t.Error()
+		}
+	})
+
+	t.Run("noRoutes", func(t *testing.T) {
+		if len(objs.Routes) != 0 {
+			t.Error()
+		}
+	})
+
+	t.Run("noPodAdditions", func(t *testing.T) {
+		if objs.PodAdditions != nil {
+			t.Error()
+		}
+	})
 
 	t.Run("traefikConfig", func(t *testing.T) {
 		cms := &corev1.ConfigMapList{}


### PR DESCRIPTION
### What does this PR do?
Fix kubernetes gateway rules creation to avoid traefik misconfiguration by unexisting (on K8S) plugin.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20375


### How to test this PR?
Run devworkspace on minikube. Workspaces is started but there is error opening workspace by its URL and errors in the logs of the gateway pod.
Use test image `mshaposh/che-operator:nightly` fixes the situation.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
