### PR TITLE
WIP Remove deploy step for DevWorkspaceOperator configmap

### DIFF
--- a/pkg/deploy/dev-workspace/dev_workspace.go
+++ b/pkg/deploy/dev-workspace/dev_workspace.go
@@ -67,7 +67,6 @@ var (
 	DevWorkspaceWorkspaceRoutingCRDFile       = DevWorkspaceTemplates + "/devworkspaceroutings.controller.devfile.io.CustomResourceDefinition.yaml"
 	DevWorkspaceTemplatesCRDFile              = DevWorkspaceTemplates + "/devworkspacetemplates.workspace.devfile.io.CustomResourceDefinition.yaml"
 	DevWorkspaceCRDFile                       = DevWorkspaceTemplates + "/devworkspaces.workspace.devfile.io.CustomResourceDefinition.yaml"
-	DevWorkspaceConfigMapFile                 = DevWorkspaceTemplates + "/devworkspace-controller-configmap.ConfigMap.yaml"
 	DevWorkspaceServiceFile                   = DevWorkspaceTemplates + "/devworkspace-controller-manager-service.Service.yaml"
 	DevWorkspaceDeploymentFile                = DevWorkspaceTemplates + "/devworkspace-controller-manager.Deployment.yaml"
 	DevWorkspaceIssuerFile                    = DevWorkspaceTemplates + "/devworkspace-controller-selfsigned-issuer.Issuer.yaml"
@@ -102,7 +101,6 @@ var (
 		syncDwCRD,
 		syncDwTemplatesCRD,
 		syncDwWorkspaceRoutingCRD,
-		syncDwConfigMap,
 		syncDwDeployment,
 	}
 
@@ -327,24 +325,6 @@ func syncDwCertificate(deployContext *deploy.DeployContext) (bool, error) {
 		return readAndSyncUnstructured(deployContext, DevWorkspaceCertificateFile)
 	}
 	return true, nil
-}
-
-func syncDwConfigMap(deployContext *deploy.DeployContext) (bool, error) {
-	obj2sync, err := readK8SObject(DevWorkspaceConfigMapFile, &corev1.ConfigMap{})
-	if err != nil {
-		return false, err
-	}
-
-	configMap := obj2sync.obj.(*corev1.ConfigMap)
-	// Remove when DevWorkspace controller should not care about DWR base host #373 https://github.com/devfile/devworkspace-operator/issues/373
-	if !util.IsOpenShift {
-		if configMap.Data == nil {
-			configMap.Data = make(map[string]string, 1)
-		}
-		configMap.Data["devworkspace.routing.cluster_host_suffix"] = deployContext.CheCluster.Spec.K8s.IngressDomain
-	}
-
-	return syncObject(deployContext, obj2sync, DevWorkspaceNamespace)
 }
 
 func syncDwDeployment(deployContext *deploy.DeployContext) (bool, error) {


### PR DESCRIPTION
### What does this PR do?
Removes the step that deploys a configmap for the DevWorkspace Operator. 

Should not be merged until https://github.com/devfile/devworkspace-operator/pull/598 is merged and new image/templates are used in the Che Operator.

As of https://github.com/devfile/devworkspace-operator/pull/598, the DevWorkspace Operator should not require any config to exist on the cluster for proper functionality, except for the specific case where `basic` routing is used on a Kubernetes cluster. 

Note also that the issue mentioned in a comment there
```go
// Remove when DevWorkspace controller should not care about DWR base host #373 https://github.com/devfile/devworkspace-operator/issues/373
```
is already closed as well.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
Sequela from https://github.com/devfile/devworkspace-operator/pull/598

### How to test this PR?
Should be no difference from the Che Operator perspective

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
