### PR TITLE
fix: update regexes for KIP default images

### DIFF
--- a/pkg/deploy/kubernetes_image_puller.go
+++ b/pkg/deploy/kubernetes_image_puller.go
@@ -36,8 +36,8 @@ var imagePullerFinalizerName = "kubernetesimagepullers.finalizers.che.eclipse.or
 
 // ImageAndName represents an image coupled with an image name.
 type ImageAndName struct {
-	name  string // image name (ex. my-image)
-	image string // image (ex. quay.io/test/abc)
+	Name  string // image name (ex. my-image)
+	Image string // image (ex. quay.io/test/abc)
 }
 
 // Reconcile the imagePuller section of the CheCluster CR.  If imagePuller.enable is set to true, install the Kubernetes Image Puller operator and create
@@ -405,11 +405,11 @@ func ImageSliceToString(imageSlice []ImageAndName) string {
 	var err error
 	imagesString := ""
 	for _, image := range imageSlice {
-		image.name, err = ConvertToRFC1123(image.name)
+		image.Name, err = ConvertToRFC1123(image.Name)
 		if err != nil {
 			continue
 		}
-		imagesString += image.name + "=" + image.image + ";"
+		imagesString += image.Name + "=" + image.Image + ";"
 	}
 	return imagesString
 }
@@ -433,7 +433,7 @@ func StringToImageSlice(imagesString string) []ImageAndName {
 			logrus.Warnf("Malformed image name/tag: %s. Ignoring.", image)
 			continue
 		}
-		images = append(images, ImageAndName{name: nameAndImage[0], image: nameAndImage[1]})
+		images = append(images, ImageAndName{Name: nameAndImage[0], Image: nameAndImage[1]})
 	}
 
 	return images
