### PR TITLE
fix: Print 'More than one checluster Custom Resource found' warning o…

### DIFF
--- a/controllers/che/cheobj_verifier.go
+++ b/controllers/che/cheobj_verifier.go
@@ -29,7 +29,9 @@ func IsTrustedBundleConfigMap(cl client.Client, watchNamespace string, obj clien
 
 	checluster, num, _ := util.FindCheClusterCRInNamespace(cl, watchNamespace)
 	if num != 1 {
-		logrus.Warn("More than one checluster Custom Resource found.")
+		if num > 1 {
+			logrus.Warn("More than one checluster Custom Resource found.")
+		}
 		return false, ctrl.Request{}
 	}
 
@@ -78,7 +80,9 @@ func IsEclipseCheRelatedObj(cl client.Client, watchNamespace string, obj client.
 
 	checluster, num, _ := util.FindCheClusterCRInNamespace(cl, watchNamespace)
 	if num != 1 {
-		logrus.Warn("More than one checluster Custom Resource found.")
+		if num > 1 {
+			logrus.Warn("More than one checluster Custom Resource found.")
+		}
 		return false, ctrl.Request{}
 	}
 


### PR DESCRIPTION
…nly there are more  than 1 CR

Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Fix bugs when warning is printed when there are no CR at all on the cluster.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20628

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
N/A


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
