### PR TITLE
fix: Deletes object with a legacy name to avoid mounting several ones…

### DIFF
--- a/controllers/usernamespace/controller.go
+++ b/controllers/usernamespace/controller.go
@@ -226,7 +226,7 @@ func (r *CheUserNamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	if err = r.reconcileTrustedCerts(ctx, deployContext, req.Name, checluster); err != nil {
-		logrus.Errorf("Failed to reconcile self-signed certificate into namespace '%s': %v", req.Name, err)
+		logrus.Errorf("Failed to reconcile trusted certificates into namespace '%s': %v", req.Name, err)
 		return ctrl.Result{}, err
 	}
 
@@ -273,6 +273,10 @@ func findManagingCheCluster(key types.NamespacedName) *v2alpha1.CheCluster {
 }
 
 func (r *CheUserNamespaceReconciler) reconcileSelfSignedCert(ctx context.Context, deployContext *deploy.DeployContext, targetNs string, checluster *v2alpha1.CheCluster) error {
+	if err := deleteLegacyObject("server-cert", &corev1.Secret{}, targetNs, checluster, deployContext); err != nil {
+		return err
+	}
+
 	targetCertName := prefixedName("server-cert")
 
 	delSecret := func() error {
@@ -323,10 +327,14 @@ func (r *CheUserNamespaceReconciler) reconcileSelfSignedCert(ctx context.Context
 }
 
 func (r *CheUserNamespaceReconciler) reconcileTrustedCerts(ctx context.Context, deployContext *deploy.DeployContext, targetNs string, checluster *v2alpha1.CheCluster) error {
+	if err := deleteLegacyObject("trusted-ca-certs", &corev1.ConfigMap{}, targetNs, checluster, deployContext); err != nil {
+		return err
+	}
+
 	targetConfigMapName := prefixedName("trusted-ca-certs")
 
 	delConfigMap := func() error {
-		_, err := deploy.Delete(deployContext, client.ObjectKey{Name: targetConfigMapName, Namespace: targetNs}, &corev1.Secret{})
+		_, err := deploy.Delete(deployContext, client.ObjectKey{Name: targetConfigMapName, Namespace: targetNs}, &corev1.ConfigMap{})
 		return err
 	}
 
@@ -375,6 +383,10 @@ func addToFirst(first map[string]string, second map[string]string) map[string]st
 }
 
 func (r *CheUserNamespaceReconciler) reconcileProxySettings(ctx context.Context, targetNs string, checluster *v2alpha1.CheCluster, deployContext *deploy.DeployContext) error {
+	if err := deleteLegacyObject("proxy-settings", &corev1.ConfigMap{}, targetNs, checluster, deployContext); err != nil {
+		return err
+	}
+
 	proxyConfig, err := che.GetProxyConfiguration(deployContext)
 	if err != nil {
 		return err
@@ -442,9 +454,13 @@ func (r *CheUserNamespaceReconciler) reconcileProxySettings(ctx context.Context,
 }
 
 func (r *CheUserNamespaceReconciler) reconcileGitTlsCertificate(ctx context.Context, targetNs string, checluster *v2alpha1.CheCluster, deployContext *deploy.DeployContext) error {
+	if err := deleteLegacyObject("git-tls-creds", &corev1.ConfigMap{}, targetNs, checluster, deployContext); err != nil {
+		return err
+	}
+
 	targetName := prefixedName("git-tls-creds")
 	delConfigMap := func() error {
-		_, err := deploy.Delete(deployContext, client.ObjectKey{Name: targetName, Namespace: targetNs}, &corev1.Secret{})
+		_, err := deploy.Delete(deployContext, client.ObjectKey{Name: targetName, Namespace: targetNs}, &corev1.ConfigMap{})
 		return err
 	}
 
@@ -544,4 +560,30 @@ func (r *CheUserNamespaceReconciler) reconcileNodeSelectorAndTolerations(ctx con
 
 func prefixedName(name string) string {
 	return "che-" + name
+}
+
+// Deletes object with a legacy name to avoid mounting several ones under the same path
+// See https://github.com/eclipse/che/issues/21385
+func deleteLegacyObject(name string, objectMeta client.Object, targetNs string, checluster *v2alpha1.CheCluster, deployContext *deploy.DeployContext) error {
+	legacyPrefixedName := checluster.Name + "-" + checluster.Namespace + "-" + name
+	key := client.ObjectKey{Name: legacyPrefixedName, Namespace: targetNs}
+
+	err := deployContext.ClusterAPI.Client.Get(context.TODO(), key, objectMeta)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	err = deployContext.ClusterAPI.Client.Delete(context.TODO(), objectMeta)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	logrus.Infof("Deleted legacy workspace object: %s, name: %s", deploy.GetObjectType(objectMeta), legacyPrefixedName)
+	return nil
 }


### PR DESCRIPTION
… under the same path

Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
 Deletes object with a legacy name to avoid mounting several ones under the same path

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21385

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Deploy Eclipse Che 7.47.0
2. Create a workspace
3. Switch to Eclipse Che next version
4. Use new operator image `docker.io/abazko/operator:21385`
5. Start a workspace

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
