### PR TITLE
fix: Create backup on every Che update

### DIFF
--- a/controllers/che/checluster_controller.go
+++ b/controllers/che/checluster_controller.go
@@ -262,33 +262,25 @@ func (r *CheClusterReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 
 	if isCheGoingToBeUpdated(instance) {
 		// Current operator is newer than deployed Che
-		// Check if any backup server configured
-		configName, err := getBackupServerConfigurationNameForBackupBeforeUpdate(deployContext)
+		backupCR, err := getBackupCRForUpdate(deployContext)
 		if err != nil {
+			if errors.IsNotFound(err) {
+				// Create a backup before updating current installation
+				if err := requestBackup(deployContext); err != nil {
+					return ctrl.Result{}, err
+				}
+				// Backup request is successfully submitted
+				// Give some time for the backup
+				return ctrl.Result{RequeueAfter: time.Second * 15}, nil
+			}
 			return ctrl.Result{}, err
 		}
-		if configName != "" {
-			// Backup server configured
-			backupCR, err := getBackupCRForUpdate(deployContext)
-			if err != nil {
-				if errors.IsNotFound(err) {
-					// Create a backup before updating current installation
-					if err := requestBackup(deployContext); err != nil {
-						return ctrl.Result{}, err
-					}
-					// Backup request is successfully submitted
-					// Give some time for the backup
-					return ctrl.Result{RequeueAfter: time.Second * 15}, nil
-				}
-				return ctrl.Result{}, err
-			}
-			if backupCR.Status.State == orgv1.STATE_IN_PROGRESS {
-				// Backup is still in progress
-				return ctrl.Result{RequeueAfter: time.Second * 5}, nil
-			}
-			// Backup is done or failed
-			// Proceed anyway
+		if backupCR.Status.State == orgv1.STATE_IN_PROGRESS {
+			// Backup is still in progress
+			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 		}
+		// Backup is done or failed
+		// Proceed anyway
 	}
 
 	// Reconcile finalizers before CR is deleted


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Makes Che operator always create a backup on update Che version
The behavior is the following:
- if there is no backup servers configured, then internal backup server is deployed and configured and used.
- if only one backup server is configured, then it is used
- if several backup servers configured, then:
  - server configuration with `che.eclipse.org/backup-before-update: true` annotation is used
  - internal backup server deployed and used if no annotation found

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1497

### How to test this PR?
1. Deploy Che of a previous version
2. Update Che to a newer version
3. Check that backup object is created

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
