### PR TITLE
fix: add permission to watch devworkspaces

### DIFF
--- a/pkg/deploy/rbac/workspace_permissions.go
+++ b/pkg/deploy/rbac/workspace_permissions.go
@@ -225,7 +225,7 @@ func (wp *WorkspacePermissionsReconciler) getDevWorkspacePolicies() []rbacv1.Pol
 		{
 			APIGroups: []string{"workspace.devfile.io"},
 			Resources: []string{"devworkspaces", "devworkspacetemplates"},
-			Verbs:     []string{"get", "create", "delete", "list", "update", "patch"},
+			Verbs:     []string{"get", "create", "delete", "list", "update", "patch", "watch"},
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Add `watch` permission for the user to watch devworkspaces in his namespace. Needed for websocket connection, see the issue.

### Screenshot/screencast of this PR
<img width="1440" alt="Screenshot 2021-12-09 at 12 07 02" src="https://user-images.githubusercontent.com/1160903/145385516-5c162e04-68f2-4777-a0e2-db9b977e7198.png">

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->



### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20898

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->

test image: `quay.io/mvala/che-operator:gh20898-websocket`

```
chectl server:deploy \
     --installer operator \
     --platform minikube \
     --che-operator-image quay.io/mvala/che-operator:gh20898-websocket \
     --workspace-engine=dev-workspace
```
deploy on minikube. After login to dashboard, there must be no websocket connection errors and you should see messages in network communication.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
