### PR TITLE
fix: Use different traefik router names for each healthz router

### DIFF
--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -75,7 +75,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.43.0-422.next
+  name: eclipse-che-preview-openshift.v7.43.0-423.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1288,4 +1288,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.43.0-422.next
+  version: 7.43.0-423.next

--- a/controllers/devworkspace/solver/che_routing.go
+++ b/controllers/devworkspace/solver/che_routing.go
@@ -486,7 +486,8 @@ func routeForHealthzEndpoint(cfg *gateway.TraefikConfig, dwId string, endpoints 
 					middlewares = append(middlewares, dwId+gateway.HeaderRewriteMiddlewareSuffix)
 				}
 				routeName, endpointPath := createEndpointPath(&e, componentName)
-				cfg.HTTP.Routers[routeName+"-healthz"] = &gateway.TraefikConfigRouter{
+				routerName := fmt.Sprintf("%s-%s-healthz", dwId, routeName)
+				cfg.HTTP.Routers[routerName] = &gateway.TraefikConfigRouter{
 					Rule:        fmt.Sprintf("Path(`/%s%s/healthz`)", dwId, endpointPath),
 					Service:     dwId,
 					Middlewares: middlewares,

--- a/controllers/devworkspace/solver/che_routing_test.go
+++ b/controllers/devworkspace/solver/che_routing_test.go
@@ -331,7 +331,7 @@ func TestCreateRelocatedObjectsK8S(t *testing.T) {
 		}
 
 		t.Run("testHealthzEndpointInMainWorkspaceRoute", func(t *testing.T) {
-			healthzName := "9999-healthz"
+			healthzName := "wsid-9999-healthz"
 			assert.Contains(t, workspaceMainConfig.HTTP.Routers, healthzName)
 			assert.Equal(t, workspaceMainConfig.HTTP.Routers[healthzName].Service, wsid)
 			assert.Equal(t, workspaceMainConfig.HTTP.Routers[healthzName].Rule, "Path(`/wsid/m1/9999/healthz`)")
@@ -423,7 +423,7 @@ func TestCreateRelocatedObjectsOpenshift(t *testing.T) {
 		}
 
 		t.Run("testHealthzEndpointInMainWorkspaceRoute", func(t *testing.T) {
-			healthzName := "9999-healthz"
+			healthzName := "wsid-9999-healthz"
 			assert.Contains(t, workspaceMainConfig.HTTP.Routers, healthzName)
 			assert.Equal(t, workspaceMainConfig.HTTP.Routers[healthzName].Service, wsid)
 			assert.Equal(t, workspaceMainConfig.HTTP.Routers[healthzName].Rule, "Path(`/wsid/m1/9999/healthz`)")
@@ -499,7 +499,7 @@ func TestUniqueMainEndpoint(t *testing.T) {
 	assert.NoError(t, yaml.Unmarshal([]byte(traefikMainWorkspaceConfig), &workspaceMainConfig))
 
 	t.Run("testHealthzEndpointInMainWorkspaceRoute", func(t *testing.T) {
-		healthzName := "e1-healthz"
+		healthzName := wsid + "-e1-healthz"
 		assert.Contains(t, workspaceMainConfig.HTTP.Routers, healthzName)
 		assert.Equal(t, workspaceMainConfig.HTTP.Routers[healthzName].Service, wsid)
 		assert.Equal(t, workspaceMainConfig.HTTP.Routers[healthzName].Rule, "Path(`/"+wsid+"/m1/e1/healthz`)")


### PR DESCRIPTION
### What does this PR do?
Modify how traefik routers are generated for the `/healthz` endpoint in the main gateway config. Rather than using routers `[workspaceID, <port>-healthz]` for each workspace, use `[workspaceID, workspaceID-<port>-healthz]`

This resolves an issue where multiple DevWorkspaces attempt to contribute e.g. a router named `3100-healthz`, causing the gateway to ignore all but the first on it encounters:

```log
time="2022-02-02T19:21:44Z" level=warning msg="HTTP router already configured, skipping" providerName=file filename=workspaced3a8bb14a78849fc.yml routerName=3100-healthz
```

The result of the warning above is that `/healthz` checks from DWO hit authorization, and the issue resolved by https://github.com/eclipse-che/che-operator/pull/1119 is back.


### Screenshot/screencast of this PR
N/A


### What issues does this PR fix or reference?
Closes https://github.com/eclipse/che/issues/21099


### How to test this PR?
From a clean install of Che + DWO on OpenShift, the following steps will reproduce the issue in the current main branch and not this PR:

1. Apply DevWorkspace to cluster in user's `<username>-che` namespace and wait for it to enter the "Running" phase. Stop workspace after it starts fully
    ```yaml
    kind: DevWorkspace
    apiVersion: workspace.devfile.io/v1alpha2
    metadata:
      name: test-dw-1
    spec:
      started: true
      routingClass: che
      template:
        components:
          - name: nodejsdev
            container:
              image: quay.io/devfile/universal-developer-image:ubi8-b452131
              endpoints:
                - exposure: public
                  name: nodejs
                  protocol: http
                  targetPort: 3000
              memoryLimit: 1G
              mountSources: true
          - name: che-code
            plugin:
              uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/insiders/devfile.yaml
    ```
2. Apply same DevWorkspace spec with a different name (e.g. `test-dw-2`) to the same namespace, wait for it to start, then stop it.
3. One of these DevWorkspaces will consistently hit a 502 Gateway timeout when you try to open it through the Che dashboard (to figure out which one, check the gateway pod's logs for the error message above and check the workspace ID)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
