### PR TITLE
chore: Bump DevWorkspace Operator dependency to v0.13.0

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -460,4 +460,4 @@
 | [golang.org/x/mobile@d3739f865fa66d07c1f506505c18aac71a8ead6e](https://cs.opensource.google/go) | BSD-3-Clause | N/A |
 | [github.com/devfile/api/v2@03e023e7078b64884216d8e6dce8f0cf8b7e74d2](https://github.com/devfile/api.git) | Apache-2.0 | [CQ](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23680) |
 | [github.com/che-incubator/kubernetes-image-puller-operator@0128446f5af78587c0427a35d693bbb8d24036bc](https://github.com/che-incubator/kubernetes-image-puller-operator.git) | EPL-2.0 | todo |
-| [github.com/devfile/devworkspace-operator@ec1a4cefefe5d77620c8f5f21624f41b7e8e9100](https://github.com/devfile/devworkspace-operator.git) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/git/github/devfile/devworkspace-operator/ec1a4cefefe5d77620c8f5f21624f41b7e8e9100) |
+| [github.com/devfile/devworkspace-operator@aaa430987417c980001c7ae19932f78991fe9707](https://github.com/devfile/devworkspace-operator.git) | Apache-2.0 | [clearlydefined](https://clearlydefined.io/definitions/git/github/devfile/devworkspace-operator/aaa430987417c980001c7ae19932f78991fe9707) |

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -75,7 +75,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.44.0-432.next
+  name: eclipse-che-preview-openshift.v7.45.0-433.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -968,7 +968,7 @@ spec:
                       - name: RELATED_IMAGE_devfile_registry
                         value: quay.io/eclipse/che-devfile-registry:next
                       - name: RELATED_IMAGE_pvc_jobs
-                        value: registry.access.redhat.com/ubi8-minimal:8.5-230
+                        value: registry.access.redhat.com/ubi8-minimal:8.5-230.1645809059
                       - name: RELATED_IMAGE_postgres
                         value: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
                       - name: RELATED_IMAGE_postgres_13_3
@@ -1282,4 +1282,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.44.0-432.next
+  version: 7.45.0-433.next

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,7 +72,7 @@ spec:
             - name: RELATED_IMAGE_che_tls_secrets_creation_job
               value: quay.io/eclipse/che-tls-secret-creator:alpine-01a4c34
             - name: RELATED_IMAGE_pvc_jobs
-              value: registry.access.redhat.com/ubi8-minimal:8.5-230
+              value: registry.access.redhat.com/ubi8-minimal:8.5-230.1645809059
             - name: RELATED_IMAGE_postgres
               value: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
             - name: RELATED_IMAGE_postgres_13_3

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Shopify/logrus-bugsnag v0.0.0-00010101000000-000000000000 // indirect
 	github.com/che-incubator/kubernetes-image-puller-operator v0.0.0-20210929175054-0128446f5af7
 	github.com/devfile/api/v2 v2.0.0-20210917193329-089a48011460
-	github.com/devfile/devworkspace-operator v0.12.3
+	github.com/devfile/devworkspace-operator v0.13.0
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/mock v1.5.0
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/deislabs/oras v0.8.1/go.mod h1:Mx0rMSbBNaNfY9hjpccEnxkOqJL6KGjtxNHPLC
 github.com/denisenkom/go-mssqldb v0.0.0-20190204142019-df6d76eb9289/go.mod h1:xN/JuLBIz4bjkxNmByTiV1IbhfnYb6oo99phBn4Eqhc=
 github.com/devfile/api/v2 v2.0.0-20210917193329-089a48011460 h1:cmd+3poyUwevcWchYdvE02YT1nQU4SJpA5/wrdLrpWE=
 github.com/devfile/api/v2 v2.0.0-20210917193329-089a48011460/go.mod h1:kLX/nW93gigOHXK3NLeJL2fSS/sgEe+OHu8bo3aoOi4=
-github.com/devfile/devworkspace-operator v0.12.3 h1:HMUfbQpDg5XBwHOLLiyUPb4hF4RJKVs95BTlL+OI6As=
-github.com/devfile/devworkspace-operator v0.12.3/go.mod h1:33uEtRwYsox/Jsuh5oqNc4iPNKtprazz15Jc0iX9aTU=
+github.com/devfile/devworkspace-operator v0.13.0 h1:s/jFTfqKmVM8UizgCcS5icZ+w3LV+iRtDDkeYqVk+os=
+github.com/devfile/devworkspace-operator v0.13.0/go.mod h1:33uEtRwYsox/Jsuh5oqNc4iPNKtprazz15Jc0iX9aTU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dhui/dktest v0.3.2/go.mod h1:l1/ib23a/CmxAe7yixtrYPc8Iy90Zy2udyaHINM5p58=

--- a/helmcharts/next/templates/manager.yaml
+++ b/helmcharts/next/templates/manager.yaml
@@ -72,7 +72,7 @@ spec:
             - name: RELATED_IMAGE_che_tls_secrets_creation_job
               value: quay.io/eclipse/che-tls-secret-creator:alpine-01a4c34
             - name: RELATED_IMAGE_pvc_jobs
-              value: registry.access.redhat.com/ubi8-minimal:8.5-230
+              value: registry.access.redhat.com/ubi8-minimal:8.5-230.1645809059
             - name: RELATED_IMAGE_postgres
               value: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
             - name: RELATED_IMAGE_postgres_13_3

--- a/vendor/github.com/devfile/devworkspace-operator/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
+++ b/vendor/github.com/devfile/devworkspace-operator/apis/controller/v1alpha1/devworkspaceoperatorconfig_types.go
@@ -76,6 +76,10 @@ type WorkspaceConfig struct {
 	// PVCName defines the name used for the persistent volume claim created
 	// to support workspace storage when the 'common' storage class is used.
 	// If not specified, the default value of `claim-devworkspace` is used.
+	// Note that changing this configuration value after workspaces have been
+	// created will disconnect all existing workspaces from the previously-used
+	// persistent volume claim, and will require manual removal of the old PVCs
+	// in the cluster.
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	PVCName string `json:"pvcName,omitempty"`

--- a/vendor/github.com/devfile/devworkspace-operator/apis/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/devfile/devworkspace-operator/apis/controller/v1alpha1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/vendor/github.com/devfile/devworkspace-operator/pkg/constants/constants.go
+++ b/vendor/github.com/devfile/devworkspace-operator/pkg/constants/constants.go
@@ -74,6 +74,10 @@ const (
 	// so do not require cleanup. When a DevWorkspace is stopped, all local changes are lost.
 	EphemeralStorageClassType = "ephemeral"
 
+	// CheCommonPVCName is the name of the common PVC equivalent used by Che. If present in the namespace, this PVC is mounted instead
+	// of the default PVC when the 'common' or 'async' storage classes are used.
+	CheCommonPVCName = "claim-che-workspace"
+
 	// Constants describing configuration for automatic project cloning
 
 	// ProjectCloneDisable specifies that project cloning should be disabled.

--- a/vendor/github.com/devfile/devworkspace-operator/pkg/constants/metadata.go
+++ b/vendor/github.com/devfile/devworkspace-operator/pkg/constants/metadata.go
@@ -20,6 +20,11 @@ const (
 	// DevWorkspaceIDLabel is the label key to store workspace identifier
 	DevWorkspaceIDLabel = "controller.devfile.io/devworkspace_id"
 
+	// WorkspaceIdOverrideAnnotation is an annotation that can be applied to DevWorkspaces
+	// to override the default DevWorkspace ID assigned by the Operator. Is only respected
+	// when a DevWorkspace is created. Once a DevWorkspace has an ID set, it cannot be changed.
+	WorkspaceIdOverrideAnnotation = "controller.devfile.io/devworkspace_id_override"
+
 	// DevWorkspaceCreatorLabel is the label key for storing the UID of the user who created the workspace
 	DevWorkspaceCreatorLabel = "controller.devfile.io/creator"
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -35,7 +35,7 @@ github.com/davecgh/go-spew/spew
 github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2
 github.com/devfile/api/v2/pkg/attributes
 github.com/devfile/api/v2/pkg/devfile
-# github.com/devfile/devworkspace-operator v0.12.3
+# github.com/devfile/devworkspace-operator v0.13.0
 ## explicit
 github.com/devfile/devworkspace-operator/apis/controller/v1alpha1
 github.com/devfile/devworkspace-operator/controllers/controller/devworkspacerouting


### PR DESCRIPTION
### What does this PR do?
Bump the DevWorkspace Operator dependency to the latest release (`v0.13.0`). Since v0.12.3, no changes are made in the library that impact the Che Operator.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
regular chore

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->

```bash
cat EOF << > /tmp/patch.yaml
<PATCH_CONTENT>
EOF

chectl server:deploy \
     --installer operator \
     --platform <PLATFORM_TO_DEPLOY> \
     --che-operator-image <CUSTOM_OPERATOR_IMAGE> \
     --che-operator-cr-patch-yaml /tmp/patch.yaml
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
