### PR TITLE
Provision internal URLs, CAs and proxy settings into dashboard

### DIFF
--- a/pkg/deploy/dashboard/dashboard_deployment_test.go
+++ b/pkg/deploy/dashboard/dashboard_deployment_test.go
@@ -255,8 +255,40 @@ func TestDashboardDeploymentVolumes(t *testing.T) {
 	}
 	testCases := []resourcesTestCase{
 		{
-			name:        "Test provisioning CAs",
-			initObjects: []runtime.Object{},
+			name:        "Test provisioning Custom CAs only",
+			initObjects: []runtime.Object{
+				// no deploy.CheTLSSelfSignedCertificateSecretName is created
+			},
+			volumes: []corev1.Volume{
+				{
+					Name: "che-custom-ca",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "ca-certs-merged",
+							},
+						},
+					}},
+			},
+			volumeMounts: []corev1.VolumeMount{
+				{Name: "che-custom-ca", MountPath: "/public-certs/custom"},
+			},
+			cheCluster: &orgv1.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "eclipse-che",
+				},
+			},
+		},
+		{
+			name: "Test provisioning Che and Custom CAs",
+			initObjects: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      deploy.CheTLSSelfSignedCertificateSecretName,
+						Namespace: "eclipse-che",
+					},
+				},
+			},
 			volumes: []corev1.Volume{
 				{
 					Name: "che-custom-ca",

--- a/pkg/deploy/dashboard/dashboard_deployment_test.go
+++ b/pkg/deploy/dashboard/dashboard_deployment_test.go
@@ -14,6 +14,9 @@ package dashboard
 import (
 	"os"
 
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/eclipse-che/che-operator/pkg/util"
 
 	"github.com/eclipse-che/che-operator/pkg/deploy"
@@ -29,8 +32,39 @@ import (
 	"testing"
 )
 
-func TestGetDashboardDeploymentSpec(t *testing.T) {
-	type testCase struct {
+func TestDashboardDeploymentSecurityContext(t *testing.T) {
+	logf.SetLogger(zap.LoggerTo(os.Stdout, true))
+	orgv1.SchemeBuilder.AddToScheme(scheme.Scheme)
+
+	cli := fake.NewFakeClientWithScheme(scheme.Scheme)
+
+	deployContext := &deploy.DeployContext{
+		CheCluster: &orgv1.CheCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "eclipse-che",
+			},
+			Spec: orgv1.CheClusterSpec{
+				Server: orgv1.CheClusterSpecServer{},
+			},
+		},
+		ClusterAPI: deploy.ClusterAPI{
+			Client: cli,
+			Scheme: scheme.Scheme,
+		},
+		Proxy: &deploy.Proxy{},
+	}
+
+	dashboard := NewDashboard(deployContext)
+	deployment, err := dashboard.getDashboardDeploymentSpec()
+	if err != nil {
+		t.Fatalf("Failed to evaluate dashboard deployment spec: %v", err)
+	}
+
+	util.ValidateSecurityContext(deployment, t)
+}
+
+func TestDashboardDeploymentResources(t *testing.T) {
+	type resourcesTestCase struct {
 		name          string
 		initObjects   []runtime.Object
 		memoryLimit   string
@@ -40,7 +74,7 @@ func TestGetDashboardDeploymentSpec(t *testing.T) {
 		cheCluster    *orgv1.CheCluster
 	}
 
-	testCases := []testCase{
+	testCases := []resourcesTestCase{
 		{
 			name:          "Test default limits",
 			initObjects:   []runtime.Object{},
@@ -107,8 +141,195 @@ func TestGetDashboardDeploymentSpec(t *testing.T) {
 					CpuLimit:      testCase.cpuLimit,
 				},
 				t)
+		})
+	}
+}
 
-			util.ValidateSecurityContext(deployment, t)
+func TestDashboardDeploymentEnvVars(t *testing.T) {
+	type resourcesTestCase struct {
+		name        string
+		initObjects []runtime.Object
+		envVars     []corev1.EnvVar
+		cheCluster  *orgv1.CheCluster
+	}
+	trueBool := true
+	testCases := []resourcesTestCase{
+		{
+			name:        "Test provisioning Che and Keycloak URLs",
+			initObjects: []runtime.Object{},
+			envVars: []corev1.EnvVar{
+				{
+					Name:  "CHE_HOST",
+					Value: "http://che.com",
+				},
+				{
+					Name:  "CHE_URL",
+					Value: "http://che.com",
+				},
+				{
+					Name:  "CHE_INTERNAL_URL",
+					Value: "http://che-host.eclipse-che.svc:8080/api",
+				},
+			},
+			cheCluster: &orgv1.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "eclipse-che",
+				},
+				Spec: orgv1.CheClusterSpec{
+					Server: orgv1.CheClusterSpecServer{
+						CheHost: "che.com",
+					},
+				},
+			},
+		},
+		{
+			name:        "Test provisioning Che and Keycloak URLs when internal SVC is disabled",
+			initObjects: []runtime.Object{},
+			envVars: []corev1.EnvVar{
+				{
+					Name:  "CHE_HOST",
+					Value: "http://che.com",
+				},
+				{
+					Name:  "CHE_URL",
+					Value: "http://che.com",
+				},
+				// the following are not provisioned: CHE_INTERNAL_URL
+			},
+			cheCluster: &orgv1.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "eclipse-che",
+				},
+				Spec: orgv1.CheClusterSpec{
+					Server: orgv1.CheClusterSpecServer{
+						DisableInternalClusterSVCNames: &trueBool,
+						CheHost:                        "che.com",
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			logf.SetLogger(zap.LoggerTo(os.Stdout, true))
+			orgv1.SchemeBuilder.AddToScheme(scheme.Scheme)
+			testCase.initObjects = append(testCase.initObjects)
+			cli := fake.NewFakeClientWithScheme(scheme.Scheme, testCase.initObjects...)
+
+			deployContext := &deploy.DeployContext{
+				CheCluster: testCase.cheCluster,
+				ClusterAPI: deploy.ClusterAPI{
+					Client: cli,
+					Scheme: scheme.Scheme,
+				},
+				Proxy: &deploy.Proxy{},
+			}
+
+			dashboard := NewDashboard(deployContext)
+			deployment, err := dashboard.getDashboardDeploymentSpec()
+			if err != nil {
+				t.Fatalf("Failed to evaluate dashboard deployment spec: %v", err)
+			}
+			containers := deployment.Spec.Template.Spec.Containers
+			if len(containers) != 1 {
+				t.Fatalf("Dashboard deployment is expected to have only one container but is has %v", len(containers))
+			}
+
+			dashboardContainer := containers[0]
+			diff := cmp.Diff(testCase.envVars, dashboardContainer.Env)
+			if diff != "" {
+				t.Fatalf("Container env var does not match expected. Diff: %s", diff)
+			}
+		})
+	}
+}
+
+func TestDashboardDeploymentVolumes(t *testing.T) {
+	type resourcesTestCase struct {
+		name         string
+		initObjects  []runtime.Object
+		volumes      []corev1.Volume
+		volumeMounts []corev1.VolumeMount
+		cheCluster   *orgv1.CheCluster
+	}
+	testCases := []resourcesTestCase{
+		{
+			name:        "Test provisioning CAs",
+			initObjects: []runtime.Object{},
+			volumes: []corev1.Volume{
+				{
+					Name: "che-custom-ca",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "ca-certs-merged",
+							},
+						},
+					}},
+				{
+					Name: "che-self-signed-ca",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: "self-signed-certificate",
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "ca.crt",
+									Path: "ca.crt",
+								},
+							},
+						},
+					},
+				},
+			},
+			volumeMounts: []corev1.VolumeMount{
+				{Name: "che-custom-ca", MountPath: "/public-certs/custom"},
+				{Name: "che-self-signed-ca", MountPath: "/public-certs/che-self-signed"},
+			},
+			cheCluster: &orgv1.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "eclipse-che",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			logf.SetLogger(zap.LoggerTo(os.Stdout, true))
+			orgv1.SchemeBuilder.AddToScheme(scheme.Scheme)
+			testCase.initObjects = append(testCase.initObjects)
+			cli := fake.NewFakeClientWithScheme(scheme.Scheme, testCase.initObjects...)
+
+			deployContext := &deploy.DeployContext{
+				CheCluster: testCase.cheCluster,
+				ClusterAPI: deploy.ClusterAPI{
+					Client: cli,
+					Scheme: scheme.Scheme,
+				},
+				Proxy: &deploy.Proxy{},
+			}
+
+			dashboard := NewDashboard(deployContext)
+			deployment, err := dashboard.getDashboardDeploymentSpec()
+			if err != nil {
+				t.Fatalf("Failed to evaluate dashboard deployment spec: %v", err)
+			}
+			containers := deployment.Spec.Template.Spec.Containers
+			if len(containers) != 1 {
+				t.Fatalf("Dashboard deployment is expected to have only one container but is has %v", len(containers))
+			}
+
+			diff := cmp.Diff(testCase.volumes, deployment.Spec.Template.Spec.Volumes)
+			if diff != "" {
+				t.Fatalf("Dashboard deployment volume not match expected. Diff: %s", diff)
+			}
+
+			dashboardContainer := containers[0]
+			diff = cmp.Diff(testCase.volumeMounts, dashboardContainer.VolumeMounts)
+			if diff != "" {
+				t.Fatalf("Dashboard deployment volume not match expected. Diff: %s", diff)
+			}
 		})
 	}
 }

