### PR TITLE
fix: Limit list k8s objects queries to current namespace for backup and restore

### DIFF
--- a/controllers/checlusterrestore/backup_data_restorer.go
+++ b/controllers/checlusterrestore/backup_data_restorer.go
@@ -153,7 +153,10 @@ func cleanPreviousInstallation(rctx *RestoreContext, dataDir string) (bool, erro
 	skipBackupObjectsRequirement, _ := labels.NewRequirement(deploy.KubernetesPartOfLabelKey, selection.NotEquals, []string{checlusterbackup.BackupCheEclipseOrg})
 
 	cheResourcesLabelSelector := labels.NewSelector().Add(*cheInstanceRequirement).Add(*cheNameRequirement).Add(*skipBackupObjectsRequirement)
-	cheResourcesListOptions := &client.ListOptions{LabelSelector: cheResourcesLabelSelector}
+	cheResourcesListOptions := &client.ListOptions{
+		LabelSelector: cheResourcesLabelSelector,
+		Namespace:     rctx.namespace,
+	}
 	cheResourcesMatchingLabelsSelector := client.MatchingLabelsSelector{Selector: cheResourcesLabelSelector}
 
 	// Delete all Che related deployments, but keep operator (excluded by name) and internal backup server (excluded by label)

--- a/controllers/checlusterrestore/checlusterrestore_controller.go
+++ b/controllers/checlusterrestore/checlusterrestore_controller.go
@@ -148,7 +148,8 @@ func (r *ReconcileCheClusterRestore) doReconcile(restoreCR *chev1.CheClusterRest
 	if backupServerConfigName == "" {
 		// Try to find backup server configuration in the same namespace
 		cheBackupServersConfigurationList := &chev1.CheBackupServerConfigurationList{}
-		if err := r.client.List(context.TODO(), cheBackupServersConfigurationList); err != nil {
+		listOptions := &client.ListOptions{Namespace: restoreCR.GetNamespace()}
+		if err := r.client.List(context.TODO(), cheBackupServersConfigurationList, listOptions); err != nil {
 			return false, err
 		}
 		if len(cheBackupServersConfigurationList.Items) != 1 {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -568,9 +568,10 @@ func ReloadCheCluster(client client.Client, cheCluster *orgv1.CheCluster) error 
 		cheCluster)
 }
 
-func FindCheCRinNamespace(client client.Client, namespace string) (*orgv1.CheCluster, int, error) {
+func FindCheCRinNamespace(cl client.Client, namespace string) (*orgv1.CheCluster, int, error) {
 	cheClusters := &orgv1.CheClusterList{}
-	if err := client.List(context.TODO(), cheClusters); err != nil {
+	listOptions := &client.ListOptions{Namespace: namespace}
+	if err := cl.List(context.TODO(), cheClusters, listOptions); err != nil {
 		return nil, -1, err
 	}
 
@@ -580,7 +581,7 @@ func FindCheCRinNamespace(client client.Client, namespace string) (*orgv1.CheClu
 
 	cheCR := &orgv1.CheCluster{}
 	namespacedName := types.NamespacedName{Namespace: namespace, Name: cheClusters.Items[0].GetName()}
-	err := client.Get(context.TODO(), namespacedName, cheCR)
+	err := cl.Get(context.TODO(), namespacedName, cheCR)
 	if err != nil {
 		return nil, -1, err
 	}


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Narrows list for a resource kind query to search only in current namespace

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20563

### How to test this PR?
Try to create a backup when several Che instances are present on a single cluster

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
