### PR TITLE
Namespace provisioning short name prefix

### DIFF
--- a/controllers/usernamespace/controller.go
+++ b/controllers/usernamespace/controller.go
@@ -159,7 +159,7 @@ func isLabeledAsUserSettings(obj metav1.Object) bool {
 
 func (r *CheUserNamespaceReconciler) isInManagedNamespace(ctx context.Context, obj metav1.Object) bool {
 	info, err := r.namespaceCache.GetNamespaceInfo(ctx, obj.GetNamespace())
-	return err == nil && info != nil && info.OwnerUid != ""
+	return err == nil && info != nil && info.IsWorkspaceNamespace
 }
 
 func (r *CheUserNamespaceReconciler) triggerAllNamespaces() handler.EventHandler {
@@ -195,7 +195,7 @@ func (r *CheUserNamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	if info == nil || info.OwnerUid == "" {
+	if info == nil || !info.IsWorkspaceNamespace {
 		// we're not handling this namespace
 		return ctrl.Result{}, nil
 	}

--- a/controllers/usernamespace/controller.go
+++ b/controllers/usernamespace/controller.go
@@ -273,7 +273,7 @@ func findManagingCheCluster(key types.NamespacedName) *v2alpha1.CheCluster {
 }
 
 func (r *CheUserNamespaceReconciler) reconcileSelfSignedCert(ctx context.Context, deployContext *deploy.DeployContext, targetNs string, checluster *v2alpha1.CheCluster) error {
-	targetCertName := prefixedName(checluster, "server-cert")
+	targetCertName := prefixedName("server-cert")
 
 	delSecret := func() error {
 		_, err := deploy.Delete(deployContext, client.ObjectKey{Name: targetCertName, Namespace: targetNs}, &corev1.Secret{})
@@ -323,7 +323,7 @@ func (r *CheUserNamespaceReconciler) reconcileSelfSignedCert(ctx context.Context
 }
 
 func (r *CheUserNamespaceReconciler) reconcileTrustedCerts(ctx context.Context, deployContext *deploy.DeployContext, targetNs string, checluster *v2alpha1.CheCluster) error {
-	targetConfigMapName := prefixedName(checluster, "trusted-ca-certs")
+	targetConfigMapName := prefixedName("trusted-ca-certs")
 
 	delConfigMap := func() error {
 		_, err := deploy.Delete(deployContext, client.ObjectKey{Name: targetConfigMapName, Namespace: targetNs}, &corev1.Secret{})
@@ -395,7 +395,7 @@ func (r *CheUserNamespaceReconciler) reconcileProxySettings(ctx context.Context,
 		proxySettings["NO_PROXY"] = proxyConfig.NoProxy
 	}
 
-	key := client.ObjectKey{Name: prefixedName(checluster, "proxy-settings"), Namespace: targetNs}
+	key := client.ObjectKey{Name: prefixedName("proxy-settings"), Namespace: targetNs}
 	cfg := &corev1.ConfigMap{}
 	exists := true
 	if err := r.client.Get(ctx, key, cfg); err != nil {
@@ -429,7 +429,7 @@ func (r *CheUserNamespaceReconciler) reconcileProxySettings(ctx context.Context,
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        prefixedName(checluster, "proxy-settings"),
+			Name:        prefixedName("proxy-settings"),
 			Namespace:   targetNs,
 			Labels:      requiredLabels,
 			Annotations: requiredAnnos,
@@ -442,7 +442,7 @@ func (r *CheUserNamespaceReconciler) reconcileProxySettings(ctx context.Context,
 }
 
 func (r *CheUserNamespaceReconciler) reconcileGitTlsCertificate(ctx context.Context, targetNs string, checluster *v2alpha1.CheCluster, deployContext *deploy.DeployContext) error {
-	targetName := prefixedName(checluster, "git-tls-creds")
+	targetName := prefixedName("git-tls-creds")
 	delConfigMap := func() error {
 		_, err := deploy.Delete(deployContext, client.ObjectKey{Name: targetName, Namespace: targetNs}, &corev1.Secret{})
 		return err
@@ -541,6 +541,6 @@ func (r *CheUserNamespaceReconciler) reconcileNodeSelectorAndTolerations(ctx con
 	return r.client.Update(ctx, ns)
 }
 
-func prefixedName(checluster *v2alpha1.CheCluster, name string) string {
-	return checluster.Name + "-" + checluster.Namespace + "-" + name
+func prefixedName(name string) string {
+	return "che-" + name
 }

--- a/controllers/usernamespace/controller_test.go
+++ b/controllers/usernamespace/controller_test.go
@@ -349,7 +349,7 @@ func TestCreatesDataInNamespace(t *testing.T) {
 		assert.False(t, res.Requeue, "The reconciliation request should have succeeded but it is requesting a requeue")
 
 		proxySettings := corev1.ConfigMap{}
-		assert.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "che-eclipse-che-proxy-settings", Namespace: namespace.GetName()}, &proxySettings))
+		assert.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "che-proxy-settings", Namespace: namespace.GetName()}, &proxySettings))
 
 		assert.Equal(t, "env", proxySettings.GetAnnotations()[constants.DevWorkspaceMountAsAnnotation],
 			"proxy settings should be annotated as mount as 'env'")
@@ -362,7 +362,7 @@ func TestCreatesDataInNamespace(t *testing.T) {
 		assert.Equal(t, ".svc", proxySettings.Data["NO_PROXY"], "Unexpected proxy settings")
 
 		cert := corev1.Secret{}
-		assert.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "che-eclipse-che-server-cert", Namespace: namespace.GetName()}, &cert))
+		assert.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "che-server-cert", Namespace: namespace.GetName()}, &cert))
 
 		assert.Equal(t, "file", cert.GetAnnotations()[constants.DevWorkspaceMountAsAnnotation], "server cert should be annotated as mount as 'file'")
 		assert.Equal(t, "/tmp/che/secret/", cert.GetAnnotations()[constants.DevWorkspaceMountPathAnnotation], "server cert annotated as mounted to an unexpected path")
@@ -373,7 +373,7 @@ func TestCreatesDataInNamespace(t *testing.T) {
 		assert.Equal(t, true, *cert.Immutable, "Unexpected mutability of the secret")
 
 		caCerts := corev1.ConfigMap{}
-		assert.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "che-eclipse-che-trusted-ca-certs", Namespace: namespace.GetName()}, &caCerts))
+		assert.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "che-trusted-ca-certs", Namespace: namespace.GetName()}, &caCerts))
 		assert.Equal(t, "file", caCerts.GetAnnotations()[constants.DevWorkspaceMountAsAnnotation], "trusted certs should be annotated as mount as 'file'")
 		assert.Equal(t, "/public-certs", caCerts.GetAnnotations()[constants.DevWorkspaceMountPathAnnotation], "trusted certs annotated as mounted to an unexpected path")
 		assert.Equal(t, "true", caCerts.GetLabels()[constants.DevWorkspaceMountLabel], "trusted certs should be labeled as mounted")
