### PR TITLE
fix: internal backup server url

### DIFF
--- a/controllers/checlusterbackup/backup_context.go
+++ b/controllers/checlusterbackup/backup_context.go
@@ -20,13 +20,14 @@ import (
 )
 
 type BackupContext struct {
-	namespace            string
-	r                    *ReconcileCheClusterBackup
-	backupCR             *chev1.CheClusterBackup
-	cheCR                *chev1.CheCluster
-	backupServerConfigCR *chev1.CheBackupServerConfiguration
-	backupServer         backup.BackupServer
-	state                *BackupState
+	namespace                           string
+	r                                   *ReconcileCheClusterBackup
+	backupCR                            *chev1.CheClusterBackup
+	cheCR                               *chev1.CheCluster
+	backupServerConfigCR                *chev1.CheBackupServerConfiguration
+	backupServer                        backup.BackupServer
+	state                               *BackupState
+	internalBackupServerExposedHostname string
 }
 
 func NewBackupContext(r *ReconcileCheClusterBackup, backupCR *chev1.CheClusterBackup, backupServerConfig *chev1.CheBackupServerConfiguration) (backupContext *BackupContext, err error) {

--- a/controllers/checlusterbackup/backup_context.go
+++ b/controllers/checlusterbackup/backup_context.go
@@ -20,14 +20,13 @@ import (
 )
 
 type BackupContext struct {
-	namespace                           string
-	r                                   *ReconcileCheClusterBackup
-	backupCR                            *chev1.CheClusterBackup
-	cheCR                               *chev1.CheCluster
-	backupServerConfigCR                *chev1.CheBackupServerConfiguration
-	backupServer                        backup.BackupServer
-	state                               *BackupState
-	internalBackupServerExposedHostname string
+	namespace            string
+	r                    *ReconcileCheClusterBackup
+	backupCR             *chev1.CheClusterBackup
+	cheCR                *chev1.CheCluster
+	backupServerConfigCR *chev1.CheBackupServerConfiguration
+	backupServer         backup.BackupServer
+	state                *BackupState
 }
 
 func NewBackupContext(r *ReconcileCheClusterBackup, backupCR *chev1.CheClusterBackup, backupServerConfig *chev1.CheBackupServerConfiguration) (backupContext *BackupContext, err error) {

--- a/controllers/checlusterbackup/internal_backup_server.go
+++ b/controllers/checlusterbackup/internal_backup_server.go
@@ -14,11 +14,12 @@ package checlusterbackup
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
 
 	chev1 "github.com/eclipse-che/che-operator/api/v1"
+	"github.com/eclipse-che/che-operator/pkg/backup_servers"
 	"github.com/eclipse-che/che-operator/pkg/deploy"
+	"github.com/eclipse-che/che-operator/pkg/deploy/expose"
 	"github.com/eclipse-che/che-operator/pkg/util"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -45,9 +46,10 @@ func ConfigureInternalBackupServer(bctx *BackupContext) (bool, error) {
 	taskList := []func(*BackupContext) (bool, error){
 		ensureInternalBackupServerDeploymentExist,
 		ensureInternalBackupServerServiceExists,
-		ensureInternalBackupServerPodReady,
+		ensureInternalBackupServerServiceExposed,
 		ensureInternalBackupServerConfigurationExistAndCorrect,
 		ensureInternalBackupServerConfigurationCurrent,
+		ensureInternalBackupServerPodReady,
 		ensureInternalBackupServerSecretExists,
 	}
 
@@ -145,8 +147,12 @@ func ensureInternalBackupServerPodReady(bctx *BackupContext) (bool, error) {
 	// It is not possible to implement the check via StartupProbe of the pod,
 	// because the probe requires 2xx status, but a fresh REST server responds with 404 only.
 
-	restServerBaseUrl := getInternalRestBackupServerUrl(bctx)
-	_, err := http.Head(restServerBaseUrl)
+	backupServer, err := backup_servers.NewBackupServer(bctx.backupServerConfigCR.Spec)
+	if err != nil {
+		return true, err
+	}
+	// Try to reach internal backup server: if it responds, then the server is ready.
+	_, _, err = backupServer.IsRepositoryExist()
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
 			// Internal REST server is not ready yet. Reconcile.
@@ -215,6 +221,33 @@ func getBackupServerServiceSpec(bctx *BackupContext) *corev1.Service {
 	return service
 }
 
+func ensureInternalBackupServerServiceExposed(bctx *BackupContext) (bool, error) {
+	if bctx.cheCR.IsInternalClusterSVCNamesEnabled() {
+		// Do nothing if internal communication is used
+		return true, nil
+	}
+
+	// Internal communication is disabled, need to use public routes.
+	// Reusing exposure code from main controller.
+	fakeDeplyContext := &deploy.DeployContext{
+		ClusterAPI: deploy.ClusterAPI{
+			Client: bctx.r.client,
+			Scheme: bctx.r.scheme,
+		},
+		CheCluster: bctx.cheCR,
+	}
+	endpoint, done, err := expose.Expose(
+		fakeDeplyContext,
+		backupServerServiceName,
+		chev1.RouteCustomSettings{},
+		chev1.IngressCustomSettings{})
+	if !done || err != nil {
+		return done, err
+	}
+	bctx.internalBackupServerExposedHostname = endpoint
+	return true, nil
+}
+
 // ensureInternalBackupServerConfigurationExistAndCorrect makes sure that there is CR with correct internal backup server configuration
 func ensureInternalBackupServerConfigurationExistAndCorrect(bctx *BackupContext) (bool, error) {
 	// Check if the internal backup server configuration exists
@@ -270,19 +303,23 @@ func getInternalBackupServerConfigurationSpec(bctx *BackupContext) *chev1.CheBac
 }
 
 func getExpectedInternalRestServerConfiguration(bctx *BackupContext) *chev1.RestServerConfig {
+	if bctx.cheCR.IsInternalClusterSVCNamesEnabled() {
+		// Use service to communicate with internal backup server
+		return &chev1.RestServerConfig{
+			Protocol:                    "http",
+			Hostname:                    fmt.Sprintf("%s.%s.svc", backupServerServiceName, bctx.namespace),
+			Port:                        backupServerPort,
+			RepositoryPath:              "che",
+			RepositoryPasswordSecretRef: BackupServerRepoPasswordSecretName,
+		}
+	}
+	// Use external route to communicate with internal backup server
 	return &chev1.RestServerConfig{
-		Protocol:                    "http",
-		Hostname:                    getInternalRestBackupServerUrl(bctx),
-		Port:                        backupServerPort,
+		Protocol:                    "https",
+		Hostname:                    bctx.internalBackupServerExposedHostname,
 		RepositoryPath:              "che",
 		RepositoryPasswordSecretRef: BackupServerRepoPasswordSecretName,
 	}
-}
-
-// getInternalRestBackupServerUrl returns full service URL to be able to access it even from a different namespace.
-// This is needed for all namespaces operator mode.
-func getInternalRestBackupServerUrl(bctx *BackupContext) string {
-	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", backupServerServiceName, bctx.namespace, backupServerPort)
 }
 
 // ensureInternalBackupServerConfigurationCurrent makes sure that current backup configuration is internal backup server

--- a/controllers/checlusterbackup/internal_backup_server.go
+++ b/controllers/checlusterbackup/internal_backup_server.go
@@ -49,8 +49,8 @@ func ConfigureInternalBackupServer(bctx *BackupContext) (bool, error) {
 		ensureInternalBackupServerServiceExposed,
 		ensureInternalBackupServerConfigurationExistAndCorrect,
 		ensureInternalBackupServerConfigurationCurrent,
-		ensureInternalBackupServerPodReady,
 		ensureInternalBackupServerSecretExists,
+		ensureInternalBackupServerPodReady,
 	}
 
 	for _, task := range taskList {
@@ -148,6 +148,10 @@ func ensureInternalBackupServerPodReady(bctx *BackupContext) (bool, error) {
 	// because the probe requires 2xx status, but a fresh REST server responds with 404 only.
 
 	backupServer, err := backup_servers.NewBackupServer(bctx.backupServerConfigCR.Spec)
+	if err != nil {
+		return true, err
+	}
+	_, err = backupServer.PrepareConfiguration(bctx.r.client, bctx.namespace)
 	if err != nil {
 		return true, err
 	}

--- a/pkg/backup_servers/backup_servers.go
+++ b/pkg/backup_servers/backup_servers.go
@@ -29,7 +29,8 @@ type BackupServer interface {
 	// InitRepository creates backup repository on the backup server side.
 	InitRepository() (bool, error)
 
-	// IsRepositoryExist check whether the repository alredy innitialized.
+	// IsRepositoryExist check whether the repository alredy initialized.
+	// Returns: exists, done, error
 	IsRepositoryExist() (bool, bool, error)
 
 	// CheckRepository verifies ability to connect to the remote backup server.


### PR DESCRIPTION
### What does this PR do?
Change default internal server server configuration to use full URL to the backup server. This allows to access it from a different namespace. Such behaviour is needed for operator running in all namespaces mode.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1497

### How to test this PR?
Try to create a backup using internal backup server in all namespaces operator mode.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
