### PR TITLE
set resources for gateway containers

### DIFF
--- a/pkg/deploy/gateway/gateway.go
+++ b/pkg/deploy/gateway/gateway.go
@@ -16,6 +16,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"sigs.k8s.io/yaml"
 
@@ -535,11 +536,31 @@ func getContainersSpec(instance *orgv1.CheCluster) []corev1.Container {
 			Image:           gatewayImage,
 			ImagePullPolicy: corev1.PullAlways,
 			VolumeMounts:    getTraefikContainerVolumeMounts(instance),
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+					corev1.ResourceCPU:    resource.MustParse("1"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("128Mi"),
+					corev1.ResourceCPU:    resource.MustParse("0.1"),
+				},
+			},
 		},
 		{
 			Name:            "configbump",
 			Image:           configSidecarImage,
 			ImagePullPolicy: corev1.PullAlways,
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+					corev1.ResourceCPU:    resource.MustParse("0.5"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("64Mi"),
+					corev1.ResourceCPU:    resource.MustParse("0.05"),
+				},
+			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "dynamic-config",

--- a/pkg/deploy/gateway/gateway_test.go
+++ b/pkg/deploy/gateway/gateway_test.go
@@ -66,8 +66,10 @@ func TestSyncAllToCluster(t *testing.T) {
 		t.Fatalf("Failed to get deployment: %v", err)
 	}
 
-	if len(deployment.Spec.Template.Spec.Containers) != 2 {
-		t.Fatalf("With classic multi-user, there should be 2 containers in the gateway, traefik and configbump. But it has '%d' containers.", len(deployment.Spec.Template.Spec.Containers))
+	assert.Lenf(t, deployment.Spec.Template.Spec.Containers, 2,
+		"With classic multi-user, there should be 2 containers in the gateway, traefik and configbump. But it has '%d' containers.", len(deployment.Spec.Template.Spec.Containers))
+	for _, c := range deployment.Spec.Template.Spec.Containers {
+		assert.NotNil(t, c.Resources, "container '%s' has not set resources", c.Name)
 	}
 
 	service := &corev1.Service{}
@@ -121,6 +123,7 @@ func TestNativeUserGateway(t *testing.T) {
 	}
 
 	for _, c := range deployment.Spec.Template.Spec.Containers {
+		assert.NotNil(t, c.Resources, "container '%s' has not set resources", c.Name)
 		if c.Name == "gateway" {
 			if len(c.VolumeMounts) != 3 {
 				t.Fatalf("gateway container should have 3 mounts, but it has '%d' ... \n%+v", len(c.VolumeMounts), c.VolumeMounts)

--- a/pkg/deploy/gateway/kube_rbac_proxy.go
+++ b/pkg/deploy/gateway/kube_rbac_proxy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/deploy"
 	"github.com/eclipse-che/che-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -62,6 +63,16 @@ func getKubeRbacProxyContainerSpec(instance *orgv1.CheCluster) corev1.Container 
 			{
 				Name:      "kube-rbac-proxy-config",
 				MountPath: "/etc/kube-rbac-proxy",
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceCPU:    resource.MustParse("0.5"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+				corev1.ResourceCPU:    resource.MustParse("0.1"),
 			},
 		},
 	}

--- a/pkg/deploy/gateway/oauth_proxy.go
+++ b/pkg/deploy/gateway/oauth_proxy.go
@@ -14,6 +14,7 @@ package gateway
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"strings"
 
 	orgv1 "github.com/eclipse-che/che-operator/api/v1"
@@ -140,6 +141,16 @@ func getOauthProxyContainerSpec(instance *orgv1.CheCluster) corev1.Container {
 			{
 				Name:      "oauth-proxy-config",
 				MountPath: "/etc/oauth-proxy",
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceCPU:    resource.MustParse("0.5"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+				corev1.ResourceCPU:    resource.MustParse("0.1"),
 			},
 		},
 		Ports: []corev1.ContainerPort{


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
defines memory/cpu resource requests and limits for gateway containers.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

<img width="899" alt="Screenshot 2022-01-03 at 18 39 32" src="https://user-images.githubusercontent.com/1160903/147961813-9147a0f1-def9-4ad7-ab74-6399b0b35e08.png">

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20606

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
deploy with `che-operator` image `quay.io/mvala/che-operator:gh20606-gatewayRes` and check that gateway containers has set resources


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
