### PR TITLE
fix: configure runtime controller with namespace event filter

### DIFF
--- a/controllers/che/checluster_controller.go
+++ b/controllers/che/checluster_controller.go
@@ -218,7 +218,7 @@ func (r *CheClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	if r.namespace != "" {
-		contollerBuilder.WithEventFilter(util.InNamespaceEventFilter(r.namespace))
+		contollerBuilder = contollerBuilder.WithEventFilter(util.InNamespaceEventFilter(r.namespace))
 	}
 
 	return contollerBuilder.

--- a/controllers/checlusterbackup/checlusterbackup_controller.go
+++ b/controllers/checlusterbackup/checlusterbackup_controller.go
@@ -77,7 +77,7 @@ func (r *ReconcileCheClusterBackup) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &chev1.CheClusterBackup{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(backupCRPredicate))
 
 	if r.namespace != "" {
-		bldr.WithEventFilter(util.InNamespaceEventFilter(r.namespace))
+		bldr = bldr.WithEventFilter(util.InNamespaceEventFilter(r.namespace))
 	}
 
 	return bldr.

--- a/controllers/checlusterrestore/checlusterrestore_controller.go
+++ b/controllers/checlusterrestore/checlusterrestore_controller.go
@@ -74,7 +74,7 @@ func (r *ReconcileCheClusterRestore) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &chev1.CheClusterRestore{}}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(restoreCRPredicate))
 
 	if r.namespace != "" {
-		bldr.WithEventFilter(util.InNamespaceEventFilter(r.namespace))
+		bldr = bldr.WithEventFilter(util.InNamespaceEventFilter(r.namespace))
 	}
 
 	return bldr.


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Configure runtime controller with namespace event filter to limit cache.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-2383

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->

1. Create 300 namespaces
2. Deploy Eclipse Che
```
chectl server:deploy \
     --installer operator \
     --platform openshift \
     --version 7.36.2 \
     --che-operator-image abazko/operator:crw-2383-port
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
