### PR TITLE
feat: reroute workspace main urls to the dashboard when workspace is stopped

### DIFF
--- a/controllers/devworkspace/solver/solver.go
+++ b/controllers/devworkspace/solver/solver.go
@@ -196,3 +196,11 @@ func findCheManager(cheManagerKey client.ObjectKey) (*v2alpha1.CheCluster, error
 
 	return &v2alpha1.CheCluster{}, &solvers.RoutingNotReady{Retry: 10 * time.Second}
 }
+
+func (c *CheRoutingSolver) WorkspaceStopped(routing *controllerv1alpha1.DevWorkspaceRouting, workspaceMeta solvers.DevWorkspaceMetadata) error {
+	cheManager, err := cheManagerOfRouting(routing)
+	if err != nil {
+		return err
+	}
+	return c.provisionRouting(&solvers.RoutingObjects{}, cheManager, routing, workspaceMeta)
+}

--- a/pkg/deploy/gateway/traefik_config.go
+++ b/pkg/deploy/gateway/traefik_config.go
@@ -36,6 +36,7 @@ type TraefikConfigService struct {
 type TraefikConfigMiddleware struct {
 	StripPrefix *TraefikConfigStripPrefix `json:"stripPrefix,omitempty"`
 	ForwardAuth *TraefikConfigForwardAuth `json:"forwardAuth,omitempty"`
+	ReplacePathRegex *TraefikConfigReplacePathRegex `json:"replacePathRegex,omitempty"`
 	Plugin      *TraefikPlugin            `json:"plugin,omitempty"`
 }
 
@@ -55,6 +56,11 @@ type TraefikConfigForwardAuth struct {
 	Address            string            `json:"address"`
 	TrustForwardHeader bool              `json:"trustForwardHeader"`
 	TLS                *TraefikConfigTLS `json:"tls,omitempty"`
+}
+
+type TraefikConfigReplacePathRegex struct {
+	Regex       string `json:"regex"`
+	Replacement string `json:"replacement"`
 }
 
 type TraefikPlugin struct {

--- a/pkg/deploy/gateway/traefik_config_util_test.go
+++ b/pkg/deploy/gateway/traefik_config_util_test.go
@@ -39,6 +39,13 @@ func TestTraefikConfig_AddComponent(t *testing.T) {
 	assert.Empty(t, cfg.HTTP.Middlewares)
 }
 
+func TestAddService(t *testing.T) {
+	cfg := CreateEmptyTraefikConfig()
+	cfg.AddService(testComponentName, "http://svc")
+	assert.Contains(t, cfg.HTTP.Services, testComponentName)
+	assert.Empty(t, cfg.HTTP.Middlewares)
+}
+
 func TestStripPrefixesWhenCreating(t *testing.T) {
 	check := func(cfg *TraefikConfig) {
 		assert.Contains(t, cfg.HTTP.Routers[testComponentName].Middlewares, testComponentName+StripPrefixMiddlewareSuffix)

--- a/vendor/github.com/devfile/devworkspace-operator/apis/controller/v1alpha1/devworkspacerouting_types.go
+++ b/vendor/github.com/devfile/devworkspace-operator/apis/controller/v1alpha1/devworkspacerouting_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 import (
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/devfile/devworkspace-operator/pkg/constants"
 )
 
 // DevWorkspaceRoutingSpec defines the desired state of DevWorkspaceRouting
@@ -204,4 +205,8 @@ type DevWorkspaceRoutingList struct {
 
 func init() {
 	SchemeBuilder.Register(&DevWorkspaceRouting{}, &DevWorkspaceRoutingList{})
+}
+
+func (d *DevWorkspaceRouting) IsWorkspaceStopped() bool {
+	return d.Annotations != nil && d.Annotations[constants.DevWorkspaceStartedStatusAnnotation] == "false"
 }

--- a/vendor/github.com/devfile/devworkspace-operator/controllers/controller/devworkspacerouting/solvers/basic_solver.go
+++ b/vendor/github.com/devfile/devworkspace-operator/controllers/controller/devworkspacerouting/solvers/basic_solver.go
@@ -80,3 +80,7 @@ func (s *BasicSolver) GetExposedEndpoints(
 	routingObj RoutingObjects) (exposedEndpoints map[string]controllerv1alpha1.ExposedEndpointList, ready bool, err error) {
 	return getExposedEndpoints(endpoints, routingObj)
 }
+
+func (s *BasicSolver) WorkspaceStopped(routing *controllerv1alpha1.DevWorkspaceRouting, workspaceMeta DevWorkspaceMetadata) error {
+	return nil
+}

--- a/vendor/github.com/devfile/devworkspace-operator/controllers/controller/devworkspacerouting/solvers/cluster_solver.go
+++ b/vendor/github.com/devfile/devworkspace-operator/controllers/controller/devworkspacerouting/solvers/cluster_solver.go
@@ -126,3 +126,7 @@ func getHostnameFromService(service corev1.Service, port int32) string {
 	}
 	return fmt.Sprintf("%s://%s.%s.svc:%d", scheme, service.Name, service.Namespace, port)
 }
+
+func (s *ClusterSolver) WorkspaceStopped(routing *controllerv1alpha1.DevWorkspaceRouting, workspaceMeta DevWorkspaceMetadata) error {
+	return nil
+}

--- a/vendor/github.com/devfile/devworkspace-operator/controllers/controller/devworkspacerouting/solvers/solver.go
+++ b/vendor/github.com/devfile/devworkspace-operator/controllers/controller/devworkspacerouting/solvers/solver.go
@@ -59,6 +59,8 @@ type RoutingSolver interface {
 	// Return value "ready" specifies if all endpoints are resolved on the cluster; if false it is necessary to retry, as
 	// URLs will be undefined.
 	GetExposedEndpoints(endpoints map[string]controllerv1alpha1.EndpointList, routingObj RoutingObjects) (exposedEndpoints map[string]controllerv1alpha1.ExposedEndpointList, ready bool, err error)
+
+	WorkspaceStopped(routing *controllerv1alpha1.DevWorkspaceRouting, workspaceMeta DevWorkspaceMetadata) error
 }
 
 type RoutingSolverGetter interface {


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
When a workspace is stopped, this PR updates the traefik such that the main url of the workspace is routed to the dashboard.

When the workspace is running, the traefik config looks like this: https://gist.githubusercontent.com/dkwon17/f094653c08776591924940c7f360b789/raw/5ed727aa13cd38dae925f57e4fc4d17416a5cca6/workspacestarted.yaml

When the workspace stops, this PR changes the traefik config to this: https://gist.githubusercontent.com/dkwon17/bcdece6b2d503c25df526496cf031992/raw/3a3487ea7ab30179bc694bf74a9622b1a48d489e/workspacestopped.yaml

In the new traefik config, the [ReplacePathRegex]( https://doc.traefik.io/traefik/middlewares/http/replacepathregex/) middleware is used to change the workspace url path to a dashboard path.


### Screenshot/screencast of this PR
In this gif we see that:
1. Workspace is stopped
2. IDE page is refreshed
3. Instead of a 504 error, the user is redirected to the dashboard
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![updateroutes](https://user-images.githubusercontent.com/83611742/168595941-09fc607f-cfe3-4c10-beea-bb0139b63a13.gif)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Part of https://github.com/eclipse/che/issues/20599. In another PR, maybe we can redirect the user to some error page provided by the dashboard.

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
 
 Tested on CRC with the following:

1. Deploy
```bash
chectl server:deploy \
     --platform crc\
     --che-operator-image quay.io/dkwon17/che-operator:updateroutes
```

2. Open the dashboard with the URL provided by the output from chectl.
3. Start a workspace, and wait until the editor opens.
4. Stop the workspace.
5. Refresh the editor. You should be redirected to the dashboard where you can start the workspace agian.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
