### PR TITLE
fix: Set CHE_INFRA_KUBERNETES_ENABLE__UNSUPPORTED__K8S: true when dev…

### DIFF
--- a/pkg/deploy/dev-workspace/dev_workspace.go
+++ b/pkg/deploy/dev-workspace/dev_workspace.go
@@ -99,11 +99,6 @@ func ReconcileDevWorkspace(deployContext *deploy.DeployContext) (done bool, err 
 		logrus.Warnf("To enable DevWorkspace engine, deploy Eclipse Che from tech-preview channel.")
 	}
 
-	if !util.IsOpenShift && util.GetCheServerCustomCheProperty(deployContext.CheCluster, "CHE_INFRA_KUBERNETES_ENABLE__UNSUPPORTED__K8S") != "true" {
-		logrus.Warn(`DevWorkspace Che operator can't be enabled on a Kubernetes cluster without explicitly enabled k8s API on che-server. To enable DevWorkspace Che operator set 'spec.server.customCheProperties[CHE_INFRA_KUBERNETES_ENABLE__UNSUPPORTED__K8S]' to 'true'.`)
-		return true, nil
-	}
-
 	isCreated, err := createDwNamespace(deployContext)
 	if err != nil {
 		return false, err

--- a/pkg/deploy/dev-workspace/dev_workspace_test.go
+++ b/pkg/deploy/dev-workspace/dev_workspace_test.go
@@ -124,11 +124,15 @@ func TestReconcileDevWorkspace(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			deployContext := deploy.GetTestDeployContext(testCase.cheCluster, []runtime.Object{})
-			deployContext.ClusterAPI.Scheme.AddKnownTypes(crdv1.SchemeGroupVersion, &crdv1.CustomResourceDefinition{})
-			deployContext.ClusterAPI.Scheme.AddKnownTypes(operatorsv1alpha1.SchemeGroupVersion, &operatorsv1alpha1.Subscription{})
 
 			util.IsOpenShift = testCase.IsOpenShift
 			util.IsOpenShift4 = testCase.IsOpenShift4
+
+			// reread templates (workaround after setting IsOpenShift value)
+			DevWorkspaceTemplates = DevWorkspaceTemplatesPath()
+			DevWorkspaceIssuerFile = DevWorkspaceTemplates + "/devworkspace-controller-selfsigned-issuer.Issuer.yaml"
+			DevWorkspaceCertificateFile = DevWorkspaceTemplates + "/devworkspace-controller-serving-cert.Certificate.yaml"
+
 			err := os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "true")
 			assert.NoError(t, err)
 

--- a/pkg/deploy/dev-workspace/sync.go
+++ b/pkg/deploy/dev-workspace/sync.go
@@ -48,7 +48,7 @@ var (
 		syncDwDeployment,
 	}
 
-	DevWorkspaceTemplates = devWorkspaceTemplatesPath()
+	DevWorkspaceTemplates = DevWorkspaceTemplatesPath()
 
 	OpenshiftDevWorkspaceTemplatesPath  = "/tmp/devworkspace-operator/templates/deployment/openshift/objects"
 	KubernetesDevWorkspaceTemplatesPath = "/tmp/devworkspace-operator/templates/deployment/kubernetes/objects"
@@ -247,7 +247,7 @@ func syncObject(deployContext *deploy.DeployContext, obj2sync client.Object, nam
 	return true, nil
 }
 
-func devWorkspaceTemplatesPath() string {
+func DevWorkspaceTemplatesPath() string {
 	if util.IsOpenShift {
 		return OpenshiftDevWorkspaceTemplatesPath
 	}

--- a/pkg/deploy/server/server_configmap.go
+++ b/pkg/deploy/server/server_configmap.go
@@ -281,6 +281,10 @@ func (s *Server) getCheConfigMapData() (cheEnv map[string]string, err error) {
 			"CHE_INFRA_KUBERNETES_INGRESS_PATH__TRANSFORM":             "%s(.*)",
 		}
 
+		if s.deployContext.CheCluster.Spec.DevWorkspace.Enable {
+			k8sCheEnv["CHE_INFRA_KUBERNETES_ENABLE__UNSUPPORTED__K8S"] = "true"
+		}
+
 		// Add TLS key and server certificate to properties since user workspaces is created in another
 		// than Che server namespace, from where the Che TLS secret is not accessable
 		if s.deployContext.CheCluster.Spec.K8s.TlsSecretName != "" {

--- a/pkg/deploy/test_util.go
+++ b/pkg/deploy/test_util.go
@@ -14,6 +14,7 @@ package deploy
 import (
 	orgv1 "github.com/eclipse-che/che-operator/api/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakeDiscovery "k8s.io/client-go/discovery/fake"
@@ -40,6 +41,8 @@ func GetTestDeployContext(cheCluster *orgv1.CheCluster, initObjs []runtime.Objec
 
 	scheme := scheme.Scheme
 	orgv1.SchemeBuilder.AddToScheme(scheme)
+	scheme.AddKnownTypes(operatorsv1alpha1.SchemeGroupVersion, &operatorsv1alpha1.Subscription{})
+	scheme.AddKnownTypes(crdv1.SchemeGroupVersion, &crdv1.CustomResourceDefinition{})
 	scheme.AddKnownTypes(operatorsv1alpha1.SchemeGroupVersion, &operatorsv1alpha1.Subscription{})
 
 	initObjs = append(initObjs, cheCluster)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -510,14 +510,6 @@ func GetWorkspaceNamespaceDefault(cr *orgv1.CheCluster) string {
 	return GetValue(cr.Spec.Server.WorkspaceNamespaceDefault, workspaceNamespaceDefault)
 }
 
-// GetCheServerCustomCheProperty - returns value of che-server's custom property.
-func GetCheServerCustomCheProperty(cr *orgv1.CheCluster, key string) string {
-	if cr.Spec.Server.CustomCheProperties != nil {
-		return cr.Spec.Server.CustomCheProperties[key]
-	}
-	return ""
-}
-
 // IsDeleteOAuthInitialUser - returns true when initial Openshfit oAuth user must be deleted.
 func IsDeleteOAuthInitialUser(cr *orgv1.CheCluster) bool {
 	return cr.Spec.Auth.InitialOpenShiftOAuthUser != nil && !*cr.Spec.Auth.InitialOpenShiftOAuthUser && cr.Status.OpenShiftOAuthUserCredentialsSecret != ""


### PR DESCRIPTION
…workspace is enabled on k8s

Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Set `CHE_INFRA_KUBERNETES_ENABLE__UNSUPPORTED__K8S: true` when devworkspace is enabled on k8s

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20620

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->

```bash
chectl server:deploy \
     --installer operator \
     --workspace-engine=dev-workspace \
     --platform minikube \
     --che-operator-image abazko/operator:20620
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
