### PR TITLE
fix: Allow to use Postgre 13.x images

### DIFF
--- a/pkg/deploy/postgres/postgres_deployment.go
+++ b/pkg/deploy/postgres/postgres_deployment.go
@@ -13,6 +13,7 @@ package postgres
 
 import (
 	"fmt"
+	"strings"
 
 	orgv1 "github.com/eclipse-che/che-operator/api/v1"
 	"github.com/eclipse-che/che-operator/pkg/deploy"
@@ -222,7 +223,7 @@ func getPostgresImage(clusterDeployment *appsv1.Deployment, cheCluster *orgv1.Ch
 		return cheCluster.Spec.Database.PostgresImage, nil
 	} else if cheCluster.Spec.Database.PostgresVersion == PostgresVersion9_6 {
 		return deploy.DefaultPostgresImage(cheCluster), nil
-	} else if cheCluster.Spec.Database.PostgresVersion == PostgresVersion13_3 {
+	} else if strings.HasPrefix(cheCluster.Spec.Database.PostgresVersion, "13.") {
 		return deploy.DefaultPostgres13Image(cheCluster), nil
 	} else if cheCluster.Spec.Database.PostgresVersion == "" {
 		if clusterDeployment == nil {

--- a/pkg/deploy/postgres/postgres_test.go
+++ b/pkg/deploy/postgres/postgres_test.go
@@ -164,6 +164,19 @@ func TestGetPostgresImage(t *testing.T) {
 				},
 				Spec: orgv1.CheClusterSpec{
 					Database: orgv1.CheClusterSpecDB{
+						PostgresVersion: "13.5",
+					},
+				},
+			},
+			expectedPostgresImage: deploy.DefaultPostgres13Image(&orgv1.CheCluster{}),
+		},
+		{
+			cheCluster: &orgv1.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "eclipse-che",
+				},
+				Spec: orgv1.CheClusterSpec{
+					Database: orgv1.CheClusterSpecDB{
 						PostgresVersion: "9.6",
 					},
 				},


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
`RELATED_IMAGE_postgres_13_3`  env variable can actually contains PostgreSQL 13.x version (CRW case).
PR allows to use PostreSQL images for 13.x version

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-2610

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
N/A


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
