### PR TITLE
Do not automatically backup to internal backup server if it doesn't exist

### DIFF
--- a/controllers/che/backup.go
+++ b/controllers/che/backup.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	chev1 "github.com/eclipse-che/che-operator/api/v1"
 	"github.com/eclipse-che/che-operator/pkg/deploy"
@@ -105,10 +106,13 @@ func getBackupCRSpec(deployContext *deploy.DeployContext) (*chev1.CheClusterBack
 // getBackupServerConfigurationNameForBackupBeforeUpdate searches for backup server configuration.
 // If there is only one, then it is used.
 // If there are two or more, then one with 'che.eclipse.org/default-backup-server-configuration' annotation is used.
-// If there is none, then empty string returned (internal backup server should be used).
+// If there is none, then empty string is returned.
 func getBackupServerConfigurationNameForBackupBeforeUpdate(deployContext *deploy.DeployContext) (string, error) {
 	backupServerConfigsList := &chev1.CheBackupServerConfigurationList{}
-	if err := deployContext.ClusterAPI.Client.List(context.TODO(), backupServerConfigsList); err != nil {
+	listOptions := &client.ListOptions{
+		Namespace: deployContext.CheCluster.GetNamespace(),
+	}
+	if err := deployContext.ClusterAPI.Client.List(context.TODO(), backupServerConfigsList, listOptions); err != nil {
 		return "", err
 	}
 	if len(backupServerConfigsList.Items) == 1 {

--- a/controllers/che/checluster_controller.go
+++ b/controllers/che/checluster_controller.go
@@ -262,25 +262,33 @@ func (r *CheClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 
 	if isCheGoingToBeUpdated(instance) {
 		// Current operator is newer than deployed Che
-		backupCR, err := getBackupCRForUpdate(deployContext)
+		// Check if any backup server configured
+		configName, err := getBackupServerConfigurationNameForBackupBeforeUpdate(deployContext)
 		if err != nil {
-			if errors.IsNotFound(err) {
-				// Create a backup before updating current installation
-				if err := requestBackup(deployContext); err != nil {
-					return ctrl.Result{}, err
-				}
-				// Backup request is successfully submitted
-				// Give some time for the backup
-				return ctrl.Result{RequeueAfter: time.Second * 15}, nil
-			}
 			return ctrl.Result{}, err
 		}
-		if backupCR.Status.State == orgv1.STATE_IN_PROGRESS {
-			// Backup is still in progress
-			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
+		if configName != "" {
+			// Backup server configured
+			backupCR, err := getBackupCRForUpdate(deployContext)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					// Create a backup before updating current installation
+					if err := requestBackup(deployContext); err != nil {
+						return ctrl.Result{}, err
+					}
+					// Backup request is successfully submitted
+					// Give some time for the backup
+					return ctrl.Result{RequeueAfter: time.Second * 15}, nil
+				}
+				return ctrl.Result{}, err
+			}
+			if backupCR.Status.State == orgv1.STATE_IN_PROGRESS {
+				// Backup is still in progress
+				return ctrl.Result{RequeueAfter: time.Second * 5}, nil
+			}
+			// Backup is done or failed
+			// Proceed anyway
 		}
-		// Backup is done or failed
-		// Proceed anyway
 	}
 
 	// Reconcile finalizers before CR is deleted


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Stops creating internal backup server and store backups on updates automatically. Does it if at least one backup server configuration is present.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://github.com/che-incubator/chectl/pull/1680

### How to test this PR?
1. Deploy previous version of Che.
2. Update to a newer version
3. Only if a backup server configuration existed, a new backup was created.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