--- a/pkg/deploy/dashboard/deployment_dashboard.go
+++ b/pkg/deploy/dashboard/deployment_dashboard.go
@@ -33,11 +33,11 @@ func (d *Dashboard) getDashboardDeploymentSpec() (*appsv1.Deployment, error) {
 
 	volumes, volumeMounts = d.provisionCustomPublicCA(volumes, volumeMounts)
 
-	selfSignedCertUsed, err := deploy.IsSelfSignedCertificateUsed(d.deployContext)
+	selfSignedCertSecretExist, err := deploy.IsSelfSignedCASecretExists(d.deployContext)
 	if err != nil {
 		return nil, err
 	}
-	if selfSignedCertUsed {
+	if selfSignedCertSecretExist {
 		volumes, volumeMounts = d.provisionCheSelfSignedCA(volumes, volumeMounts)
 	}
 

--- a/pkg/deploy/server/server_deployment.go
+++ b/pkg/deploy/server/server_deployment.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (s Server) getDeploymentSpec() (*appsv1.Deployment, error) {
-	selfSignedCertUsed, err := deploy.IsSelfSignedCertificateUsed(s.deployContext)
+	selfSignedCASecretExists, err := deploy.IsSelfSignedCASecretExists(s.deployContext)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (s Server) getDeploymentSpec() (*appsv1.Deployment, error) {
 		Name:  "CHE_GIT_SELF__SIGNED__CERT__HOST",
 		Value: "",
 	}
-	if selfSignedCertUsed {
+	if selfSignedCASecretExists {
 		selfSignedCertEnv = corev1.EnvVar{
 			Name: "CHE_SELF__SIGNED__CERT",
 			ValueFrom: &corev1.EnvVarSource{

--- a/pkg/deploy/server/server_deployment.go
+++ b/pkg/deploy/server/server_deployment.go
@@ -43,20 +43,18 @@ func (s Server) getDeploymentSpec() (*appsv1.Deployment, error) {
 		Name:  "CHE_SELF__SIGNED__CERT",
 		Value: "",
 	}
-	customPublicCertsVolumeSource := corev1.VolumeSource{}
-	customPublicCertsVolumeSource = corev1.VolumeSource{
-		ConfigMap: &corev1.ConfigMapVolumeSource{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: deploy.CheAllCACertsConfigMapName,
+	customPublicCertsVolume := corev1.Volume{
+		Name: "che-public-certs",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: deploy.CheAllCACertsConfigMapName,
+				},
 			},
 		},
 	}
-	customPublicCertsVolume := corev1.Volume{
-		Name:         "che-public-certs",
-		VolumeSource: customPublicCertsVolumeSource,
-	}
 	customPublicCertsVolumeMount := corev1.VolumeMount{
-		Name:      "che-public-certs",
+		Name:      customPublicCertsVolume.Name,
 		MountPath: "/public-certs",
 	}
 	gitSelfSignedCertEnv := corev1.EnvVar{


### PR DESCRIPTION
### What does this PR do?
This PR about provisioning internal URLs, CAs and proxy settings into dashboard.
It's for https://github.com/eclipse-che/che-dashboard/pull/348

Note that dashboard will always use public Keycloak URL, since it needs user's info endpoint, and it gets it from Che Server.
Potentially it could evaluate it for itself, but I don't think it worthes the afford since:
- it's used only on Kubernetes and we expect it be dropped once we have native auth for Kubernetes;

### Screenshot/screencast of this PR



### What issues does this PR fix or reference?
This is prereq for Dashboard part for https://github.com/eclipse/che/issues/20367

### How to test this PR?
Http proxy and custom certs are not easy to test, so I just copied Theia solution on dashboard side and assume it works.
1. For Che Self Signed certs verification you need to test Che on minikube:
```sh
cat EOF << > /tmp/che-cluster-patch.yaml
spec:
  k8s:
    singleHostExposureType: gateway
  server:
    dashboardImage: 'sleshchenko/che-dashboard:che-ca'
    dashboardImagePullPolicy: Always
    customCheProperties:
      CHE_INFRA_KUBERNETES_ENABLE__UNSUPPORTED__K8S: "true"
EOF
chectl server:deploy --installer=operator --platform=minikube \
  --che-operator-cr-patch-yaml=che-cluster-patch.yaml \
  --che-operator-image=sleshchenko/che-operator:dashboard-ca \
  --workspace-engine=dev-workspace
```
2. Open Dashboard and make sure dashboard reports the right values in logs:
![Screenshot_20210916_152206](https://user-images.githubusercontent.com/5887312/133611584-e1c47250-9f24-4fa4-9f64-a0b4442fed9c.png)

3. Disable internal URLs
```
oc patch checluster/eclipse-che -n eclipse-che --type=merge \
    --patch "{\"spec\":{\"server\":{\"disableInternalClusterSVCNames\":true}}}"
```
4. After Che operator did its job check Che Operator and Dashboard collaborate together well, and now public Che URL is used:
![Screenshot_20210916_152924](https://user-images.githubusercontent.com/5887312/133612338-a55ab339-7dcc-405f-bbba-a884b632875c.png)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
