### PR TITLE
Allow loading preload page without authorization

### DIFF
--- a/pkg/deploy/dashboard/dashboard.go
+++ b/pkg/deploy/dashboard/dashboard.go
@@ -120,7 +120,7 @@ func (d *DashboardReconciler) Finalize(ctx *deploy.DeployContext) bool {
 func (d *DashboardReconciler) createGatewayConfig(ctx *deploy.DeployContext) *gateway.TraefikConfig {
 	cfg := gateway.CreateCommonTraefikConfig(
 		d.getComponentName(ctx),
-		fmt.Sprintf("PathPrefix(`%s`)", exposePath),
+		fmt.Sprintf("Path(`/`, `/f`) || PathPrefix(`%s`)", exposePath),
 		10,
 		"http://"+d.getComponentName(ctx)+":8080",
 		[]string{})

--- a/pkg/deploy/gateway/gateway.go
+++ b/pkg/deploy/gateway/gateway.go
@@ -218,7 +218,7 @@ func DeleteGatewayRouteConfig(componentName string, deployContext *deploy.Deploy
 func getGatewayServerConfigSpec(deployContext *deploy.DeployContext) (corev1.ConfigMap, error) {
 	cfg := CreateCommonTraefikConfig(
 		serverComponentName,
-		"Path(`/`, `/f`) || PathPrefix(`/api`, `/swagger`, `/_app`)",
+		"PathPrefix(`/api`, `/swagger`, `/_app`)",
 		1,
 		"http://"+deploy.CheServiceName+":8080",
 		[]string{})

--- a/pkg/deploy/gateway/gateway_test.go
+++ b/pkg/deploy/gateway/gateway_test.go
@@ -153,7 +153,7 @@ func TestOauthProxyConfigUnauthorizedPaths(t *testing.T) {
 
 		configmap := getGatewayOauthProxyConfigSpec(ctx, "blabol")
 		config := configmap.Data["oauth-proxy.cfg"]
-		if !strings.Contains(config, "skip_auth_regex = \"/healthz$\"") {
+		if !strings.Contains(config, "skip_auth_regex = \"^/$|/healthz$|^/dashboard/static/preload\"") {
 			t.Errorf("oauth config shold not contain any skip auth when both registries are external")
 		}
 	})
@@ -170,7 +170,7 @@ func TestOauthProxyConfigUnauthorizedPaths(t *testing.T) {
 
 		configmap := getGatewayOauthProxyConfigSpec(ctx, "blabol")
 		config := configmap.Data["oauth-proxy.cfg"]
-		if !strings.Contains(config, "skip_auth_regex = \"^/devfile-registry|/healthz$\"") {
+		if !strings.Contains(config, "skip_auth_regex = \"^/devfile-registry|^/$|/healthz$|^/dashboard/static/preload\"") {
 			t.Error("oauth config should skip auth for devfile registry", config)
 		}
 	})
@@ -187,7 +187,7 @@ func TestOauthProxyConfigUnauthorizedPaths(t *testing.T) {
 
 		configmap := getGatewayOauthProxyConfigSpec(ctx, "blabol")
 		config := configmap.Data["oauth-proxy.cfg"]
-		if !strings.Contains(config, "skip_auth_regex = \"^/plugin-registry|/healthz$\"") {
+		if !strings.Contains(config, "skip_auth_regex = \"^/plugin-registry|^/$|/healthz$|^/dashboard/static/preload\"") {
 			t.Error("oauth config should skip auth for plugin registry", config)
 		}
 	})
@@ -204,7 +204,7 @@ func TestOauthProxyConfigUnauthorizedPaths(t *testing.T) {
 
 		configmap := getGatewayOauthProxyConfigSpec(ctx, "blabol")
 		config := configmap.Data["oauth-proxy.cfg"]
-		if !strings.Contains(config, "skip_auth_regex = \"^/plugin-registry|^/devfile-registry|/healthz$\"") {
+		if !strings.Contains(config, "skip_auth_regex = \"^/plugin-registry|^/devfile-registry|^/$|/healthz$|^/dashboard/static/preload\"") {
 			t.Error("oauth config should skip auth for plugin and devfile registry.", config)
 		}
 	})

--- a/pkg/deploy/gateway/oauth_proxy.go
+++ b/pkg/deploy/gateway/oauth_proxy.go
@@ -118,7 +118,9 @@ func skipAuthConfig(instance *orgv1.CheCluster) string {
 	if !instance.Spec.Server.ExternalDevfileRegistry {
 		skipAuthPaths = append(skipAuthPaths, "^/"+deploy.DevfileRegistryName)
 	}
+	skipAuthPaths = append(skipAuthPaths, "^/$")
 	skipAuthPaths = append(skipAuthPaths, "/healthz$")
+	skipAuthPaths = append(skipAuthPaths, "^/dashboard/static/preload")
 	if len(skipAuthPaths) > 0 {
 		propName := "skip_auth_routes"
 		if util.IsOpenShift {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Allow loading preload page without authorization.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/20463

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
 Can be tested by following these steps: https://github.com/eclipse-che/che-operator#deploy-che-operator-with-chectl-using---installer-operator-flag

It could be tested with platform minikube and this che-operator image: **docker.io/olexii4dockerid/che-operator:next**.

1. Deploy Che.

Example:
```bash
chectl server:deploy \
    --installer=operator \
    --platform=minikube \
    --che-operator-cr-patch-yaml=./custom-che-server.yaml \
    --che-operator-image=docker.io/olexii4dockerid/che-operator:next
```
File **custom-che-server.yaml**
```
spec:
 server:
   dashboardImage: quay.io/eclipse/che-dashboard:pr-501
```
 
2. Try to accept factory with URL without being logged in, like 
```$CHE_HOST#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2```.
3. Check that Dashboard is opened with factory flow
```$CHE_HOST/dashboard/#/load-factory?url=https://github.com/che-samples/java-spring-petclinic/tree/devfilev2```.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
