### PR TITLE
fix: registries accessible without auth

### DIFF
--- a/pkg/deploy/gateway/gateway.go
+++ b/pkg/deploy/gateway/gateway.go
@@ -15,10 +15,11 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"strconv"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/eclipse-che/che-operator/pkg/deploy"
 

--- a/pkg/deploy/gateway/gateway_test.go
+++ b/pkg/deploy/gateway/gateway_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"encoding/base64"
+	"strings"
 	"testing"
 
 	orgv1 "github.com/eclipse-che/che-operator/api/v1"
@@ -174,4 +175,58 @@ func TestRandomCookieSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to decode the secret '%s'", err)
 	}
+}
+
+func TestOauthProxyConfigUnauthorizedRegistries(t *testing.T) {
+	t.Run("no skip auth", func(t *testing.T) {
+		configmap := getGatewayOauthProxyConfigSpec(&orgv1.CheCluster{
+			Spec: orgv1.CheClusterSpec{
+				Server: orgv1.CheClusterSpecServer{
+					ExternalDevfileRegistry: true,
+					ExternalPluginRegistry:  true,
+				}}}, "blabol")
+		config := configmap.Data["oauth-proxy.cfg"]
+		if strings.Contains(config, "skip_auth_regex") {
+			t.Errorf("oauth config shold not contain any skip auth when both registries are external")
+		}
+	})
+
+	t.Run("no devfile-registry auth", func(t *testing.T) {
+		configmap := getGatewayOauthProxyConfigSpec(&orgv1.CheCluster{
+			Spec: orgv1.CheClusterSpec{
+				Server: orgv1.CheClusterSpecServer{
+					ExternalDevfileRegistry: false,
+					ExternalPluginRegistry:  true,
+				}}}, "blabol")
+		config := configmap.Data["oauth-proxy.cfg"]
+		if !strings.Contains(config, "skip_auth_regex = \"^/devfile-registry\"") {
+			t.Error("oauth config should skip auth for devfile registry", config)
+		}
+	})
+
+	t.Run("skip plugin-registry auth", func(t *testing.T) {
+		configmap := getGatewayOauthProxyConfigSpec(&orgv1.CheCluster{
+			Spec: orgv1.CheClusterSpec{
+				Server: orgv1.CheClusterSpecServer{
+					ExternalDevfileRegistry: true,
+					ExternalPluginRegistry:  false,
+				}}}, "blabol")
+		config := configmap.Data["oauth-proxy.cfg"]
+		if !strings.Contains(config, "skip_auth_regex = \"^/plugin-registry\"") {
+			t.Error("oauth config should skip auth for plugin registry", config)
+		}
+	})
+
+	t.Run("skip both registries auth", func(t *testing.T) {
+		configmap := getGatewayOauthProxyConfigSpec(&orgv1.CheCluster{
+			Spec: orgv1.CheClusterSpec{
+				Server: orgv1.CheClusterSpecServer{
+					ExternalDevfileRegistry: false,
+					ExternalPluginRegistry:  false,
+				}}}, "blabol")
+		config := configmap.Data["oauth-proxy.cfg"]
+		if !strings.Contains(config, "skip_auth_regex = \"^/plugin-registry|^/devfile-registry\"") {
+			t.Error("oauth config should skip auth for plugin and devfile registry.", config)
+		}
+	})
 }


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Makes plugin and devfile registries accessible without authentication with native auth.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20449


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
image: `quay.io/mvala/che-operator:gh20449-unauthRegistries`

```bash

chectl server:deploy \
     --installer=operator \
     --platform=openshift \
     --che-operator-image=quay.io/mvala/che-operator:gh20449-unauthRegistries \
     --workspace-engine=dev-workspace
```

1. deploy with devworkspaces and che-operator image ^
2. without prior logging into Che, open `<che-url>/plugin-registry` or `<che-url>/devfile-registry`. You should be able to access those without login.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
