### PR TITLE
fix: check if tag exists on remote before...

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -264,9 +264,12 @@ pushGitChanges() {
   echo "[INFO] Push git changes into $RELEASE_BRANCH branch"
   git push origin $RELEASE_BRANCH ${FORCE_UPDATE}
   if [[ $FORCE_UPDATE == "--force" ]]; then # if forced update, delete existing tag so we can replace it
-    if git rev-parse "$RELEASE" >/dev/null 2>&1; then # if tag exists
-      git tag -d $RELEASE
+    if [[ $(git ls-remote --tags $(git remote get-url origin) $RELEASE) ]]; then # if tag exists in remote repo
+      echo "Remove existing tag $RELEASE"
+      git tag -d $RELEASE || true
       git push origin :$RELEASE
+    else
+      echo "Remote tag $RELEASE does not exist" # should never get here
     fi
   fi
   git tag -a $RELEASE -m $RELEASE

--- a/make-release.sh
+++ b/make-release.sh
@@ -264,9 +264,14 @@ pushGitChanges() {
   echo "[INFO] Push git changes into $RELEASE_BRANCH branch"
   git push origin $RELEASE_BRANCH ${FORCE_UPDATE}
   if [[ $FORCE_UPDATE == "--force" ]]; then # if forced update, delete existing tag so we can replace it
+    if [[ $(git tag -l $RELEASE) ]]; then # if tag exists in local repo
+      echo "Remove existing local tag $RELEASE"
+      git tag -d $RELEASE
+    else
+      echo "Local tag $RELEASE does not exist" # should never get here
+    fi
     if [[ $(git ls-remote --tags $(git remote get-url origin) $RELEASE) ]]; then # if tag exists in remote repo
-      echo "Remove existing tag $RELEASE"
-      git tag -d $RELEASE || true
+      echo "Remove existing remote tag $RELEASE"
       git push origin :$RELEASE
     else
       echo "Remote tag $RELEASE does not exist" # should never get here


### PR DESCRIPTION
### What does this PR do?

fix: check if tag exists on remote before attempting to delete it

Change-Id: Ibf0021ef56d5d1f18fc9e1181ea6029b6a694738
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
Fix for https://github.com/eclipse-che/che-operator/runs/4430414080?check_suite_focus=true

```
Switched to branch '7.40.x'
Your branch is up to date with 'origin/7.40.x'.
Switched to branch '7.40.0-release'
[INFO] Release '7.40.0' from branch '7.40.x'
[INFO] Push git changes into 7.40.0-release branch
To https://github.com/eclipse-che/che-operator
 + 842ffa16...009109c2 7.40.0-release -> 7.40.0-release (forced update)
Deleted tag '7.40.0' (was d333bfa3)
error: unable to delete '7.40.0': remote ref does not exist
error: failed to push some refs to 'https://github.com/eclipse-che/che-operator'
Error: Process completed with exit code 1.
```

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.