### PR TITLE
Make backup / restore of Che installation work with devworkspace mode

### DIFF
--- a/controllers/checlusterbackup/backup_data_collector.go
+++ b/controllers/checlusterbackup/backup_data_collector.go
@@ -162,7 +162,9 @@ func backupDatabases(bctx *BackupContext, destDir string) (bool, error) {
 
 	databasesToBackup := []string{
 		bctx.cheCR.Spec.Database.ChePostgresDb,
-		"keycloak",
+	}
+	if !bctx.cheCR.Spec.DevWorkspace.Enable {
+		databasesToBackup = append(databasesToBackup, "keycloak")
 	}
 
 	k8sClient := util.GetK8Client()


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Makes backup and restore flows work in devworkspace mode.
This does not back up / restore users' workspaces, only Che installation.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20671
https://github.com/eclipse/che-docs/pull/2121 (backup / restore part)

### How to test this PR?
1. Deploy Che with devworkspace enabled
2. Create a workspace
3. Create a backup using chectl `chectl server:backup`
4. Delete the workspace or do other harm (or even delete checluster object)
5. Restore Che using `chectl server:restore --snaphot-id=latest --batch`
6. Check everything (the workspace, for example) is in place

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
