### PR TITLE
Deploy stable version of Dev Workspace operator when Eclipse Che is deployed with testCatalog.sh or testUpdate.sh

### DIFF
--- a/.ci/cico_updates_openshift.sh
+++ b/.ci/cico_updates_openshift.sh
@@ -15,8 +15,6 @@ set -e
 set -x
 
 export OPERATOR_REPO=$(dirname $(dirname $(readlink -f "$0")));
-source "${OPERATOR_REPO}"/.github/bin/common.sh
-source "${OPERATOR_REPO}"/olm/olm.sh
 
 #Stop execution on any error
 trap "catchFinish" EXIT SIGINT

--- a/.ci/cico_updates_openshift.sh
+++ b/.ci/cico_updates_openshift.sh
@@ -16,6 +16,7 @@ set -x
 
 export OPERATOR_REPO=$(dirname $(dirname $(readlink -f "$0")));
 source "${OPERATOR_REPO}"/.github/bin/common.sh
+source "${OPERATOR_REPO}"/olm/olm.sh
 
 #Stop execution on any error
 trap "catchFinish" EXIT SIGINT

--- a/.ci/oci-nightly-update.sh
+++ b/.ci/oci-nightly-update.sh
@@ -35,6 +35,7 @@ overrideDefaults() {
 }
 
 runTests() {
+  deployDevWorkspaceOperator "stable"
   deployEclipseCheOnWithOperator "openshift" ${LAST_OPERATOR_VERSION_TEMPLATE_PATH} "false"
   updateEclipseChe "openshift" ${CURRENT_OPERATOR_VERSION_TEMPLATE_PATH} "true"
 }

--- a/.ci/oci-nightly-update.sh
+++ b/.ci/oci-nightly-update.sh
@@ -16,12 +16,8 @@
 ##########  More info about how it is configured can be found here: https://docs.ci.openshift.org/docs/how-tos/testing-operator-sdk-operators #############
 #######################################################################################################################################################
 
-# exit immediately when a command fails
 set -e
-# only exit with zero if all commands of the pipeline exit successfully
-set -o pipefail
-# error on unset variables
-set -u
+set -x
 
 export OPERATOR_REPO=$(dirname $(dirname $(readlink -f "$0")));
 source "${OPERATOR_REPO}"/olm/olm.sh

--- a/.ci/oci-nightly-update.sh
+++ b/.ci/oci-nightly-update.sh
@@ -24,6 +24,7 @@ set -o pipefail
 set -u
 
 export OPERATOR_REPO=$(dirname $(dirname $(readlink -f "$0")));
+source "${OPERATOR_REPO}"/olm/olm.sh
 source "${OPERATOR_REPO}"/.github/bin/common.sh
 
 #Stop execution on any error

--- a/.github/bin/common.sh
+++ b/.github/bin/common.sh
@@ -352,7 +352,7 @@ spec:
 EOF
 
   sleep 10s
-  kubectl wait --for=condition=ready pod -l "olm.catalogSource=${name}" -n openshift-operators --timeout=120s
+  kubectl wait --for=condition=ready pod -l "olm.catalogSource=${name}" -n openshift-operators --timeout=240s
 }
 
 createSubscription() {

--- a/.github/bin/common.sh
+++ b/.github/bin/common.sh
@@ -351,7 +351,7 @@ spec:
       interval: 15m
 EOF
 
-  sleep 10s
+  sleep 20s
   kubectl wait --for=condition=ready pod -l "olm.catalogSource=${name}" -n openshift-operators --timeout=240s
 }
 

--- a/.github/bin/common.sh
+++ b/.github/bin/common.sh
@@ -386,22 +386,21 @@ EOF
   fi
 }
 
-deployDevWorkspaceOperatorFromFastChannel() {
-  echo "[INFO] Deploy Dev Workspace operator from 'fast' channel"
+deployDevWorkspaceOperator() {
+  local cheChannel=${1}
+  local devWorkspaceChannel="fast"
+  local devWorkspaceCatalogImage="quay.io/devfile/devworkspace-operator-index:next"
+
+  if [[ ${cheChannel} == "stable" ]]; then
+    devWorkspaceChannel="stable"
+    devWorkspaceCatalogImage="quay.io/devfile/devworkspace-operator-index:next"
+  fi
+
+  echo "[INFO] Deploy Dev Workspace operator from '${devWorkspaceChannel}' channel"
 
   customDevWorkspaceCatalog=$(getDevWorkspaceCustomCatalogSourceName)
-  createCatalogSource "${customDevWorkspaceCatalog}" "quay.io/devfile/devworkspace-operator-index:next"
-  createSubscription "devworkspace-operator" "devworkspace-operator" "fast" "${customDevWorkspaceCatalog}" "Auto"
-
-  waitDevWorkspaceControllerStarted
-}
-
-deployDevWorkspaceOperatorFromNextChannel() {
-  echo "[INFO] Deploy Dev Workspace operator from 'stable' channel"
-
-  customDevWorkspaceCatalog=$(getDevWorkspaceCustomCatalogSourceName)
-  createCatalogSource "${customDevWorkspaceCatalog}" "quay.io/devfile/devworkspace-operator-index:next" "Red Hat" "DevWorkspace Operator Catalog"
-  createSubscription "devworkspace-operator" "devworkspace-operator" "fast" "${customDevWorkspaceCatalog}" "Auto"
+  createCatalogSource "${customDevWorkspaceCatalog}" ${devWorkspaceCatalogImage} "Red Hat" "DevWorkspace Operator Catalog"
+  createSubscription "devworkspace-operator" "devworkspace-operator" "${devWorkspaceChannel}" "${customDevWorkspaceCatalog}" "Auto"
 
   waitDevWorkspaceControllerStarted
 }

--- a/.github/bin/common.sh
+++ b/.github/bin/common.sh
@@ -387,20 +387,18 @@ EOF
 }
 
 deployDevWorkspaceOperator() {
+  echo "[INFO] Deploy Dev Workspace operator"
+
   local cheChannel=${1}
-  local devWorkspaceChannel="fast"
   local devWorkspaceCatalogImage="quay.io/devfile/devworkspace-operator-index:next"
 
   if [[ ${cheChannel} == "stable" ]]; then
-    devWorkspaceChannel="stable"
-    devWorkspaceCatalogImage="quay.io/devfile/devworkspace-operator-index:next"
+    devWorkspaceCatalogImage="quay.io/devfile/devworkspace-operator-index:release"
   fi
-
-  echo "[INFO] Deploy Dev Workspace operator from '${devWorkspaceChannel}' channel"
 
   customDevWorkspaceCatalog=$(getDevWorkspaceCustomCatalogSourceName)
   createCatalogSource "${customDevWorkspaceCatalog}" ${devWorkspaceCatalogImage} "Red Hat" "DevWorkspace Operator Catalog"
-  createSubscription "devworkspace-operator" "devworkspace-operator" "${devWorkspaceChannel}" "${customDevWorkspaceCatalog}" "Auto"
+  createSubscription "devworkspace-operator" "devworkspace-operator" "fast" "${customDevWorkspaceCatalog}" "Auto"
 
   waitDevWorkspaceControllerStarted
 }

