### PR TITLE
fix: don't require `app.kubernetes.io/instance:che` label on k8s object to trigger a reconcile

### DIFF
--- a/controllers/che/cheobj_verifier.go
+++ b/controllers/che/cheobj_verifier.go
@@ -57,12 +57,6 @@ func IsTrustedBundleConfigMap(cl client.Client, watchNamespace string, obj clien
 			// ignore not matched labels
 			return false, ctrl.Request{}
 		}
-
-		// Check for instance label
-		if value, exists := obj.GetLabels()[deploy.KubernetesInstanceLabelKey]; !exists || value != deploy.DefaultCheFlavor(checluster) {
-			// Ignore config map with missing instance label
-			return false, ctrl.Request{}
-		}
 	}
 
 	return true, ctrl.Request{
@@ -97,11 +91,6 @@ func IsEclipseCheRelatedObj(cl client.Client, watchNamespace string, obj client.
 
 	// Check for part-of label
 	if value, exists := obj.GetLabels()[deploy.KubernetesPartOfLabelKey]; !exists || value != deploy.CheEclipseOrg {
-		return false, ctrl.Request{}
-	}
-
-	// Check for instance label
-	if value, exists := obj.GetLabels()[deploy.KubernetesInstanceLabelKey]; !exists || value != deploy.DefaultCheFlavor(checluster) {
 		return false, ctrl.Request{}
 	}
 

--- a/controllers/checlusterrestore/backup_data_restorer.go
+++ b/controllers/checlusterrestore/backup_data_restorer.go
@@ -149,9 +149,10 @@ func cleanPreviousInstallation(rctx *RestoreContext, dataDir string) (bool, erro
 	cheFlavor := deploy.DefaultCheFlavor(rctx.cheCR)
 
 	cheNameRequirement, _ := labels.NewRequirement(deploy.KubernetesNameLabelKey, selection.Equals, []string{cheFlavor})
+	cheInstanceRequirement, _ := labels.NewRequirement(deploy.KubernetesInstanceLabelKey, selection.Equals, []string{cheFlavor})
 	skipBackupObjectsRequirement, _ := labels.NewRequirement(deploy.KubernetesPartOfLabelKey, selection.NotEquals, []string{checlusterbackup.BackupCheEclipseOrg})
 
-	cheResourcesLabelSelector := labels.NewSelector().Add(*cheNameRequirement).Add(*skipBackupObjectsRequirement)
+	cheResourcesLabelSelector := labels.NewSelector().Add(*cheInstanceRequirement).Add(*cheNameRequirement).Add(*skipBackupObjectsRequirement)
 	cheResourcesListOptions := &client.ListOptions{
 		LabelSelector: cheResourcesLabelSelector,
 		Namespace:     rctx.namespace,

--- a/controllers/checlusterrestore/backup_data_restorer.go
+++ b/controllers/checlusterrestore/backup_data_restorer.go
@@ -149,10 +149,9 @@ func cleanPreviousInstallation(rctx *RestoreContext, dataDir string) (bool, erro
 	cheFlavor := deploy.DefaultCheFlavor(rctx.cheCR)
 
 	cheNameRequirement, _ := labels.NewRequirement(deploy.KubernetesNameLabelKey, selection.Equals, []string{cheFlavor})
-	cheInstanceRequirement, _ := labels.NewRequirement(deploy.KubernetesInstanceLabelKey, selection.Equals, []string{cheFlavor})
 	skipBackupObjectsRequirement, _ := labels.NewRequirement(deploy.KubernetesPartOfLabelKey, selection.NotEquals, []string{checlusterbackup.BackupCheEclipseOrg})
 
-	cheResourcesLabelSelector := labels.NewSelector().Add(*cheInstanceRequirement).Add(*cheNameRequirement).Add(*skipBackupObjectsRequirement)
+	cheResourcesLabelSelector := labels.NewSelector().Add(*cheNameRequirement).Add(*skipBackupObjectsRequirement)
 	cheResourcesListOptions := &client.ListOptions{
 		LabelSelector: cheResourcesLabelSelector,
 		Namespace:     rctx.namespace,


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Fix for https://github.com/eclipse-che/che-operator/pull/1166 not to require `app.kubernetes.io/instance:che` label for k8s objects to trigger a reconcile


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20841

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
1. Deploy Eclipse Che
```
chectl server:deploy \
     --installer operator \
     --platform minikube \
     --che-operator-image abazko/operator:20841
```

2. Create config map
```
kubectl create configmap ca-certs -n eclipse-che
kubectl label configmap/ca-certs  app.kubernetes.io/part-of=che.eclipse.org app.kubernetes.io/component=ca-bundle -n eclipse-che 
```

3. Check that configamp is included into ca-certs-merged
```
kubectl get configmap ca-certs-merged -n eclipse-che -o jsonpath="{.metadata.annotations}"
```     

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
