### PR TITLE
Fix OpenShift OAuth Proxy config

### DIFF
--- a/pkg/deploy/gateway/oauth_proxy.go
+++ b/pkg/deploy/gateway/oauth_proxy.go
@@ -68,7 +68,7 @@ cookie_expire = "24h0m0s"
 email_domains = "*"
 cookie_httponly = false
 pass_access_token = true
-skip_provider_button = true
+skip_provider_button = false
 %s
 `, GatewayServicePort,
 		ctx.CheCluster.GetCheHost(),


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Fix OpenShift OAuth Proxy config.

We already have several [openshift/oauth-proxy](https://github.com/openshift/oauth-proxy) issues with redirection:
 - [The page isn’t redirecting properly](https://github.com/openshift/oauth-proxy/issues/232) with open [PR](https://github.com/openshift/oauth-proxy/pull/234)
 - [skip-provider-button seems to force final redirection url to be /](https://github.com/bitly/oauth2_proxy/issues/327) with open [PR](https://github.com/bitly/oauth2_proxy/pull/395)

These issues depend on setting ```skip-provider-button=true```. It could always redirect to ```oauth/start```. 

I suggest using ```skip-provider-button=false``` as a quick fix until oauth-proxy PRs are waiting to be merged.

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/21352

### How to test this PR?
It could be tested with platform OpenShift and this che-operator image: **docker.io/olexii4dockerid/che-operator:next**.

1. Deploy Che.

Example:
```bash
chectl server:deploy \
    --installer=operator \
    --platform=openshift \
    --che-operator-image=docker.io/olexii4dockerid/che-operator:next
```
 
2. Try to accept factory with URL without being logged in, like 
```$CHE_HOST#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2```.
3. Check that Dashboard is opened with factory flow
```$CHE_HOST/dashboard/#/load-factory?url=https://github.com/che-samples/java-spring-petclinic/tree/devfilev2```. And the load-factory page has loaded without any errors.
4. Open the second tab with the dashboard.
5. Logout on the second tab and refresh the first one. You will see OAuth pages on bought tabs.
6. Try to login on bought tabs. login should be successful on bought tabs.

![2022-04-28_20_58_12](https://user-images.githubusercontent.com/6310786/165818171-8f516e98-0235-4402-9da0-87af4047a42d.png)

https://youtu.be/T7AqfANoA9c

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