--- a/olm/testCatalog.sh
+++ b/olm/testCatalog.sh
@@ -60,7 +60,7 @@ usage () {
 run() {
   createNamespace ${NAMESPACE}
 
-  deployDevWorkspaceOperator
+  deployDevWorkspaceOperator ${CHANNEL}
 
   local customCatalogSource=$(getCustomCatalogSourceName)
   createCatalogSource "${customCatalogSource}" "${CATALOG_IMAGE}"

--- a/olm/testCatalog.sh
+++ b/olm/testCatalog.sh
@@ -62,6 +62,8 @@ run() {
 
   if [[ ${CHANNEL} == "next" ]]; then
     deployDevWorkspaceOperatorFromFastChannel
+  else
+    deployDevWorkspaceOperatorFromNextChannel
   fi
 
   local customCatalogSource=$(getCustomCatalogSourceName)

--- a/olm/testCatalog.sh
+++ b/olm/testCatalog.sh
@@ -60,11 +60,7 @@ usage () {
 run() {
   createNamespace ${NAMESPACE}
 
-  if [[ ${CHANNEL} == "next" ]]; then
-    deployDevWorkspaceOperatorFromFastChannel
-  else
-    deployDevWorkspaceOperatorFromNextChannel
-  fi
+  deployDevWorkspaceOperator
 
   local customCatalogSource=$(getCustomCatalogSourceName)
   createCatalogSource "${customCatalogSource}" "${CATALOG_IMAGE}"

--- a/olm/testUpdate.sh
+++ b/olm/testUpdate.sh
@@ -61,6 +61,8 @@ run() {
 
   if [[ ${CHANNEL} == "next" ]]; then
     deployDevWorkspaceOperatorFromFastChannel
+  else
+    deployDevWorkspaceOperatorFromNextChannel
   fi
 
   local customCatalogSource=$(getCustomCatalogSourceName)

--- a/olm/testUpdate.sh
+++ b/olm/testUpdate.sh
@@ -61,8 +61,6 @@ run() {
 
   deployDevWorkspaceOperator ${CHANNEL}
 
-  exit
-
   local customCatalogSource=$(getCustomCatalogSourceName)
   createCatalogSource "${customCatalogSource}" "${CATALOG_IMAGE}"
 

--- a/olm/testUpdate.sh
+++ b/olm/testUpdate.sh
@@ -20,7 +20,7 @@ if [ -z "${OPERATOR_REPO}" ]; then
   OPERATOR_REPO=$(dirname "$(dirname "$SCRIPT")")
 fi
 source "${OPERATOR_REPO}"/olm/olm.sh
-source "${OPERATOR_REPO}/.github/bin/common.sh"
+source "${OPERATOR_REPO}"/.github/bin/common.sh
 
 init() {
   NAMESPACE="eclipse-che"

--- a/olm/testUpdate.sh
+++ b/olm/testUpdate.sh
@@ -59,11 +59,7 @@ usage () {
 run() {
   createNamespace "${NAMESPACE}"
 
-  if [[ ${CHANNEL} == "next" ]]; then
-    deployDevWorkspaceOperatorFromFastChannel
-  else
-    deployDevWorkspaceOperatorFromNextChannel
-  fi
+  deployDevWorkspaceOperator
 
   local customCatalogSource=$(getCustomCatalogSourceName)
   createCatalogSource "${customCatalogSource}" "${CATALOG_IMAGE}"

--- a/olm/testUpdate.sh
+++ b/olm/testUpdate.sh
@@ -59,7 +59,9 @@ usage () {
 run() {
   createNamespace "${NAMESPACE}"
 
-  deployDevWorkspaceOperator
+  deployDevWorkspaceOperator ${CHANNEL}
+
+  exit
 
   local customCatalogSource=$(getCustomCatalogSourceName)
   createCatalogSource "${customCatalogSource}" "${CATALOG_IMAGE}"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Deploy stable version of Dev Workspace operator when Eclipse Che is deployed with `testCatalog.sh` or `testUpdate.sh`

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20908

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