@@ -382,7 +382,7 @@ func TestCreatesDataInNamespace(t *testing.T) {
 		assert.Equal(t, "trusted cert 2", string(caCerts.Data["trusted2"]), "Unexpected trusted cert 2 value")
 
 		gitTlsConfig := corev1.ConfigMap{}
-		assert.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "che-eclipse-che-git-tls-creds", Namespace: namespace.GetName()}, &gitTlsConfig))
+		assert.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "che-git-tls-creds", Namespace: namespace.GetName()}, &gitTlsConfig))
 		assert.Equal(t, "true", gitTlsConfig.Labels[constants.DevWorkspaceGitTLSLabel])
 		assert.Equal(t, "true", gitTlsConfig.Labels[constants.DevWorkspaceWatchConfigMapLabel])
 		assert.Equal(t, "the.host.of.git", gitTlsConfig.Data["host"])

--- a/controllers/usernamespace/namespacecache_test.go
+++ b/controllers/usernamespace/namespacecache_test.go
@@ -110,7 +110,7 @@ func TestExamineUpdatesCache(t *testing.T) {
 		nsi, err := nsc.GetNamespaceInfo(ctx, nsName)
 		assert.NoError(t, err)
 
-		assert.Empty(t, nsi.OwnerUid, "Detected owner UID should be empty")
+		assert.False(t, nsi.IsWorkspaceNamespace, "The namespace should not be found as managed")
 
 		assert.Contains(t, nsc.knownNamespaces, nsName, "The namespace info should have been cached")
 
@@ -126,7 +126,19 @@ func TestExamineUpdatesCache(t *testing.T) {
 		nsi, err = nsc.ExamineNamespace(ctx, nsName)
 		assert.NoError(t, err)
 
-		assert.Equal(t, "uid", nsi.OwnerUid, "unexpected detected owner UID")
+		assert.True(t, nsi.IsWorkspaceNamespace, "namespace should be found as managed using the legacy user UID label")
+
+		ns.(metav1.Object).SetLabels(map[string]string{
+			chePartOfLabel: chePartOfLabelValue,
+			cheComponentLabel: cheComponentLabelValue,
+		})
+
+		assert.NoError(t, cl.Update(ctx, ns))
+
+		nsi, err = nsc.ExamineNamespace(ctx, nsName)
+		assert.NoError(t, err)
+
+		assert.True(t, nsi.IsWorkspaceNamespace, "namespace should be found as managed using the part-of and component labels")
 	}
 
 	test(infrastructure.Kubernetes, &corev1.Namespace{

--- a/controllers/usernamespace/namespacecache_test.go
+++ b/controllers/usernamespace/namespacecache_test.go
@@ -129,7 +129,7 @@ func TestExamineUpdatesCache(t *testing.T) {
 		assert.True(t, nsi.IsWorkspaceNamespace, "namespace should be found as managed using the legacy user UID label")
 
 		ns.(metav1.Object).SetLabels(map[string]string{
-			chePartOfLabel: chePartOfLabelValue,
+			chePartOfLabel:    chePartOfLabelValue,
 			cheComponentLabel: cheComponentLabelValue,
 		})
 


### PR DESCRIPTION
### What does this PR do?
Given the fact that we only support a single `CheCluster` CR in the whole Kubernetes cluster, there is no need for complicated name-prefixing during the namespace provisioning.

This PR just shortens the name prefix of all objects created to just `che-`.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
eclipse/che#21327

### How to test this PR?
1. Install Che to OpenShift into the `openshift-operators` namespace.
2. Start a workspace
3. The workspace should start without errors.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
