### PR TITLE
fix: Support internal endpoints

### DIFF
--- a/controllers/devworkspace/solver/che_routing.go
+++ b/controllers/devworkspace/solver/che_routing.go
@@ -215,7 +215,7 @@ func (c *CheRoutingSolver) cheExposedEndpoints(cheCluster *v2alpha1.CheCluster, 
 
 	for component, endpoints := range componentEndpoints {
 		for _, endpoint := range endpoints {
-			if dw.EndpointExposure(endpoint.Exposure) != dw.PublicEndpointExposure {
+			if dw.EndpointExposure(endpoint.Exposure) == dw.NoneEndpointExposure {
 				continue
 			}
 
@@ -360,7 +360,7 @@ func exposeAllEndpoints(cheCluster *v2alpha1.CheCluster, routing *dwo.DevWorkspa
 	order := 1
 	for componentName, endpoints := range routing.Spec.Endpoints {
 		for _, e := range endpoints {
-			if dw.EndpointExposure(e.Exposure) != dw.PublicEndpointExposure {
+			if dw.EndpointExposure(e.Exposure) == dw.NoneEndpointExposure {
 				continue
 			}
 

--- a/controllers/devworkspace/solver/che_routing.go
+++ b/controllers/devworkspace/solver/che_routing.go
@@ -377,9 +377,7 @@ func exposeAllEndpoints(cheCluster *v2alpha1.CheCluster, routing *dwo.DevWorkspa
 				continue
 			}
 
-			if e.Attributes.GetString(urlRewriteSupportedEndpointAttributeName, nil) == "true" {
-				addEndpointToTraefikConfig(componentName, e, wsRouteConfig, cheCluster, routing)
-			} else {
+			if e.Attributes.GetString(urlRewriteSupportedEndpointAttributeName, nil) != "true" {
 				if !containPort(commonService, int32(e.TargetPort)) {
 					commonService.Spec.Ports = append(commonService.Spec.Ports, corev1.ServicePort{
 						Name:       common.EndpointName(e.Name),
@@ -388,7 +386,15 @@ func exposeAllEndpoints(cheCluster *v2alpha1.CheCluster, routing *dwo.DevWorkspa
 						TargetPort: intstr.FromInt(e.TargetPort),
 					})
 				}
+			}
 
+			if dw.EndpointExposure(e.Exposure) != dw.PublicEndpointExposure {
+				continue
+			}
+
+			if e.Attributes.GetString(urlRewriteSupportedEndpointAttributeName, nil) == "true" {
+				addEndpointToTraefikConfig(componentName, e, wsRouteConfig, cheCluster, routing)
+			} else {
 				ingressExpose(&EndpointInfo{
 					order:         order,
 					componentName: componentName,

--- a/controllers/devworkspace/solver/che_routing.go
+++ b/controllers/devworkspace/solver/che_routing.go
@@ -226,6 +226,19 @@ func (c *CheRoutingSolver) cheExposedEndpoints(cheCluster *v2alpha1.CheCluster, 
 				continue
 			}
 
+			// The gateway server must not be set up
+			// Endpoint url is set to the service hostname
+			if dw.EndpointExposure(endpoint.Exposure) == dw.InternalEndpointExposure {
+				internalUrl := getServiceURL(int32(endpoint.TargetPort), workspaceID, routingObj.Services[0].Namespace)
+				exposedEndpoints[component] = append(exposedEndpoints[component], dwo.ExposedEndpoint{
+					Name:       endpoint.Name,
+					Url:        internalUrl,
+					Attributes: endpoint.Attributes,
+				})
+
+				continue
+			}
+
 			// try to find the endpoint in the ingresses/routes first. If it is there, it is exposed on a subdomain
 			// otherwise it is exposed through the gateway
 			var endpointURL string


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Support internal endpoints

### Screenshot/screencast of this PR
Devfile: https://gist.githubusercontent.com/l0rd/baa74d544f38c7fd358d1711dd46a071/raw/exposures-devfile.yaml
Exposed endpoints: 
![screenshot-console-openshift-console apps ci-ln-g2x9hyk-72292 origin-ci-int-gce dev rhcloud com-2022 05 12-16_02_32](https://user-images.githubusercontent.com/1640675/168081176-35c76477-6e68-44eb-a7ec-0e45ca532c37.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21387

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

https://github.com/eclipse-che/che-operator/pull/1384#issuecomment-1137823573

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
