### PR TITLE
Migrate old objects with app=che label

### DIFF
--- a/pkg/deploy/migration/on-reconcile-one-time-migration.go
+++ b/pkg/deploy/migration/on-reconcile-one-time-migration.go
@@ -71,7 +71,12 @@ func (m *Migrator) migrate(ctx *deploy.DeployContext) (bool, error) {
 		return false, err
 	}
 
-	if err := addPartOfLabelForObjectsWithInstanceCheLabel(ctx); err != nil {
+	cheFlavor := deploy.DefaultCheFlavor(ctx.CheCluster)
+	if err := addPartOfCheLabelForObjectsWithLabel(ctx, deploy.KubernetesInstanceLabelKey, cheFlavor); err != nil {
+		return false, err
+	}
+
+	if err := addPartOfCheLabelForObjectsWithLabel(ctx, "app", cheFlavor); err != nil {
 		return false, err
 	}
 
@@ -204,13 +209,11 @@ func setPartOfLabel(obj client.Object) client.Object {
 	return obj
 }
 
-// addPartOfLabelForObjectsWithInstanceCheLabel searches for objects in Che installation namespace,
-// that have 'app.kubernetes.io/instance=che' label and adds 'app.kubernetes.io/part-of=che.eclipse.org'
-func addPartOfLabelForObjectsWithInstanceCheLabel(ctx *deploy.DeployContext) error {
-	cheFlavor := deploy.DefaultCheFlavor(ctx.CheCluster)
-
+// addPartOfCheLabelForObjectsWithLabel searches for objects in Che installation namespace,
+// that have given label and adds 'app.kubernetes.io/part-of=che.eclipse.org'
+func addPartOfCheLabelForObjectsWithLabel(ctx *deploy.DeployContext, labelKey string, labelValue string) error {
 	// Prepare selector for all instance=che objects in the installation namespace
-	instanceCheSelectorRequirement, err := labels.NewRequirement(deploy.KubernetesInstanceLabelKey, selection.Equals, []string{cheFlavor})
+	instanceCheSelectorRequirement, err := labels.NewRequirement(labelKey, selection.Equals, []string{labelValue})
 	if err != nil {
 		logrus.Error(getFailedToCreateSelectorErrorMessage())
 		return err


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Applys `app.kubernetes.io/part-of=che.eclipse.org` label to objects that have `app=che` legacy label to handle migration of old versions of Che

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20972

### How to test this PR?
1. Create a secret with `app=che` label
2. Deploy Che in the namespace
3. Ensure the secret has `app.kubernetes.io/part-of=che.eclipse.org` label

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
