### PR TITLE
fix: Respect labels for workspace routes set in spec.server.CustomChe…

### DIFF
--- a/controllers/devworkspace/solver/endpoint_exposer.go
+++ b/controllers/devworkspace/solver/endpoint_exposer.go
@@ -15,6 +15,7 @@ package solver
 import (
 	"context"
 	"fmt"
+
 	dwo "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
 	checluster "github.com/eclipse-che/che-operator/api"

--- a/controllers/devworkspace/solver/endpoint_exposer.go
+++ b/controllers/devworkspace/solver/endpoint_exposer.go
@@ -15,9 +15,9 @@ package solver
 import (
 	"context"
 	"fmt"
-
 	dwo "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/constants"
+	checluster "github.com/eclipse-che/che-operator/api"
 	"github.com/eclipse-che/che-operator/api/v2alpha1"
 	"github.com/eclipse-che/che-operator/controllers/devworkspace/defaults"
 	"github.com/eclipse-che/che-operator/pkg/deploy"
@@ -26,6 +26,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -40,6 +41,7 @@ type IngressExposer struct {
 type RouteExposer struct {
 	devWorkspaceID       string
 	baseDomain           string
+	labels               map[string]string
 	tlsSecretKey         string
 	tlsSecretCertificate string
 }
@@ -65,6 +67,10 @@ func getEndpointExposingObjectName(componentName string, workspaceID string, por
 func (e *RouteExposer) initFrom(ctx context.Context, cl client.Client, cluster *v2alpha1.CheCluster, routing *dwo.DevWorkspaceRouting) error {
 	e.baseDomain = cluster.Status.WorkspaceBaseDomain
 	e.devWorkspaceID = routing.Spec.DevWorkspaceId
+
+	e.labels = map[string]string{}
+	checlusterV1 := checluster.AsV1(cluster)
+	deploy.MergeLabels(e.labels, checlusterV1.Spec.Server.CustomCheProperties["CHE_INFRA_OPENSHIFT_ROUTE_LABELS"])
 
 	if cluster.Spec.Workspaces.DomainEndpoints.TlsSecretName != "" {
 		secret := &corev1.Secret{}
@@ -133,14 +139,17 @@ func (e *IngressExposer) initFrom(ctx context.Context, cl client.Client, cluster
 
 func (e *RouteExposer) getRouteForService(endpoint *EndpointInfo) routev1.Route {
 	targetEndpoint := intstr.FromInt(int(endpoint.port))
+	labels := labels.Merge(
+		e.labels,
+		map[string]string{
+			constants.DevWorkspaceIDLabel:   e.devWorkspaceID,
+			deploy.KubernetesPartOfLabelKey: deploy.CheEclipseOrg,
+		})
 	route := routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getEndpointExposingObjectName(endpoint.componentName, e.devWorkspaceID, endpoint.port, endpoint.endpointName),
-			Namespace: endpoint.service.Namespace,
-			Labels: map[string]string{
-				constants.DevWorkspaceIDLabel:   e.devWorkspaceID,
-				deploy.KubernetesPartOfLabelKey: deploy.CheEclipseOrg,
-			},
+			Name:            getEndpointExposingObjectName(endpoint.componentName, e.devWorkspaceID, endpoint.port, endpoint.endpointName),
+			Namespace:       endpoint.service.Namespace,
+			Labels:          labels,
 			Annotations:     routeAnnotations(endpoint.componentName, endpoint.endpointName),
 			OwnerReferences: endpoint.service.OwnerReferences,
 		},

--- a/pkg/deploy/registry/registry_deployment.go
+++ b/pkg/deploy/registry/registry_deployment.go
@@ -28,6 +28,12 @@ func GetSpecRegistryDeployment(
 	resources corev1.ResourceRequirements,
 	probePath string) *appsv1.Deployment {
 
+	// append env var with ConfigMap revision to restore pod automatically when config has been changed
+	cm := &corev1.ConfigMap{}
+	exists, _ := deploy.GetNamespacedObject(deployContext, registryType+"-registry", cm)
+	configMapRevision := map[bool]string{true: cm.GetResourceVersion(), false: ""}[exists]
+	env = append(env, corev1.EnvVar{Name: "CM_REVISION", Value: configMapRevision})
+
 	terminationGracePeriodSeconds := int64(30)
 	name := registryType + "-registry"
 	labels, labelSelector := deploy.GetLabelsAndSelector(deployContext.CheCluster, name)


### PR DESCRIPTION
…Properties[CHE_INFRA_OPENSHIFT_ROUTE_LABELS]

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Respect labels for workspace routes to work with router sharding.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-2854

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

Image to test:
```bash
docker.io/abazko/operator:CRW-2854 
```
CheCluster 
```
spec:
  server:
    cheServerRoute:
      labels: <LABELS>
      domain: <DOMAIN>
    customCheProperties:
      CHE_INFRA_OPENSHIFT_ROUTE_LABELS: <LABELS>
      CHE_INFRA_OPENSHIFT_ROUTE_HOST_DOMAIN__SUFFIX: <DOMAIN>
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
