### PR TITLE
fix: Use cached and non-cached clients in backup/restore controllers

### DIFF
--- a/controllers/checlusterbackup/backup_context.go
+++ b/controllers/checlusterbackup/backup_context.go
@@ -48,7 +48,7 @@ func NewBackupContext(r *ReconcileCheClusterBackup, backupCR *chev1.CheClusterBa
 		// After the preparations, a new reconcile loop will be triggered, so backupServer will not be nil any more.
 	}
 
-	cheCR, _, err := util.FindCheClusterCRInNamespace(r.client, namespace)
+	cheCR, _, err := util.FindCheClusterCRInNamespace(r.cachingClient, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/checlusterbackup/backup_data_collector.go
+++ b/controllers/checlusterbackup/backup_data_collector.go
@@ -60,7 +60,7 @@ func createBackupMetadataFile(bctx *BackupContext, destDir string) (bool, error)
 
 	var appsDomain string
 	if util.IsOpenShift {
-		host, err := util.GetRouterCanonicalHostname(bctx.r.client, bctx.namespace)
+		host, err := util.GetRouterCanonicalHostname(bctx.r.nonCachingClient, bctx.namespace)
 		if err != nil {
 			return false, err
 		}
@@ -129,7 +129,7 @@ func prepareDirectory(destDir string) error {
 func backupCheCR(bctx *BackupContext, destDir string) (bool, error) {
 	cheCR := &orgv1.CheCluster{}
 	namespacedName := types.NamespacedName{Namespace: bctx.namespace, Name: bctx.cheCR.GetName()}
-	if err := bctx.r.client.Get(context.TODO(), namespacedName, cheCR); err != nil {
+	if err := bctx.r.cachingClient.Get(context.TODO(), namespacedName, cheCR); err != nil {
 		return false, err
 	}
 	util.ClearMetadata(&cheCR.ObjectMeta)
@@ -221,7 +221,7 @@ func backupConfigMaps(bctx *BackupContext, destDir string) (bool, error) {
 	}
 
 	fakeDeployContext := &deploy.DeployContext{
-		ClusterAPI: deploy.ClusterAPI{Client: bctx.r.client},
+		ClusterAPI: deploy.ClusterAPI{Client: bctx.r.nonCachingClient},
 		CheCluster: bctx.cheCR,
 	}
 	caBundlesConfigmaps, err := deploy.GetCACertsConfigMaps(fakeDeployContext)
@@ -268,7 +268,7 @@ func backupSecrets(bctx *BackupContext, destDir string) (bool, error) {
 	for _, secretName := range secretsNames {
 		secret := &corev1.Secret{}
 		namespacedName := types.NamespacedName{Name: secretName, Namespace: bctx.namespace}
-		if err := bctx.r.client.Get(context.TODO(), namespacedName, secret); err != nil {
+		if err := bctx.r.nonCachingClient.Get(context.TODO(), namespacedName, secret); err != nil {
 			return false, err
 		}
 

--- a/controllers/checlusterrestore/restore_context.go
+++ b/controllers/checlusterrestore/restore_context.go
@@ -38,7 +38,7 @@ func NewRestoreContext(r *ReconcileCheClusterRestore, restoreCR *chev1.CheCluste
 		return nil, err
 	}
 
-	cheCR, CRCount, err := util.FindCheClusterCRInNamespace(r.client, namespace)
+	cheCR, CRCount, err := util.FindCheClusterCRInNamespace(r.cachingClient, namespace)
 	if err != nil {
 		// Check if Che CR is present
 		if CRCount > 0 {

--- a/main.go
+++ b/main.go
@@ -245,8 +245,8 @@ func main() {
 	}
 
 	cheReconciler := checontroller.NewReconciler(mgr.GetClient(), noncachedClient, discoveryClient, mgr.GetScheme(), watchNamespace)
-	backupReconciler := backupcontroller.NewReconciler(mgr, watchNamespace)
-	restoreReconciler := restorecontroller.NewReconciler(mgr, watchNamespace)
+	backupReconciler := backupcontroller.NewReconciler(mgr.GetClient(), noncachedClient, mgr.GetScheme(), watchNamespace)
+	restoreReconciler := restorecontroller.NewReconciler(mgr.GetClient(), noncachedClient, mgr.GetScheme(), watchNamespace)
 
 	if err = cheReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to set up controller", "controller", "CheCluster")


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Uses two k8s clients in backup and restore controllers: caching client and non-caching client.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
A step towards https://github.com/eclipse/che/issues/20647

### How to test this PR?
1. Run `chectl server:deploy --installer=operator --platform=openshift`
2. Run `chectl server:backup`
3. Run `chectl server:restore --snapshot-id=latest`
4. Check Che is ready and works

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
