### PR TITLE
Use errors middleware to redirect on idled workspace after 4 seconds

### DIFF
--- a/controllers/devworkspace/solver/che_routing_test.go
+++ b/controllers/devworkspace/solver/che_routing_test.go
@@ -322,6 +322,14 @@ func TestCreateRelocatedObjectsK8S(t *testing.T) {
 			assert.Truef(t, found, "traefik config route doesn't set middleware '%s'", mware)
 		}
 
+		t.Run("testServerTransportIsEmpty", func(t *testing.T) {
+			assert.Empty(t, workspaceMainConfig.HTTP.ServersTransports)
+
+			assert.Len(t, workspaceMainConfig.HTTP.Services, 1)
+			assert.Contains(t, workspaceMainConfig.HTTP.Services, wsid)
+			assert.Empty(t, workspaceMainConfig.HTTP.Services[wsid].LoadBalancer.ServersTransport)
+		})
+
 		t.Run("testHealthzEndpointInMainWorkspaceRoute", func(t *testing.T) {
 			healthzName := "wsid-9999-healthz"
 			assert.Contains(t, workspaceMainConfig.HTTP.Routers, healthzName)

--- a/controllers/devworkspace/solver/che_routing_test.go
+++ b/controllers/devworkspace/solver/che_routing_test.go
@@ -302,12 +302,14 @@ func TestCreateRelocatedObjectsK8S(t *testing.T) {
 
 		workspaceMainConfig := gateway.TraefikConfig{}
 		assert.NoError(t, yaml.Unmarshal([]byte(traefikMainWorkspaceConfig), &workspaceMainConfig))
-		assert.Len(t, workspaceMainConfig.HTTP.Middlewares, 2)
+		assert.Len(t, workspaceMainConfig.HTTP.Middlewares, 4)
 
 		wsid = "wsid"
 		mwares = []string{
 			wsid + gateway.AuthMiddlewareSuffix,
-			wsid + gateway.StripPrefixMiddlewareSuffix}
+			wsid + gateway.StripPrefixMiddlewareSuffix,
+			wsid + gateway.HeadersMiddlewareSuffix,
+			wsid + gateway.ErrorsMiddlewareSuffix}
 		for _, mware := range mwares {
 			assert.Contains(t, workspaceMainConfig.HTTP.Middlewares, mware)
 
@@ -392,13 +394,15 @@ func TestCreateRelocatedObjectsOpenshift(t *testing.T) {
 
 		workspaceMainConfig := gateway.TraefikConfig{}
 		assert.NoError(t, yaml.Unmarshal([]byte(traefikMainWorkspaceConfig), &workspaceMainConfig))
-		assert.Len(t, workspaceMainConfig.HTTP.Middlewares, 3)
+		assert.Len(t, workspaceMainConfig.HTTP.Middlewares, 5)
 
 		wsid = "wsid"
 		mwares := []string{
 			wsid + gateway.AuthMiddlewareSuffix,
 			wsid + gateway.StripPrefixMiddlewareSuffix,
-			wsid + gateway.HeaderRewriteMiddlewareSuffix}
+			wsid + gateway.HeaderRewriteMiddlewareSuffix,
+			wsid + gateway.HeadersMiddlewareSuffix,
+			wsid + gateway.ErrorsMiddlewareSuffix}
 		for _, mware := range mwares {
 			assert.Contains(t, workspaceMainConfig.HTTP.Middlewares, mware)
 
@@ -410,6 +414,17 @@ func TestCreateRelocatedObjectsOpenshift(t *testing.T) {
 			}
 			assert.Truef(t, found, "traefik config route doesn't set middleware '%s'", mware)
 		}
+
+		t.Run("testServerTransportInMainWorkspaceRoute", func(t *testing.T) {
+			serverTransportName := wsid
+
+			assert.Len(t, workspaceMainConfig.HTTP.ServersTransports, 1)
+			assert.Contains(t, workspaceMainConfig.HTTP.ServersTransports, serverTransportName)
+
+			assert.Len(t, workspaceMainConfig.HTTP.Services, 1)
+			assert.Contains(t, workspaceMainConfig.HTTP.Services, wsid)
+			assert.Equal(t, workspaceMainConfig.HTTP.Services[wsid].LoadBalancer.ServersTransport, serverTransportName)
+		})
 
 		t.Run("testHealthzEndpointInMainWorkspaceRoute", func(t *testing.T) {
 			healthzName := "wsid-9999-healthz"

--- a/pkg/deploy/gateway/traefik_config.go
+++ b/pkg/deploy/gateway/traefik_config.go
@@ -17,9 +17,10 @@ type TraefikConfig struct {
 }
 
 type TraefikConfigHTTP struct {
-	Routers     map[string]*TraefikConfigRouter     `json:"routers"`
-	Services    map[string]*TraefikConfigService    `json:"services"`
-	Middlewares map[string]*TraefikConfigMiddleware `json:"middlewares,omitempty"`
+	Routers           map[string]*TraefikConfigRouter           `json:"routers"`
+	Services          map[string]*TraefikConfigService          `json:"services"`
+	Middlewares       map[string]*TraefikConfigMiddleware       `json:"middlewares,omitempty"`
+	ServersTransports map[string]*TraefikConfigServersTransport `json:"serversTransports,omitempty"`
 }
 
 type TraefikConfigRouter struct {
@@ -36,11 +37,18 @@ type TraefikConfigService struct {
 type TraefikConfigMiddleware struct {
 	StripPrefix *TraefikConfigStripPrefix `json:"stripPrefix,omitempty"`
 	ForwardAuth *TraefikConfigForwardAuth `json:"forwardAuth,omitempty"`
+	Errors      *TraefikConfigErrors      `json:"errors,omitempty"`
+	Headers     *TraefikConfigHeaders     `json:"headers,omitempty"`
 	Plugin      *TraefikPlugin            `json:"plugin,omitempty"`
 }
 
+type TraefikConfigServersTransport struct {
+	ForwardingTimeouts *TraefikConfigForwardingTimeouts `json:"forwardingTimeouts"`
+}
+
 type TraefikConfigLoadbalancer struct {
-	Servers []TraefikConfigLoadbalancerServer `json:"servers"`
+	Servers          []TraefikConfigLoadbalancerServer `json:"servers"`
+	ServersTransport string                            `json:"serversTransport,omitempty"`
 }
 
 type TraefikConfigLoadbalancerServer struct {
@@ -57,6 +65,16 @@ type TraefikConfigForwardAuth struct {
 	TLS                *TraefikConfigTLS `json:"tls,omitempty"`
 }
 
+type TraefikConfigErrors struct {
+	Status  string `json:"status"`
+	Service string `json:"service"`
+	Query   string `json:"query"`
+}
+
+type TraefikConfigHeaders struct {
+	CustomResponseHeaders map[string]string `json:"customResponseHeaders,omitempty"`
+}
+
 type TraefikPlugin struct {
 	HeaderRewrite *TraefikPluginHeaderRewrite `json:"header-rewrite,omitempty"`
 }
@@ -69,4 +87,8 @@ type TraefikPluginHeaderRewrite struct {
 
 type TraefikConfigTLS struct {
 	InsecureSkipVerify bool `json:"insecureSkipVerify"`
+}
+
+type TraefikConfigForwardingTimeouts struct {
+	DialTimeout string `json:"dialTimeout"`
 }

--- a/pkg/deploy/gateway/traefik_config_util.go
+++ b/pkg/deploy/gateway/traefik_config_util.go
@@ -15,6 +15,8 @@ const (
 	StripPrefixMiddlewareSuffix   = "-strip-prefix"
 	HeaderRewriteMiddlewareSuffix = "-header-rewrite"
 	AuthMiddlewareSuffix          = "-auth"
+	ErrorsMiddlewareSuffix        = "-errors"
+	HeadersMiddlewareSuffix       = "-headers"
 )
 
 func CreateEmptyTraefikConfig() *TraefikConfig {
@@ -49,6 +51,7 @@ func (cfg *TraefikConfig) AddComponent(componentName string, rule string, priori
 			},
 		},
 	}
+
 	if len(stripPrefixes) > 0 {
 		cfg.AddStripPrefix(componentName, stripPrefixes)
 	}
@@ -98,6 +101,28 @@ func (cfg *TraefikConfig) AddAuth(componentName string, authAddress string) {
 	cfg.HTTP.Middlewares[middlewareName] = &TraefikConfigMiddleware{
 		ForwardAuth: &TraefikConfigForwardAuth{
 			Address: authAddress,
+		},
+	}
+}
+
+func (cfg *TraefikConfig) AddErrors(componentName string, status string, service string, query string) {
+	middlewareName := componentName + ErrorsMiddlewareSuffix
+	cfg.HTTP.Routers[componentName].Middlewares = append(cfg.HTTP.Routers[componentName].Middlewares, middlewareName)
+	cfg.HTTP.Middlewares[middlewareName] = &TraefikConfigMiddleware{
+		Errors: &TraefikConfigErrors{
+			Status:  status,
+			Service: service,
+			Query:   query,
+		},
+	}
+}
+
+func (cfg *TraefikConfig) AddResponseHeaders(componentName string, headers map[string]string) {
+	middlewareName := componentName + HeadersMiddlewareSuffix
+	cfg.HTTP.Routers[componentName].Middlewares = append(cfg.HTTP.Routers[componentName].Middlewares, middlewareName)
+	cfg.HTTP.Middlewares[middlewareName] = &TraefikConfigMiddleware{
+		Headers: &TraefikConfigHeaders{
+			CustomResponseHeaders: headers,
 		},
 	}
 }

--- a/pkg/deploy/gateway/traefik_config_util_test.go
+++ b/pkg/deploy/gateway/traefik_config_util_test.go
@@ -92,6 +92,38 @@ func TestAddOpenShiftTokenCheck(t *testing.T) {
 	}
 }
 
+func TestAddErrors(t *testing.T) {
+	status := "500-599"
+	service := "service"
+	query := "/"
+
+	cfg := CreateCommonTraefikConfig(testComponentName, testRule, 1, "http://svc:8080", []string{})
+	cfg.AddErrors(testComponentName, status, service, query)
+
+	assert.Len(t, cfg.HTTP.Routers[testComponentName].Middlewares, 1, *cfg)
+	assert.Len(t, cfg.HTTP.Middlewares, 1, *cfg)
+	middlewareName := cfg.HTTP.Routers[testComponentName].Middlewares[0]
+	if assert.Contains(t, cfg.HTTP.Middlewares, middlewareName, *cfg) && assert.NotNil(t, cfg.HTTP.Middlewares[middlewareName].Errors) {
+		assert.Equal(t, status, cfg.HTTP.Middlewares[middlewareName].Errors.Status)
+		assert.Equal(t, service, cfg.HTTP.Middlewares[middlewareName].Errors.Service)
+		assert.Equal(t, query, cfg.HTTP.Middlewares[middlewareName].Errors.Query)
+	}
+}
+
+func TestAddResponseHeaders(t *testing.T) {
+	reponseHeaders := map[string]string{"cache-control": "no-store, max-age=0"}
+
+	cfg := CreateCommonTraefikConfig(testComponentName, testRule, 1, "http://svc:8080", []string{})
+	cfg.AddResponseHeaders(testComponentName, reponseHeaders)
+
+	assert.Len(t, cfg.HTTP.Routers[testComponentName].Middlewares, 1, *cfg)
+	assert.Len(t, cfg.HTTP.Middlewares, 1, *cfg)
+	middlewareName := cfg.HTTP.Routers[testComponentName].Middlewares[0]
+	if assert.Contains(t, cfg.HTTP.Middlewares, middlewareName, *cfg) && assert.NotNil(t, cfg.HTTP.Middlewares[middlewareName].Headers) {
+		assert.Equal(t, reponseHeaders, cfg.HTTP.Middlewares[middlewareName].Headers.CustomResponseHeaders)
+	}
+}
+
 func TestMiddlewaresPreserveOrder(t *testing.T) {
 	t.Run("strip-header", func(t *testing.T) {
 		cfg := CreateCommonTraefikConfig(testComponentName, testRule, 1, "http://svc:8080", []string{})


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Alternative PR to https://github.com/eclipse-che/che-operator/pull/1386. The main difference is that this PR uses the Errors Traefik middleware.

### Screenshot/screencast of this PR
In this gif we see that:
1. Workspace is stopped
2. IDE page is refreshed
3. Instead of a 504 error, the user is redirected to the dashboard after 4 seconds
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![errorsmiddleware](https://user-images.githubusercontent.com/83611742/170130527-2b7e42af-cc79-40ee-ba54-0137961ec4d1.gif)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Part of https://github.com/eclipse/che/issues/20599. In another PR, maybe we can redirect the user to some error page provided by the dashboard.

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
 
 Tested on CRC with the following:

1. Deploy
```bash
chectl server:deploy \
     --platform crc\
     --che-operator-image quay.io/dkwon17/che-operator:useerrorsmiddleware
```

2. Open the dashboard with the URL provided by the output from chectl.
3. Start a workspace, and wait until the editor opens.
4. Stop the workspace.
5. Refresh the editor. You should be redirected to the dashboard after 4 seconds where you can start the workspace again.
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
