### PR TITLE
fix: Use the labels used by the che-server to recognize workspace namespaces

### DIFF
--- a/controllers/usernamespace/controller.go
+++ b/controllers/usernamespace/controller.go
@@ -159,7 +159,7 @@ func isLabeledAsUserSettings(obj metav1.Object) bool {
 
 func (r *CheUserNamespaceReconciler) isInManagedNamespace(ctx context.Context, obj metav1.Object) bool {
 	info, err := r.namespaceCache.GetNamespaceInfo(ctx, obj.GetNamespace())
-	return err == nil && info != nil && info.OwnerUid != ""
+	return err == nil && info != nil && info.IsWorkspaceNamespace
 }
 
 func (r *CheUserNamespaceReconciler) triggerAllNamespaces() handler.EventHandler {
@@ -195,7 +195,7 @@ func (r *CheUserNamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	if info == nil || info.OwnerUid == "" {
+	if info == nil || !info.IsWorkspaceNamespace {
 		// we're not handling this namespace
 		return ctrl.Result{}, nil
 	}

--- a/controllers/usernamespace/namespacecache_test.go
+++ b/controllers/usernamespace/namespacecache_test.go
@@ -110,7 +110,7 @@ func TestExamineUpdatesCache(t *testing.T) {
 		nsi, err := nsc.GetNamespaceInfo(ctx, nsName)
 		assert.NoError(t, err)
 
-		assert.Empty(t, nsi.OwnerUid, "Detected owner UID should be empty")
+		assert.False(t, nsi.IsWorkspaceNamespace, "The namespace should not be found as managed")
 
 		assert.Contains(t, nsc.knownNamespaces, nsName, "The namespace info should have been cached")
 
@@ -126,7 +126,19 @@ func TestExamineUpdatesCache(t *testing.T) {
 		nsi, err = nsc.ExamineNamespace(ctx, nsName)
 		assert.NoError(t, err)
 
-		assert.Equal(t, "uid", nsi.OwnerUid, "unexpected detected owner UID")
+		assert.True(t, nsi.IsWorkspaceNamespace, "namespace should be found as managed using the legacy user UID label")
+
+		ns.(metav1.Object).SetLabels(map[string]string{
+			chePartOfLabel: chePartOfLabelValue,
+			cheComponentLabel: cheComponentLabelValue,
+		})
+
+		assert.NoError(t, cl.Update(ctx, ns))
+
+		nsi, err = nsc.ExamineNamespace(ctx, nsName)
+		assert.NoError(t, err)
+
+		assert.True(t, nsi.IsWorkspaceNamespace, "namespace should be found as managed using the part-of and component labels")
 	}
 
 	test(infrastructure.Kubernetes, &corev1.Namespace{

--- a/controllers/usernamespace/namespacecache_test.go
+++ b/controllers/usernamespace/namespacecache_test.go
@@ -129,7 +129,7 @@ func TestExamineUpdatesCache(t *testing.T) {
 		assert.True(t, nsi.IsWorkspaceNamespace, "namespace should be found as managed using the legacy user UID label")
 
 		ns.(metav1.Object).SetLabels(map[string]string{
-			chePartOfLabel: chePartOfLabelValue,
+			chePartOfLabel:    chePartOfLabelValue,
 			cheComponentLabel: cheComponentLabelValue,
 		})
 


### PR DESCRIPTION
### What does this PR do?
Use the app.kubernetes.io/part-of=che.eclipse.org and app.kubernetes.io/component=workspaces-namespace labels to mark a namespace as workspace namespace.

This should bring the operator and che-server in line with how they are marking the managed namespaces.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
eclipse/che#21327

### How to test this PR?
1. 
   ```bash
   chectl server:deploy \
        --installer operator \
        --platform <PLATFORM_TO_DEPLOY> \
        --che-operator-image quay.io/lkrejci/che-operator:issue-21327
   ```
1. Create a workspace
1. Check that the workspace namespace has the following labels:
   ```
   app.kubernetes.io/component: workspaces-namespace
   app.kubernetes.io/part-of: che.eclipse.org
   ```
1. check that the namespace has been provisioned. Depending on the configuration you can see 1 or more configmaps `eclipse-che-eclipse-che-git-tls-creds`, `eclipse-che-eclipse-che-trusted-ca-certs`, `eclipse-che-eclipse-che-proxy-settings` and secret `eclipse-che-eclipse-che-server-cert`.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
