### PR TITLE
feat: Add devfile registry internal URL as environment variable

### DIFF
--- a/pkg/deploy/devfileregistry/devfileregistry_deployment.go
+++ b/pkg/deploy/devfileregistry/devfileregistry_deployment.go
@@ -12,10 +12,13 @@
 package devfileregistry
 
 import (
+	"fmt"
+
 	"github.com/eclipse-che/che-operator/pkg/deploy"
 	"github.com/eclipse-che/che-operator/pkg/deploy/registry"
 	"github.com/eclipse-che/che-operator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -25,6 +28,15 @@ func (p *DevfileRegistry) GetDevfileRegistryDeploymentSpec() *appsv1.Deployment 
 	registryImagePullPolicy := v1.PullPolicy(util.GetValue(string(p.deployContext.CheCluster.Spec.Server.DevfileRegistryPullPolicy), deploy.DefaultPullPolicyFromDockerImage(registryImage)))
 	probePath := "/devfiles/"
 	devfileImagesEnv := util.GetEnvByRegExp("^.*devfile_registry_image.*$")
+
+	// If there is a devfile registry deployed by operator
+	if p.deployContext.CheCluster.IsInternalClusterSVCNamesEnabled() && !p.deployContext.CheCluster.Spec.Server.ExternalDevfileRegistry {
+		devfileImagesEnv = append(devfileImagesEnv,
+			corev1.EnvVar{
+				Name:  "CHE_DEVFILE_REGISTRY_INTERNAL_URL",
+				Value: fmt.Sprintf("http://%s.%s.svc:8080", deploy.DevfileRegistryName, p.deployContext.CheCluster.Namespace)},
+		)
+	}
 
 	resources := v1.ResourceRequirements{
 		Requests: v1.ResourceList{


### PR DESCRIPTION
### What does this PR do?
Add env variable for internal devfile registry URL

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20904


### How to test this PR?
Deploy che like with chectl, connect to the devfile-registry container of devfile-registry pod

check environment variable is there

```
/usr/local/apache2 $ env | grep URL
CHE_DEVFILE_IMAGES_REGISTRY_URL=
CHE_DEVFILE_REGISTRY_INTERNAL_URL=http://devfile-registry.eclipse-che.svc:8080
CHE_DEVFILE_REGISTRY_URL=https://che-eclipse-che.apps.cluster-9189.9189.sandbox549.opentlc.com/devfile-registry
/usr/local/apache2 $ 
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: I573fc1ce95b00e281e541526933825456add39bd
Signed-off-by: Florent Benoit <fbenoit@redhat.com>