### PR TITLE
The git certificate needs to be labeled as mounted to workspace.

### DIFF
--- a/controllers/usernamespace/controller.go
+++ b/controllers/usernamespace/controller.go
@@ -472,6 +472,7 @@ func (r *CheUserNamespaceReconciler) reconcileGitTlsCertificate(ctx context.Cont
 			Namespace: targetNs,
 			Labels: defaults.AddStandardLabelsForComponent(checluster, userSettingsComponentLabelValue, map[string]string{
 				constants.DevWorkspaceGitTLSLabel:         "true",
+				constants.DevWorkspaceMountLabel:          "true",
 				constants.DevWorkspaceWatchConfigMapLabel: "true",
 			}),
 		},

--- a/controllers/usernamespace/controller_test.go
+++ b/controllers/usernamespace/controller_test.go
@@ -384,6 +384,7 @@ func TestCreatesDataInNamespace(t *testing.T) {
 		gitTlsConfig := corev1.ConfigMap{}
 		assert.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "che-git-tls-creds", Namespace: namespace.GetName()}, &gitTlsConfig))
 		assert.Equal(t, "true", gitTlsConfig.Labels[constants.DevWorkspaceGitTLSLabel])
+		assert.Equal(t, "true", gitTlsConfig.Labels[constants.DevWorkspaceMountLabel])
 		assert.Equal(t, "true", gitTlsConfig.Labels[constants.DevWorkspaceWatchConfigMapLabel])
 		assert.Equal(t, "the.host.of.git", gitTlsConfig.Data["host"])
 		assert.Equal(t, "the public certificate of the.host.of.git", gitTlsConfig.Data["certificate"])


### PR DESCRIPTION
### What does this PR do?
`$TITLE`. This is a cherry-pick of #1375 into the 7.46.x branch.

### What issues does this PR fix or reference?
#1375 
eclipse/che#21327
https://issues.redhat.com/browse/CRW-2882

### How to test this PR?
The same as #1375 but with a build from the 7.46.x branch (you can use `quay.io/lkrejci/che-operator:issue-21327-7.46.x` image). Make sure the devworkspace operator running in the cluster is `v0.14.1` or newer (if not deployed using OLM, edit the devworkspace-controller-manager deployment in the devworkspace-controller namespace and make sure the image has this or newer version).

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
