### PR TITLE
[wip] Add TokenValidityCheck On OpenShift for che-dashboard

### DIFF
--- a/pkg/deploy/dashboard/dashboard.go
+++ b/pkg/deploy/dashboard/dashboard.go
@@ -126,6 +126,7 @@ func (d *DashboardReconciler) createGatewayConfig(ctx *deploy.DeployContext) *ga
 		[]string{})
 	if util.IsOpenShift {
 		cfg.AddAuthHeaderRewrite(d.getComponentName(ctx))
+		cfg.AddOpenShiftTokenCheck(d.getComponentName(ctx))
 	}
 	return cfg
 }


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Add TokenValidityCheck On OpenShift for che-dashboard.

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/21352

### How to test this PR?
It could be tested with platform openshift and this che-operator image: **docker.io/olexii4dockerid/che-operator:next**.

1. Deploy Che.

Example:
```bash
chectl server:deploy \
    --installer=operator \
    --platform=openshift \
    --che-operator-image=docker.io/olexii4dockerid/che-operator:next
```
 
2. Try to accept factory with URL without being logged in, like 
```$CHE_HOST#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2```.
3. Check that Dashboard is opened with factory flow
```$CHE_HOST/dashboard/#/load-factory?url=https://github.com/che-samples/java-spring-petclinic/tree/devfilev2```. And the load-factory page has loaded without any errors.

![2022-04-28_20_58_12](https://user-images.githubusercontent.com/6310786/165818171-8f516e98-0235-4402-9da0-87af4047a42d.png)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
