### PR TITLE
chore: Update DevWorkspace Operator dependency to v0.12.3

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -460,4 +460,4 @@
 | [golang.org/x/mobile@d3739f865fa66d07c1f506505c18aac71a8ead6e](https://cs.opensource.google/go) | BSD-3-Clause | N/A |
 | [github.com/devfile/api/v2@03e023e7078b64884216d8e6dce8f0cf8b7e74d2](https://github.com/devfile/api.git) | Apache-2.0 | [CQ](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23680) |
 | [github.com/che-incubator/kubernetes-image-puller-operator@0128446f5af78587c0427a35d693bbb8d24036bc](https://github.com/che-incubator/kubernetes-image-puller-operator.git) | EPL-2.0 | todo |
-| [github.com/devfile/devworkspace-operator@23b39b88fa997d92185645c94249f16446d1adf4](https://github.com/devfile/devworkspace-operator.git) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/git/github/devfile/devworkspace-operator/23b39b88fa997d92185645c94249f16446d1adf4) |
+| [github.com/devfile/devworkspace-operator@ec1a4cefefe5d77620c8f5f21624f41b7e8e9100](https://github.com/devfile/devworkspace-operator.git) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/git/github/devfile/devworkspace-operator/ec1a4cefefe5d77620c8f5f21624f41b7e8e9100) |

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/go-toolset
 FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12-2 as builder
 ENV GOPATH=/go/
-ARG DEV_WORKSPACE_CONTROLLER_VERSION="v0.12.1"
+ARG DEV_WORKSPACE_CONTROLLER_VERSION="v0.12.3"
 ARG DEV_HEADER_REWRITE_TRAEFIK_PLUGIN="main"
 ARG TESTS="true"
 USER root

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ ECLIPSE_CHE_CRD_V1="$(CRD_FOLDER)/org_v1_che_crd.yaml"
 # default crd names used operator-sdk from the box
 ECLIPSE_CHE_CRD="$(CRD_FOLDER)/org.eclipse.che_checlusters.yaml"
 
-DEV_WORKSPACE_CONTROLLER_VERSION="v0.12.1"
+DEV_WORKSPACE_CONTROLLER_VERSION="v0.12.3"
 DEV_HEADER_REWRITE_TRAEFIK_PLUGIN="main"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)

--- a/api/v2alpha1/zz_generated.deepcopy.go
+++ b/api/v2alpha1/zz_generated.deepcopy.go
@@ -17,7 +17,7 @@
 package v2alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/api/v2alpha1/zz_generated.deepcopy.go
+++ b/api/v2alpha1/zz_generated.deepcopy.go
@@ -17,7 +17,7 @@
 package v2alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -75,7 +75,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.43.0-421.next
+  name: eclipse-che-preview-openshift.v7.43.0-422.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -968,7 +968,7 @@ spec:
                       - name: RELATED_IMAGE_devfile_registry
                         value: quay.io/eclipse/che-devfile-registry:next
                       - name: RELATED_IMAGE_pvc_jobs
-                        value: registry.access.redhat.com/ubi8-minimal:8.5-218
+                        value: registry.access.redhat.com/ubi8-minimal:8.5-230
                       - name: RELATED_IMAGE_postgres
                         value: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
                       - name: RELATED_IMAGE_postgres_13_3
@@ -984,7 +984,7 @@ spec:
                       - name: RELATED_IMAGE_single_host_gateway_config_sidecar
                         value: quay.io/che-incubator/configbump:0.1.4
                       - name: RELATED_IMAGE_devworkspace_controller
-                        value: quay.io/devfile/devworkspace-controller:v0.11.0
+                        value: quay.io/devfile/devworkspace-controller:v0.12.3
                       - name: RELATED_IMAGE_gateway_authentication_sidecar
                         value: quay.io/openshift/origin-oauth-proxy:4.7
                       - name: RELATED_IMAGE_gateway_authorization_sidecar
@@ -1288,4 +1288,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.43.0-421.next
+  version: 7.43.0-422.next

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -75,7 +75,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.43.0-420.next
+  name: eclipse-che-preview-openshift.v7.43.0-421.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1288,4 +1288,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.43.0-420.next
+  version: 7.43.0-421.next

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -88,7 +88,7 @@ spec:
             - name: RELATED_IMAGE_single_host_gateway_config_sidecar
               value: quay.io/che-incubator/configbump:0.1.4
             - name: RELATED_IMAGE_devworkspace_controller
-              value: quay.io/devfile/devworkspace-controller:v0.11.0
+              value: quay.io/devfile/devworkspace-controller:v0.12.3
             - name: RELATED_IMAGE_gateway_authentication_sidecar
               value: quay.io/openshift/origin-oauth-proxy:4.7
             - name: RELATED_IMAGE_gateway_authorization_sidecar

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,7 +72,7 @@ spec:
             - name: RELATED_IMAGE_che_tls_secrets_creation_job
               value: quay.io/eclipse/che-tls-secret-creator:alpine-01a4c34
             - name: RELATED_IMAGE_pvc_jobs
-              value: registry.access.redhat.com/ubi8-minimal:8.5-218
+              value: registry.access.redhat.com/ubi8-minimal:8.5-230
             - name: RELATED_IMAGE_postgres
               value: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
             - name: RELATED_IMAGE_postgres_13_3

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Shopify/logrus-bugsnag v0.0.0-00010101000000-000000000000 // indirect
 	github.com/che-incubator/kubernetes-image-puller-operator v0.0.0-20210929175054-0128446f5af7
 	github.com/devfile/api/v2 v2.0.0-20210917193329-089a48011460
-	github.com/devfile/devworkspace-operator v0.12.2
+	github.com/devfile/devworkspace-operator v0.12.3
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/mock v1.5.0
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/deislabs/oras v0.8.1/go.mod h1:Mx0rMSbBNaNfY9hjpccEnxkOqJL6KGjtxNHPLC
 github.com/denisenkom/go-mssqldb v0.0.0-20190204142019-df6d76eb9289/go.mod h1:xN/JuLBIz4bjkxNmByTiV1IbhfnYb6oo99phBn4Eqhc=
 github.com/devfile/api/v2 v2.0.0-20210917193329-089a48011460 h1:cmd+3poyUwevcWchYdvE02YT1nQU4SJpA5/wrdLrpWE=
 github.com/devfile/api/v2 v2.0.0-20210917193329-089a48011460/go.mod h1:kLX/nW93gigOHXK3NLeJL2fSS/sgEe+OHu8bo3aoOi4=
-github.com/devfile/devworkspace-operator v0.12.2 h1:6D/2vHHJQACmJdr+uqKi8X4563yseQfs8Hyf25xHZ5k=
-github.com/devfile/devworkspace-operator v0.12.2/go.mod h1:33uEtRwYsox/Jsuh5oqNc4iPNKtprazz15Jc0iX9aTU=
+github.com/devfile/devworkspace-operator v0.12.3 h1:HMUfbQpDg5XBwHOLLiyUPb4hF4RJKVs95BTlL+OI6As=
+github.com/devfile/devworkspace-operator v0.12.3/go.mod h1:33uEtRwYsox/Jsuh5oqNc4iPNKtprazz15Jc0iX9aTU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dhui/dktest v0.3.2/go.mod h1:l1/ib23a/CmxAe7yixtrYPc8Iy90Zy2udyaHINM5p58=

--- a/helmcharts/next/templates/manager.yaml
+++ b/helmcharts/next/templates/manager.yaml
@@ -72,7 +72,7 @@ spec:
             - name: RELATED_IMAGE_che_tls_secrets_creation_job
               value: quay.io/eclipse/che-tls-secret-creator:alpine-01a4c34
             - name: RELATED_IMAGE_pvc_jobs
-              value: registry.access.redhat.com/ubi8-minimal:8.5-218
+              value: registry.access.redhat.com/ubi8-minimal:8.5-230
             - name: RELATED_IMAGE_postgres
               value: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
             - name: RELATED_IMAGE_postgres_13_3
@@ -88,7 +88,7 @@ spec:
             - name: RELATED_IMAGE_single_host_gateway_config_sidecar
               value: quay.io/che-incubator/configbump:0.1.4
             - name: RELATED_IMAGE_devworkspace_controller
-              value: quay.io/devfile/devworkspace-controller:v0.11.0
+              value: quay.io/devfile/devworkspace-controller:v0.12.3
             - name: RELATED_IMAGE_gateway_authentication_sidecar
               value: quay.io/openshift/origin-oauth-proxy:4.7
             - name: RELATED_IMAGE_gateway_authorization_sidecar

--- a/vendor/github.com/devfile/devworkspace-operator/apis/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/devfile/devworkspace-operator/apis/controller/v1alpha1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/vendor/github.com/devfile/devworkspace-operator/pkg/config/sync.go
+++ b/vendor/github.com/devfile/devworkspace-operator/pkg/config/sync.go
@@ -99,8 +99,12 @@ func SetupControllerConfig(client crclient.Client) error {
 	return nil
 }
 
+func IsSetUp() bool {
+	return internalConfig != nil
+}
+
 func ExperimentalFeaturesEnabled() bool {
-	if internalConfig.EnableExperimentalFeatures == nil {
+	if internalConfig == nil || internalConfig.EnableExperimentalFeatures == nil {
 		return false
 	}
 	return *internalConfig.EnableExperimentalFeatures

--- a/vendor/github.com/devfile/devworkspace-operator/pkg/provision/sync/sync.go
+++ b/vendor/github.com/devfile/devworkspace-operator/pkg/provision/sync/sync.go
@@ -125,7 +125,7 @@ func isMutableObject(obj crclient.Object) bool {
 }
 
 func printDiff(specObj, clusterObj crclient.Object, log logr.Logger) {
-	if config.ExperimentalFeaturesEnabled() {
+	if config.IsSetUp() && config.ExperimentalFeaturesEnabled() {
 		var diffOpts cmp.Options
 		switch specObj.(type) {
 		case *rbacv1.Role:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -19,8 +19,6 @@ github.com/BurntSushi/toml
 ## explicit
 # github.com/beorn7/perks v1.0.1 => github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
-# github.com/bitly/go-simplejson v0.0.0-00010101000000-000000000000 => github.com/bitly/go-simplejson v0.0.0-20171023175154-0c965951289c
-## explicit
 # github.com/blang/semver v3.5.1+incompatible => github.com/blang/semver v3.5.1+incompatible
 github.com/blang/semver
 # github.com/blang/semver/v4 v4.0.0 => github.com/blang/semver/v4 v4.0.0
@@ -37,7 +35,7 @@ github.com/davecgh/go-spew/spew
 github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2
 github.com/devfile/api/v2/pkg/attributes
 github.com/devfile/api/v2/pkg/devfile
-# github.com/devfile/devworkspace-operator v0.12.2
+# github.com/devfile/devworkspace-operator v0.12.3
 ## explicit
 github.com/devfile/devworkspace-operator/apis/controller/v1alpha1
 github.com/devfile/devworkspace-operator/controllers/controller/devworkspacerouting
@@ -328,8 +326,6 @@ google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/inf.v0 v0.9.1 => gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
-# gopkg.in/tomb.v2 v2.0.0-00010101000000-000000000000 => gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
-## explicit
 # gopkg.in/yaml.v2 v2.4.0 => gopkg.in/yaml.v2 v2.4.0
 gopkg.in/yaml.v2
 # honnef.co/go/tools v0.0.1-2020.1.3 => honnef.co/go/tools v0.0.0-20200822191040-81508471876c


### PR DESCRIPTION
### What does this PR do?
Updates the DevWorkspace Operator dependency to v0.12.3 in order to pick up changes from commit https://github.com/devfile/devworkspace-operator/commit/69be85cdf34d1cb7d4aafc85cdd9c8a809e27a09

This resolves an issue where the DevWorkspaceRouting reconciler, as used by the Che Operator, can panic due to the internal config structure used by DWO not being set up.

### Screenshot/screencast of this PR
N/A


### What issues does this PR fix or reference?
No issue created (yet)

### How to test this PR?
Changes from this PR are built into quay.io/amisevsk/che-operator:dwo-0.12.3

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [N/A] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [N/A] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [N/A] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
