### PR TITLE
fix: delete KIP finalizer and KIP operator on CheCluster CR delete

### DIFF
--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -78,7 +78,7 @@ const (
 	DefaultSecurityContextFsGroup   = "1724"
 	DefaultSecurityContextRunAsUser = "1724"
 
-	KubernetesImagePullerOperatorCSV = "kubernetes-imagepuller-operator.v0.0.4"
+	KubernetesImagePullerOperatorCSV = "kubernetes-imagepuller-operator.v0.0.9"
 
 	DefaultServerExposureStrategy = "multi-host"
 	NativeSingleHostExposureType  = "native"

--- a/pkg/deploy/kubernetes_image_puller.go
+++ b/pkg/deploy/kubernetes_image_puller.go
@@ -44,6 +44,10 @@ type ImageAndName struct {
 // a KubernetesImagePuller CR.  Add a finalizer to the CheCluster CR.  If false, remove the KubernetesImagePuller CR, uninstall the operator, and remove the finalizer.
 func ReconcileImagePuller(ctx *DeployContext) (reconcile.Result, error) {
 
+	if !ctx.CheCluster.ObjectMeta.DeletionTimestamp.IsZero() {
+		return DeleteImagePullerOperatorAndFinalizer(ctx)
+	}
+
 	// Determine what server groups the API Server knows about
 	foundPackagesAPI, foundOperatorsAPI, _, err := CheckNeededImagePullerApis(ctx)
 	if err != nil {
@@ -171,25 +175,31 @@ func ReconcileImagePuller(ctx *DeployContext) (reconcile.Result, error) {
 
 	} else {
 		if foundOperatorsAPI && foundPackagesAPI {
-			removed, err := UninstallImagePullerOperator(ctx)
-			if err != nil {
-				logrus.Errorf("Error uninstalling Image Puller: %v", err)
-				return reconcile.Result{}, err
-			}
-
-			if removed {
-				return reconcile.Result{RequeueAfter: time.Second}, nil
-			}
-
-			if HasImagePullerFinalizer(ctx.CheCluster) {
-				err = DeleteImagePullerFinalizer(ctx)
-				if err != nil {
-					logrus.Errorf("Error deleting finalizer: %v", err)
-					return reconcile.Result{}, err
-				}
-				return reconcile.Result{RequeueAfter: time.Second}, nil
-			}
+			return DeleteImagePullerOperatorAndFinalizer(ctx)
 		}
+	}
+	return reconcile.Result{}, nil
+}
+
+func DeleteImagePullerOperatorAndFinalizer(ctx *DeployContext) (reconcile.Result, error) {
+	requeue := false
+	if _, err := GetImagePullerOperator(ctx); err == nil {
+		requeue = true
+		if _, err := UninstallImagePullerOperator(ctx); err != nil {
+			logrus.Errorf("Error uninstalling Image Puller: %v", err)
+			return reconcile.Result{}, err
+		}
+	}
+	if HasImagePullerFinalizer(ctx.CheCluster) {
+		requeue = true
+		if err := DeleteImagePullerFinalizer(ctx); err != nil {
+			logrus.Errorf("Error deleting finalizer: %v", err)
+			return reconcile.Result{}, err
+		}
+	}
+
+	if requeue {
+		return reconcile.Result{RequeueAfter: time.Second}, nil
 	}
 	return reconcile.Result{}, nil
 }
@@ -561,7 +571,6 @@ func SetImages(ctx *DeployContext, images []ImageAndName) error {
 // the image puller spec.  Returns true if the CheCluster was updated
 func UninstallImagePullerOperator(ctx *DeployContext) (bool, error) {
 	updated := false
-
 	_, hasOperatorsAPIs, hasImagePullerAPIs, err := CheckNeededImagePullerApis(ctx)
 	if err != nil {
 		return updated, err
@@ -569,8 +578,7 @@ func UninstallImagePullerOperator(ctx *DeployContext) (bool, error) {
 
 	if hasImagePullerAPIs {
 		// Delete the KubernetesImagePuller
-		imagePuller := &chev1alpha1.KubernetesImagePuller{}
-		err := ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Namespace: ctx.CheCluster.Namespace, Name: ctx.CheCluster.Name + "-image-puller"}, imagePuller)
+		imagePuller, err := GetImagePullerOperator(ctx)
 		if err != nil && !errors.IsNotFound(err) {
 			return updated, err
 		}
@@ -629,7 +637,8 @@ func UninstallImagePullerOperator(ctx *DeployContext) (bool, error) {
 	}
 
 	// Update CR to remove imagePullerSpec
-	if ctx.CheCluster.Spec.ImagePuller.Enable || ctx.CheCluster.Spec.ImagePuller.Spec != (chev1alpha1.KubernetesImagePullerSpec{}) {
+	if (ctx.CheCluster.Spec.ImagePuller.Enable || ctx.CheCluster.Spec.ImagePuller.Spec != (chev1alpha1.KubernetesImagePullerSpec{})) &&
+		ctx.CheCluster.ObjectMeta.DeletionTimestamp.IsZero() {
 		ctx.CheCluster.Spec.ImagePuller.Spec = chev1alpha1.KubernetesImagePullerSpec{}
 		logrus.Infof("Updating CheCluster %v to remove image puller spec", ctx.CheCluster.Name)
 		err := ctx.ClusterAPI.Client.Update(context.TODO(), ctx.CheCluster, &client.UpdateOptions{})
@@ -639,4 +648,14 @@ func UninstallImagePullerOperator(ctx *DeployContext) (bool, error) {
 		updated = true
 	}
 	return updated, nil
+}
+
+// GetImagePullerOperator returns the current kubernetes-imagepuller-operator if exists
+func GetImagePullerOperator(ctx *DeployContext) (*chev1alpha1.KubernetesImagePuller, error) {
+	imagePuller := &chev1alpha1.KubernetesImagePuller{}
+	err := ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Namespace: ctx.CheCluster.Namespace, Name: ctx.CheCluster.Name + "-image-puller"}, imagePuller)
+	if err != nil {
+		return nil, err
+	}
+	return imagePuller, nil
 }


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

Image: `quay.io/dkwon17/che-operator:cr_delete`

### What does this PR do?
Deleting the CheCluster CR when `spec.imagePuller.enable` is set to `true`, caused the CR to not be deleted, due to the Kubernetes Image Puller finalizer not being removed from the CR. This PR removes the finalizer and also removes the Kubernetes Image Puller Operator.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
Deleting the CheCluster CR when `spec.imagePuller.enable` is set to `true`, works properly.
The Kubernetes Image Puller Operator is also deleted.
![cr-delete](https://user-images.githubusercontent.com/83611742/134067288-24ac9563-fd58-46ea-b0a5-aa6c9f616151.gif)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-2256


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
Tested on CRC.

1. Run the following to deploy Che:
```bash
chectl server:deploy -n eclipse-che --olm-channel=stable -p openshift --che-operator-image=quay.io/dkwon17/che-operator:cr_delete
```

2. After installation, set `spec.imagePuller.enable` is set to `true` in the CheCluster CR instance, and save changes:
![image](https://user-images.githubusercontent.com/83611742/134065243-b4110960-33c5-44e4-b983-478dd50a0263.png)

3. Wait until the Kubernetes Image Puller Operator is installed:
![image](https://user-images.githubusercontent.com/83611742/134066944-a6770de2-1e74-4800-97ce-7dfb3fc54a65.png)

4. Delete the CheCluster CR instance. The CR instance and the Image Puller Operator should both be deleted:
![cr-delete](https://user-images.githubusercontent.com/83611742/134067288-24ac9563-fd58-46ea-b0a5-aa6c9f616151.gif)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