@@ -443,27 +443,22 @@ func StringToImageSlice(imagesString string) []ImageAndName {
 func GetDefaultImages() []ImageAndName {
 	images := []ImageAndName{}
 	imagePatterns := [...]string{
-		"^RELATED_IMAGE_.*_plugin_java8$",
-		"^RELATED_IMAGE_.*_plugin_java11$",
-		"^RELATED_IMAGE_.*_plugin_kubernetes$",
-		"^RELATED_IMAGE_.*_plugin_openshift$",
 		"^RELATED_IMAGE_.*_plugin_broker.*",
 		"^RELATED_IMAGE_.*_theia.*",
-		"^RELATED_IMAGE_.*_stacks_cpp$",
-		"^RELATED_IMAGE_.*_stacks_dotnet$",
-		"^RELATED_IMAGE_.*_stacks_golang$",
-		"^RELATED_IMAGE_.*_stacks_php$",
-		"^RELATED_IMAGE_.*_cpp_.*_devfile_registry_image.*",
-		"^RELATED_IMAGE_.*_dotnet_.*_devfile_registry_image.*",
-		"^RELATED_IMAGE_.*_golang_.*_devfile_registry_image.*",
-		"^RELATED_IMAGE_.*_php_.*_devfile_registry_image.*",
-		"^RELATED_IMAGE_.*_java.*_maven_devfile_registry_image.*",
+		"^RELATED_IMAGE_.*_machine(_)?exec(_.*)?_plugin_registry_image.*",
+		"^RELATED_IMAGE_.*_kubernetes(_.*)?_plugin_registry_image.*",
+		"^RELATED_IMAGE_.*_openshift(_.*)?_plugin_registry_image.*",
+		"^RELATED_IMAGE_.*_cpp(_.*)?_devfile_registry_image.*",
+		"^RELATED_IMAGE_.*_dotnet(_.*)?_devfile_registry_image.*",
+		"^RELATED_IMAGE_.*_golang(_.*)?_devfile_registry_image.*",
+		"^RELATED_IMAGE_.*_php(_.*)?_devfile_registry_image.*",
+		"^RELATED_IMAGE_.*_java.{1,2}(_maven)?_devfile_registry_image.*",
 	}
 	for _, pattern := range imagePatterns {
 		matches := util.GetEnvByRegExp(pattern)
 		for _, match := range matches {
 			match.Name = match.Name[len("RELATED_IMAGE_"):]
-			images = append(images, ImageAndName{name: match.Name, image: match.Value})
+			images = append(images, ImageAndName{Name: match.Name, Image: match.Value})
 		}
 	}
 	return images
@@ -541,13 +536,13 @@ func UpdateDefaultImagesIfNeeded(ctx *DeployContext) error {
 func UpdateSpecImages(specImages []ImageAndName, defaultImages []ImageAndName) bool {
 	match := false
 	for i, specImage := range specImages {
-		specImageName, specImageTag := util.GetImageNameAndTag(specImage.image)
+		specImageName, specImageTag := util.GetImageNameAndTag(specImage.Image)
 		for _, defaultImage := range defaultImages {
-			defaultImageName, defaultImageTag := util.GetImageNameAndTag(defaultImage.image)
+			defaultImageName, defaultImageTag := util.GetImageNameAndTag(defaultImage.Image)
 			// if the image tags are different for this image, then update
 			if defaultImageName == specImageName && defaultImageTag != specImageTag {
 				match = true
-				specImages[i].image = defaultImage.image
+				specImages[i].Image = defaultImage.Image
 				break
 			}
 		}

--- a/pkg/deploy/kubernetes_image_puller_test.go
+++ b/pkg/deploy/kubernetes_image_puller_test.go
@@ -1,0 +1,119 @@
+//
+// Copyright (c) 2020-2021 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package deploy
+
+import (
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEnvVars(t *testing.T) {
+
+	type testcase struct {
+		name     string
+		env      map[string]string
+		expected []ImageAndName
+	}
+
+	cases := []testcase{
+		{
+			name: "detect plugin broker images",
+			env: map[string]string{
+				"RELATED_IMAGE_che_workspace_plugin_broker_artifacts": "quay.io/eclipse/che-plugin-metadata-broker",
+				"RELATED_IMAGE_che_workspace_plugin_broker_metadata":  "quay.io/eclipse/che-plugin-artifacts-broker",
+			},
+			expected: []ImageAndName{
+				{Name: "che_workspace_plugin_broker_artifacts", Image: "quay.io/eclipse/che-plugin-metadata-broker"},
+				{Name: "che_workspace_plugin_broker_metadata", Image: "quay.io/eclipse/che-plugin-artifacts-broker"},
+			},
+		},
+		{
+			name: "detect theia images",
+			env: map[string]string{
+				"RELATED_IMAGE_che_theia_plugin_registry_image_IBZWQYJ":                         "quay.io/eclipse/che-theia",
+				"RELATED_IMAGE_che_theia_endpoint_runtime_binary_plugin_registry_image_IBZWQYJ": "quay.io/eclipse/che-theia-endpoint-runtime-binary",
+			},
+			expected: []ImageAndName{
+				{Name: "che_theia_plugin_registry_image_IBZWQYJ", Image: "quay.io/eclipse/che-theia"},
+				{Name: "che_theia_endpoint_runtime_binary_plugin_registry_image_IBZWQYJ", Image: "quay.io/eclipse/che-theia-endpoint-runtime-binary"},
+			},
+		},
+		{
+			name: "detect machine exec image",
+			env: map[string]string{
+				"RELATED_IMAGE_che_machine_exec_plugin_registry_image_IBZWQYJ": "quay.io/eclipse/che-machine-exec",
+			},
+			expected: []ImageAndName{
+				{Name: "che_machine_exec_plugin_registry_image_IBZWQYJ", Image: "quay.io/eclipse/che-machine-exec"},
+			},
+		},
+		{
+			name: "detect plugin registry images",
+			env: map[string]string{
+				"RELATED_IMAGE_che_openshift_plugin_registry_image_IBZWQYJ": "index.docker.io/dirigiblelabs/dirigible-openshift",
+			},
+			expected: []ImageAndName{
+				{Name: "che_openshift_plugin_registry_image_IBZWQYJ", Image: "index.docker.io/dirigiblelabs/dirigible-openshift"},
+			},
+		},
+		{
+			name: "detect devfile registry images",
+			env: map[string]string{
+				"RELATED_IMAGE_che_cpp_rhel7_devfile_registry_image_G4XDGNR":    "quay.io/eclipse/che-cpp-rhel7",
+				"RELATED_IMAGE_che_dotnet_2_2_devfile_registry_image_G4XDGNR":   "quay.io/eclipse/che-dotnet-2.2",
+				"RELATED_IMAGE_che_dotnet_3_1_devfile_registry_image_G4XDGNR":   "quay.io/eclipse/che-dotnet-3.1",
+				"RELATED_IMAGE_che_golang_1_14_devfile_registry_image_G4XDGNR":  "quay.io/eclipse/che-golang-1.14",
+				"RELATED_IMAGE_che_php_7_devfile_registry_image_G4XDGNR":        "quay.io/eclipse/che-php-7",
+				"RELATED_IMAGE_che_java11_maven_devfile_registry_image_G4XDGNR": "quay.io/eclipse/che-java11-maven",
+				"RELATED_IMAGE_che_java8_maven_devfile_registry_image_G4XDGNR":  "quay.io/eclipse/che-java8-maven",
+			},
+			expected: []ImageAndName{
+				{Name: "che_cpp_rhel7_devfile_registry_image_G4XDGNR", Image: "quay.io/eclipse/che-cpp-rhel7"},
+				{Name: "che_dotnet_2_2_devfile_registry_image_G4XDGNR", Image: "quay.io/eclipse/che-dotnet-2.2"},
+				{Name: "che_dotnet_3_1_devfile_registry_image_G4XDGNR", Image: "quay.io/eclipse/che-dotnet-3.1"},
+				{Name: "che_golang_1_14_devfile_registry_image_G4XDGNR", Image: "quay.io/eclipse/che-golang-1.14"},
+				{Name: "che_php_7_devfile_registry_image_G4XDGNR", Image: "quay.io/eclipse/che-php-7"},
+				{Name: "che_java11_maven_devfile_registry_image_G4XDGNR", Image: "quay.io/eclipse/che-java11-maven"},
+				{Name: "che_java8_maven_devfile_registry_image_G4XDGNR", Image: "quay.io/eclipse/che-java8-maven"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			for k, v := range c.env {
+				os.Setenv(k, v)
+			}
+
+			actual := GetDefaultImages()
+
+			if d := cmp.Diff(sortImages(c.expected), sortImages(actual)); d != "" {
+				t.Errorf("Error, collected images differ (-want, +got): %v", d)
+			}
+			for k := range c.env {
+				os.Unsetenv(k)
+			}
+		})
+	}
+}
+
+func sortImages(images []ImageAndName) []ImageAndName {
+	imagesCopy := make([]ImageAndName, len(images))
+	copy(imagesCopy, images)
+	sort.Slice(imagesCopy, func(i, j int) bool {
+		return imagesCopy[i].Name < imagesCopy[j].Name
+	})
+	return imagesCopy
+}


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
* Updates regex for java devfile registry related images to allow the `maven` part of the name to be optional.
* Updates the `devfile_registry_image`regexes to be more lenient. "Stack" images are now covered by the updated `devfile_registry_image`regexes.


### Screenshot/screencast of this PR
The images that are collected are unchanged:
![image](https://user-images.githubusercontent.com/83611742/132748058-ba1674e1-8ba1-4e15-b31b-b6a56df78882.png)


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
Image: [quay.io/dkwon17/che-operator:update-regexp](quay.io/dkwon17/che-operator:update-regexp)

1. Start crc and deploy 
```
$ crc start --memory=16192 --cpus=4
$ chectl server:deploy -n eclipse-che --olm-channel=stable -p openshift --che-operator-image=quay.io/dkwon17/che-operator:update-regexp
```
2. Enable the kubernetes image puller from the `eclipse-che` `CheCluster` custom resource yaml file by setting `spec.imagePuller.enable` to true and save the changes.
![image](https://user-images.githubusercontent.com/83611742/123484126-dd26f400-d5d5-11eb-80eb-3e56aa07c089.png)

3. After about 5 minutes minutes, there should be a new `kubernetes-image-puller-*` pod with the containers shown in the screenshot above



### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
