### PR TITLE
feat: CheCluster defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ mkfile_dir := $(dir $(mkfile_path))
 # Default Eclipse Che operator image
 IMG ?= quay.io/eclipse/che-operator:next
 
-CRD_OPTIONS ?= "crd:crdVersions=v1"
 CONFIG_MANAGER="config/manager/manager.yaml"
 
 INTERNAL_TMP_DIR=/tmp/che-operator-dev
@@ -346,7 +345,7 @@ docker-push: ## Push Eclipse Che operator image to a registry
 	${IMAGE_TOOL} push ${IMG}
 
 manifests: download-controller-gen download-addlicense ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd:crdVersions=v1 rbac:roleName=manager-role paths="./..." output:crd:artifacts:config=config/crd/bases
 
 	# remove yaml delimitier, which makes OLM catalog source image broken.
 	sed -i '/---/d' "$(CHECLUSTER_CRD_PATH)"

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,7 @@ update-helmcharts: ## Update Helm Charts
 		yq -rYi --arg examples "$${CRDS_SAMPLES}" ".annotations.\"artifacthub.io/crdsExamples\" = \$$examples" $${chartYaml}
 		rm -rf $${HELMCHARTS_TEMPLATES}/org_v2_checluster.yaml
 	else
+		yq -riY '.spec.networking = null' $${HELMCHARTS_TEMPLATES}/org_v2_checluster.yaml
 		yq -riY '.spec.networking.tlsSecretName = "che-tls"' $${HELMCHARTS_TEMPLATES}/org_v2_checluster.yaml
 		yq -riY '.spec.networking.domain = "{{ .Values.networking.domain }}"' $${HELMCHARTS_TEMPLATES}/org_v2_checluster.yaml
 		yq -riY '.spec.networking.auth.oAuthSecret = "{{ .Values.networking.auth.oAuthSecret }}"' $${HELMCHARTS_TEMPLATES}/org_v2_checluster.yaml

--- a/api/v2/checluster_types.go
+++ b/api/v2/checluster_types.go
@@ -33,16 +33,19 @@ type CheClusterSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Development environments"
+	// +kubebuilder:default:={storage: {pvcStrategy: common}, defaultNamespace: {template: <username>-che}}
 	DevEnvironments CheClusterDevEnvironments `json:"devEnvironments"`
 	// Che components configuration.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Components"
+	// +kubebuilder:default:={cheServer: {logLevel: INFO, debug: false}, metrics: {enable: true}, database: {externalDb: false, credentialsSecretName: postgres-credentials, postgresHostName: postgres, postgresPort: "5432", postgresDb: dbche, pvc: {claimSize: "1Gi"}}}
 	Components CheClusterComponents `json:"components"`
 	// Networking, Che authentication, and TLS configuration.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Networking"
+	// +kubebuilder:default:={auth: {gateway: {configLabels: {app: che, component: che-gateway-config}}}}
 	Networking CheClusterSpecNetworking `json:"networking"`
 	// Configuration of an alternative registry that stores Che images.
 	// +optional
@@ -460,6 +463,7 @@ type Container struct {
 	Image string `json:"image,omitempty"`
 	// Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
 	// +optional
+	// +kubebuilder:validation:Enum=Always;IfNotPresent;Never
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// Compute resources required by this container.
 	// +optional

--- a/api/v2/checluster_types.go
+++ b/api/v2/checluster_types.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019-2021 Red Hat, Inc.
+// Copyright (c) 2019-2022 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -43,7 +43,7 @@ type CheClusterSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=3
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Networking"
-	Networking CheClusterSpecNetworking `json:"networking,omitempty"`
+	Networking CheClusterSpecNetworking `json:"networking"`
 	// Configuration of an alternative registry that stores Che images.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=4
@@ -56,7 +56,8 @@ type CheClusterSpec struct {
 type CheClusterDevEnvironments struct {
 	// Workspaces persistent storage.
 	// +optional
-	Storage WorkspaceStorage `json:"storage"`
+	// +kubebuilder:default:={pvcStrategy: common}
+	Storage WorkspaceStorage `json:"storage,omitempty"`
 	// Default plug-ins applied to DevWorkspaces.
 	// +optional
 	DefaultPlugins []WorkspaceDefaultPlugins `json:"defaultPlugins,omitempty"`
@@ -68,6 +69,7 @@ type CheClusterDevEnvironments struct {
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// User's default namespace.
 	// +optional
+	// +kubebuilder:default:={template: <username>-che}
 	DefaultNamespace DefaultNamespace `json:"defaultNamespace,omitempty"`
 	// Trusted certificate settings.
 	// +optional
@@ -82,6 +84,7 @@ type CheClusterComponents struct {
 	DevWorkspace DevWorkspace `json:"devWorkspace"`
 	// General configuration settings related to the Che server.
 	// +optional
+	// +kubebuilder:default:={logLevel: INFO, debug: false}
 	CheServer CheServer `json:"cheServer"`
 	// Configuration settings related to the plug-in registry used by the Che installation.
 	// +optional
@@ -91,6 +94,7 @@ type CheClusterComponents struct {
 	DevfileRegistry DevfileRegistry `json:"devfileRegistry"`
 	// Configuration settings related to the database used by the Che installation.
 	// +optional
+	// +kubebuilder:default:={externalDb: false, postgresHostName: postgres, postgresPort: "5432", postgresDb: dbche, pvc: {claimSize: "1Gi"}}
 	Database Database `json:"database"`
 	// Configuration settings related to the dashboard used by the Che installation.
 	// +optional
@@ -100,6 +104,7 @@ type CheClusterComponents struct {
 	ImagePuller ImagePuller `json:"imagePuller"`
 	// Che server metrics configuration.
 	// +optional
+	// +kubebuilder:default:={enable: true}
 	Metrics ServerMetrics `json:"metrics"`
 }
 
@@ -133,6 +138,7 @@ type CheClusterSpecNetworking struct {
 	TlsSecretName string `json:"tlsSecretName,omitempty"`
 	// Authentication settings.
 	// +optional
+	// +kubebuilder:default:={gateway: {configLabels: {app: che, component: che-gateway-config}}}
 	Auth Auth `json:"auth"`
 }
 
@@ -163,6 +169,7 @@ type CheServer struct {
 	LogLevel string `json:"logLevel,omitempty"`
 	// Enables the debug mode for Che server.
 	// +optional
+	// +kubebuilder:default:=false
 	Debug *bool `json:"debug,omitempty"`
 	// ClusterRoles assigned to Che ServiceAccount.
 	// The defaults roles are:
@@ -233,6 +240,7 @@ type Database struct {
 	// When `externalDb` is set as `true`, no dedicated database is deployed by the
 	// Operator and you need to provide connection details about the external database you want to use.
 	// +optional
+	// +kubebuilder:default:=false
 	ExternalDb bool `json:"externalDb"`
 	// Deployment override options.
 	// +optional
@@ -254,18 +262,18 @@ type Database struct {
 	// The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database.
 	// The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
 	// +optional
-	// +kubebuilder:default:="postgres-credentials"
 	CredentialsSecretName string `json:"credentialsSecretName,omitempty"`
 	// PVC settings for PostgreSQL database.
 	// +optional
+	// +kubebuilder:default:={claimSize: "1Gi"}
 	Pvc PVC `json:"pvc,omitempty"`
 }
 
 // Che server metrics configuration
 type ServerMetrics struct {
 	// Enables `metrics` for the Che server endpoint.
-	// +kubebuilder:default:=true
 	// +optional
+	// +kubebuilder:default:=true
 	Enable bool `json:"enable"`
 }
 
@@ -281,6 +289,7 @@ type ImagePuller struct {
 	// pre-pulled after installation.
 	// Note that while this Operator and its behavior is community-supported, its payload may be commercially-supported
 	// for pulling commercially-supported images.
+	// +optional
 	Enable bool `json:"enable"`
 	// A Kubernetes Image Puller spec to configure the image puller in the CheCluster.
 	// +optional
@@ -301,8 +310,10 @@ type DevWorkspace struct {
 
 type DefaultNamespace struct {
 	// If you don't create the user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace.
-	// You can use `<username>`, `<userid>` and `<workspaceid>` placeholders, such as che-workspace-<username>.
+	// You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
 	// +optional
+	// +kubebuilder:default:=<username>-che
+	// +kubebuilder:validation:Pattern=<username>|<userid>
 	Template string `json:"template,omitempty"`
 }
 
@@ -333,6 +344,7 @@ type WorkspaceStorage struct {
 	// For details, see https://github.com/eclipse/che/issues/21185.
 	// +optional
 	// +kubebuilder:default:="common"
+	// +kubebuilder:validation:Enum=common;per-workspace
 	PvcStrategy string `json:"pvcStrategy,omitempty"`
 }
 
@@ -346,13 +358,17 @@ type WorkspaceDefaultPlugins struct {
 // Authentication settings.
 type Auth struct {
 	// Public URL of the Identity Provider server.
+	// +optional
 	IdentityProviderURL string `json:"identityProviderURL,omitempty"`
 	// Name of the OpenShift `OAuthClient` resource used to set up identity federation on the OpenShift side.
+	// +optional
 	OAuthClientName string `json:"oAuthClientName,omitempty"`
 	// Name of the secret set in the OpenShift `OAuthClient` resource used to set up identity federation on the OpenShift side.
+	// +optional
 	OAuthSecret string `json:"oAuthSecret,omitempty"`
 	// Gateway settings.
 	// +optional
+	// +kubebuilder:default:={configLabels: {app: che, component: che-gateway-config}}
 	Gateway Gateway `json:"gateway,omitempty"`
 }
 
@@ -366,8 +382,9 @@ type Gateway struct {
 	// - `kube-rbac-proxy`
 	// +optional
 	Deployment Deployment `json:"deployment,omitempty"`
-	// Gate configuration labels.
+	// Gateway configuration labels.
 	// +optional
+	// +kubebuilder:default:={app: che, component: che-gateway-config}
 	ConfigLabels map[string]string `json:"configLabels,omitempty"`
 }
 
@@ -390,6 +407,7 @@ type Proxy struct {
 	// Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration,
 	// defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources.
 	// See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.
+	// +optional
 	NonProxyHosts []string `json:"nonProxyHosts,omitempty"`
 	// The secret name that contains `user` and `password` for a proxy server.
 	// The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.

--- a/api/v2/checluster_types.go
+++ b/api/v2/checluster_types.go
@@ -94,7 +94,7 @@ type CheClusterComponents struct {
 	DevfileRegistry DevfileRegistry `json:"devfileRegistry"`
 	// Configuration settings related to the database used by the Che installation.
 	// +optional
-	// +kubebuilder:default:={externalDb: false, postgresHostName: postgres, postgresPort: "5432", postgresDb: dbche, pvc: {claimSize: "1Gi"}}
+	// +kubebuilder:default:={externalDb: false, credentialsSecretName: postgres-credentials, postgresHostName: postgres, postgresPort: "5432", postgresDb: dbche, pvc: {claimSize: "1Gi"}}
 	Database Database `json:"database"`
 	// Configuration settings related to the dashboard used by the Che installation.
 	// +optional
@@ -262,6 +262,7 @@ type Database struct {
 	// The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database.
 	// The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
 	// +optional
+	// +kubebuilder:default:="postgres-credentials"
 	CredentialsSecretName string `json:"credentialsSecretName,omitempty"`
 	// PVC settings for PostgreSQL database.
 	// +optional

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.50.0-601.next
+  name: eclipse-che-preview-openshift.v7.50.0-606.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1387,7 +1387,7 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.50.0-601.next
+  version: 7.50.0-606.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.50.0-598.next
+  name: eclipse-che-preview-openshift.v7.50.0-601.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1387,7 +1387,7 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.50.0-598.next
+  version: 7.50.0-601.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -55,31 +55,10 @@ metadata:
             "namespace": "eclipse-che"
           },
           "spec": {
-            "components": {
-              "database": {
-                "externalDb": false
-              },
-              "metrics": {
-                "enable": true
-              }
-            },
-            "devEnvironments": {
-              "defaultNamespace": {
-                "template": "<username>-che"
-              },
-              "storage": {
-                "pvcStrategy": "common"
-              }
-            },
-            "networking": {
-              "auth": {
-                "identityProviderURL": "",
-                "oAuthClientName": "",
-                "oAuthSecret": ""
-              },
-              "domain": "",
-              "tlsSecretName": ""
-            }
+            "components": {},
+            "containerRegistry": {},
+            "devEnvironments": {},
+            "networking": {}
           }
         }
       ]
@@ -97,7 +76,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.50.0-568.next
+  name: eclipse-che-preview-openshift.v7.50.0-597.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -150,7 +129,7 @@ spec:
           - description: Che components configuration.
             displayName: Components
             path: components
-          - description: Networking, Che authentication, and TLS configuration.
+          - description: Networking, Che authentication and TLS configuration.
             displayName: Networking
             path: networking
           - description: Configuration of an alternative registry that stores Che
@@ -163,17 +142,17 @@ spec:
             path: chePhase
             x-descriptors:
               - urn:alm:descriptor:text
-          - description: Public URL of the Che server.
+          - description: Public URL to the Che server.
             displayName: Eclipse Che URL
             path: cheURL
             x-descriptors:
               - urn:alm:descriptor:org.w3:link
-          - description: Currently installed Che version.
+          - description: Current installed Che version.
             displayName: 'displayName: Eclipse Che version'
             path: cheVersion
             x-descriptors:
               - urn:alm:descriptor:text
-          - description: The public URL of the internal devfile registry.
+          - description: The public URL to the internal devfile registry.
             displayName: Devfile registry URL
             path: devfileRegistryURL
             x-descriptors:
@@ -184,12 +163,12 @@ spec:
             x-descriptors:
               - urn:alm:descriptor:text
           - description: A human readable message indicating details about why the
-              Che deployment is in the current phase.
+              Che deployment is in current phase.
             displayName: Message
             path: message
             x-descriptors:
               - urn:alm:descriptor:text
-          - description: The public URL of the internal plug-in registry.
+          - description: The public URL to the internal plug-in registry.
             displayName: Plugin registry URL
             path: pluginRegistryURL
             x-descriptors:
@@ -200,7 +179,7 @@ spec:
             x-descriptors:
               - urn:alm:descriptor:text
           - description: A brief CamelCase message indicating details about why the
-              Che deployment is in the current phase.
+              Che deployment is in current phase.
             displayName: Reason
             path: reason
             x-descriptors:
@@ -1408,7 +1387,7 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.50.0-568.next
+  version: 7.50.0-597.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.50.0-597.next
+  name: eclipse-che-preview-openshift.v7.50.0-598.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -129,7 +129,7 @@ spec:
           - description: Che components configuration.
             displayName: Components
             path: components
-          - description: Networking, Che authentication and TLS configuration.
+          - description: Networking, Che authentication, and TLS configuration.
             displayName: Networking
             path: networking
           - description: Configuration of an alternative registry that stores Che
@@ -142,17 +142,17 @@ spec:
             path: chePhase
             x-descriptors:
               - urn:alm:descriptor:text
-          - description: Public URL to the Che server.
+          - description: Public URL of the Che server.
             displayName: Eclipse Che URL
             path: cheURL
             x-descriptors:
               - urn:alm:descriptor:org.w3:link
-          - description: Current installed Che version.
+          - description: Currently installed Che version.
             displayName: 'displayName: Eclipse Che version'
             path: cheVersion
             x-descriptors:
               - urn:alm:descriptor:text
-          - description: The public URL to the internal devfile registry.
+          - description: The public URL of the internal devfile registry.
             displayName: Devfile registry URL
             path: devfileRegistryURL
             x-descriptors:
@@ -163,12 +163,12 @@ spec:
             x-descriptors:
               - urn:alm:descriptor:text
           - description: A human readable message indicating details about why the
-              Che deployment is in current phase.
+              Che deployment is in the current phase.
             displayName: Message
             path: message
             x-descriptors:
               - urn:alm:descriptor:text
-          - description: The public URL to the internal plug-in registry.
+          - description: The public URL of the internal plug-in registry.
             displayName: Plugin registry URL
             path: pluginRegistryURL
             x-descriptors:
@@ -179,7 +179,7 @@ spec:
             x-descriptors:
               - urn:alm:descriptor:text
           - description: A brief CamelCase message indicating details about why the
-              Che deployment is in current phase.
+              Che deployment is in the current phase.
             displayName: Reason
             path: reason
             x-descriptors:
@@ -1387,7 +1387,7 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.50.0-597.next
+  version: 7.50.0-598.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
@@ -1542,6 +1542,7 @@ spec:
                       type: object
                     database:
                       default:
+                        credentialsSecretName: postgres-credentials
                         externalDb: false
                         postgresDb: dbche
                         postgresHostName: postgres
@@ -1552,6 +1553,7 @@ spec:
                         used by the Che installation.
                       properties:
                         credentialsSecretName:
+                          default: postgres-credentials
                           description: The secret that contains PostgreSQL `user`
                             and `password` that the Che server uses to connect to
                             the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org`

--- a/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
@@ -1273,6 +1273,20 @@ spec:
               description: Desired configuration of Eclipse Che installation.
               properties:
                 components:
+                  default:
+                    cheServer:
+                      debug: false
+                      logLevel: INFO
+                    database:
+                      credentialsSecretName: postgres-credentials
+                      externalDb: false
+                      postgresDb: dbche
+                      postgresHostName: postgres
+                      postgresPort: "5432"
+                      pvc:
+                        claimSize: 1Gi
+                    metrics:
+                      enable: true
                   description: Che components configuration.
                   properties:
                     cheServer:
@@ -1314,6 +1328,10 @@ spec:
                                     description: Image pull policy. Default value
                                       is `Always` for `nightly`, `next` or `latest`
                                       images, and `IfNotPresent` in other cases.
+                                    enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
                                     type: string
                                   name:
                                     description: Container name.
@@ -1460,6 +1478,10 @@ spec:
                                     description: Image pull policy. Default value
                                       is `Always` for `nightly`, `next` or `latest`
                                       images, and `IfNotPresent` in other cases.
+                                    enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
                                     type: string
                                   name:
                                     description: Container name.
@@ -1576,6 +1598,10 @@ spec:
                                     description: Image pull policy. Default value
                                       is `Always` for `nightly`, `next` or `latest`
                                       images, and `IfNotPresent` in other cases.
+                                    enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
                                     type: string
                                   name:
                                     description: Container name.
@@ -1708,6 +1734,10 @@ spec:
                                     description: Image pull policy. Default value
                                       is `Always` for `nightly`, `next` or `latest`
                                       images, and `IfNotPresent` in other cases.
+                                    enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
                                     type: string
                                   name:
                                     description: Container name.
@@ -1803,6 +1833,10 @@ spec:
                                     description: Image pull policy. Default value
                                       is `Always` for `nightly`, `next` or `latest`
                                       images, and `IfNotPresent` in other cases.
+                                    enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
                                     type: string
                                   name:
                                     description: Container name.
@@ -1968,6 +2002,10 @@ spec:
                                     description: Image pull policy. Default value
                                       is `Always` for `nightly`, `next` or `latest`
                                       images, and `IfNotPresent` in other cases.
+                                    enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
                                     type: string
                                   name:
                                     description: Container name.
@@ -2072,6 +2110,11 @@ spec:
                       type: string
                   type: object
                 devEnvironments:
+                  default:
+                    defaultNamespace:
+                      template: <username>-che
+                    storage:
+                      pvcStrategy: common
                   description: Development environment default configuration options.
                   properties:
                     defaultNamespace:
@@ -2194,6 +2237,12 @@ spec:
                       type: object
                   type: object
                 networking:
+                  default:
+                    auth:
+                      gateway:
+                        configLabels:
+                          app: che
+                          component: che-gateway-config
                   description: Networking, Che authentication, and TLS configuration.
                   properties:
                     annotations:
@@ -2248,6 +2297,10 @@ spec:
                                         description: Image pull policy. Default value
                                           is `Always` for `nightly`, `next` or `latest`
                                           images, and `IfNotPresent` in other cases.
+                                        enum:
+                                          - Always
+                                          - IfNotPresent
+                                          - Never
                                         type: string
                                       name:
                                         description: Container name.

--- a/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
@@ -1276,6 +1276,9 @@ spec:
                   description: Che components configuration.
                   properties:
                     cheServer:
+                      default:
+                        debug: false
+                        logLevel: INFO
                       description: General configuration settings related to the Che
                         server.
                       properties:
@@ -1291,13 +1294,14 @@ spec:
                             type: string
                           type: array
                         debug:
+                          default: false
                           description: Enables the debug mode for Che server.
                           type: boolean
                         deployment:
                           description: Deployment override options.
                           properties:
-                            containers:
-                              description: List of containers belonging to the pod.
+                            container:
+                              description: A single application container.
                               items:
                                 description: Container custom settings.
                                 properties:
@@ -1319,7 +1323,7 @@ spec:
                                       container.
                                     properties:
                                       limits:
-                                        description: Describes the maximum amount
+                                        description: Limits describe the maximum amount
                                           of compute resources allowed.
                                         properties:
                                           cpu:
@@ -1340,8 +1344,8 @@ spec:
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       request:
-                                        description: Describes the minimum amount
-                                          of compute resources required.
+                                        description: Request describes the minimum
+                                          amount of compute resources required.
                                         properties:
                                           cpu:
                                             anyOf:
@@ -1384,9 +1388,9 @@ spec:
                             type: string
                           description: A map of additional environment variables applied
                             in the generated `che` ConfigMap to be used by the Che
-                            server in addition to the values already generated from
+                            server, in addition to the values already generated from
                             other fields of the `CheCluster` custom resource (CR).
-                            If the `extraProperties` field contains a property normally
+                            If the `extraProperties` fields contains a property normally
                             generated in `che` ConfigMap from other CR fields, the
                             value defined in the `extraProperties` is used instead.
                           type: object
@@ -1411,23 +1415,23 @@ spec:
                                 bypassing the proxy. Specify wild card domain use
                                 the following form `.<DOMAIN>`, for example:    -
                                 localhost    - my.host.com    - 123.42.12.32 Use only
-                                when a proxy configuration is required. The Operator
-                                respects OpenShift cluster-wide proxy configuration,
-                                defining `nonProxyHosts` in a custom resource leads
-                                to merging non-proxy hosts lists from the cluster
-                                proxy configuration, and the ones defined in the custom
-                                resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html.
+                                when a proxy configuration is required. Operator respects
+                                OpenShift cluster-wide proxy configuration, defining
+                                `nonProxyHosts` in a custom resource leads to merging
+                                non-proxy hosts lists from the cluster proxy configuration,
+                                and the ones defined in the custom resources. See
+                                the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html.
                                 See also the `proxyURL` fields.'
                               items:
                                 type: string
                               type: array
                             port:
                               description: Proxy server port.
-                              type: string
+                              type: integer
                             url:
                               description: 'URL (protocol+hostname) of the proxy server.
-                                Use only when a proxy configuration is required. The
-                                Operator respects OpenShift cluster-wide proxy configuration,
+                                Use only when a proxy configuration is required. Operator
+                                respects OpenShift cluster-wide proxy configuration,
                                 defining `url` in a custom resource leads to overriding
                                 the cluster proxy configuration. See the following
                                 page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html.
@@ -1436,14 +1440,14 @@ spec:
                           type: object
                       type: object
                     dashboard:
-                      description: Configuration settings related to the dashboard
+                      description: Configuration settings related to the Dashboard
                         used by the Che installation.
                       properties:
                         deployment:
                           description: Deployment override options.
                           properties:
-                            containers:
-                              description: List of containers belonging to the pod.
+                            container:
+                              description: A single application container.
                               items:
                                 description: Container custom settings.
                                 properties:
@@ -1465,7 +1469,7 @@ spec:
                                       container.
                                     properties:
                                       limits:
-                                        description: Describes the maximum amount
+                                        description: Limits describe the maximum amount
                                           of compute resources allowed.
                                         properties:
                                           cpu:
@@ -1486,8 +1490,8 @@ spec:
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       request:
-                                        description: Describes the minimum amount
-                                          of compute resources required.
+                                        description: Request describes the minimum
+                                          amount of compute resources required.
                                         properties:
                                           cpu:
                                             anyOf:
@@ -1537,21 +1541,27 @@ spec:
                           type: object
                       type: object
                     database:
+                      default:
+                        externalDb: false
+                        postgresDb: dbche
+                        postgresHostName: postgres
+                        postgresPort: "5432"
+                        pvc:
+                          claimSize: 1Gi
                       description: Configuration settings related to the database
                         used by the Che installation.
                       properties:
                         credentialsSecretName:
-                          default: postgres-credentials
                           description: The secret that contains PostgreSQL `user`
                             and `password` that the Che server uses to connect to
-                            the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org`
+                            the DB. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org`
                             label.
                           type: string
                         deployment:
                           description: Deployment override options.
                           properties:
-                            containers:
-                              description: List of containers belonging to the pod.
+                            container:
+                              description: A single application container.
                               items:
                                 description: Container custom settings.
                                 properties:
@@ -1573,7 +1583,7 @@ spec:
                                       container.
                                     properties:
                                       limits:
-                                        description: Describes the maximum amount
+                                        description: Limits describe the maximum amount
                                           of compute resources allowed.
                                         properties:
                                           cpu:
@@ -1594,8 +1604,8 @@ spec:
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       request:
-                                        description: Describes the minimum amount
-                                          of compute resources required.
+                                        description: Request describes the minimum
+                                          amount of compute resources required.
                                         properties:
                                           cpu:
                                             anyOf:
@@ -1634,17 +1644,18 @@ spec:
                               type: object
                           type: object
                         externalDb:
+                          default: false
                           description: Instructs the Operator to deploy a dedicated
                             database. By default, a dedicated PostgreSQL database
                             is deployed as part of the Che installation. When `externalDb`
                             is set as `true`, no dedicated database is deployed by
                             the Operator and you need to provide connection details
-                            about the external database you want to use.
+                            to the external DB you want to use.
                           type: boolean
                         postgresDb:
                           default: dbche
                           description: PostgreSQL database name that the Che server
-                            uses to connect to the database.
+                            uses to connect to the DB.
                           type: string
                         postgresHostName:
                           default: postgres
@@ -1659,12 +1670,14 @@ spec:
                             See field `externalDb`.
                           type: string
                         pvc:
+                          default:
+                            claimSize: 1Gi
                           description: PVC settings for PostgreSQL database.
                           properties:
                             claimSize:
                               description: Persistent Volume Claim size. To update
-                                the claim size, the storage class that provisions
-                                it must support resizing.
+                                the claim size, Storage class that provisions it must
+                                support resize.
                               type: string
                             storageClass:
                               description: Storage class for the Persistent Volume
@@ -1674,13 +1687,13 @@ spec:
                           type: object
                       type: object
                     devWorkspace:
-                      description: DevWorkspace Operator configuration.
+                      description: DevWorkspace operator configuration.
                       properties:
                         deployment:
                           description: Deployment override options.
                           properties:
-                            containers:
-                              description: List of containers belonging to the pod.
+                            container:
+                              description: A single application container.
                               items:
                                 description: Container custom settings.
                                 properties:
@@ -1702,7 +1715,7 @@ spec:
                                       container.
                                     properties:
                                       limits:
-                                        description: Describes the maximum amount
+                                        description: Limits describe the maximum amount
                                           of compute resources allowed.
                                         properties:
                                           cpu:
@@ -1723,8 +1736,8 @@ spec:
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       request:
-                                        description: Describes the minimum amount
-                                          of compute resources required.
+                                        description: Request describes the minimum
+                                          amount of compute resources required.
                                         properties:
                                           cpu:
                                             anyOf:
@@ -1768,14 +1781,14 @@ spec:
                           type: string
                       type: object
                     devfileRegistry:
-                      description: Configuration settings related to the devfile registry
+                      description: Configuration settings related to the Devfile registry
                         used by the Che installation.
                       properties:
                         deployment:
                           description: Deployment override options.
                           properties:
-                            containers:
-                              description: List of containers belonging to the pod.
+                            container:
+                              description: A single application container.
                               items:
                                 description: Container custom settings.
                                 properties:
@@ -1797,7 +1810,7 @@ spec:
                                       container.
                                     properties:
                                       limits:
-                                        description: Describes the maximum amount
+                                        description: Limits describe the maximum amount
                                           of compute resources allowed.
                                         properties:
                                           cpu:
@@ -1818,8 +1831,8 @@ spec:
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       request:
-                                        description: Describes the minimum amount
-                                          of compute resources required.
+                                        description: Request describes the minimum
+                                          amount of compute resources required.
                                         properties:
                                           cpu:
                                             anyOf:
@@ -1891,8 +1904,8 @@ spec:
                             for pulling commercially-supported images.
                           type: boolean
                         spec:
-                          description: A Kubernetes Image Puller spec to configure
-                            the image puller in the CheCluster.
+                          description: A Kubernetes Image Puller spec  to configure
+                            the image puller in the CheCluster
                           properties:
                             affinity:
                               type: string
@@ -1921,10 +1934,10 @@ spec:
                             nodeSelector:
                               type: string
                           type: object
-                      required:
-                        - enable
                       type: object
                     metrics:
+                      default:
+                        enable: true
                       description: Che server metrics configuration.
                       properties:
                         enable:
@@ -1939,8 +1952,8 @@ spec:
                         deployment:
                           description: Deployment override options.
                           properties:
-                            containers:
-                              description: List of containers belonging to the pod.
+                            container:
+                              description: A single application container.
                               items:
                                 description: Container custom settings.
                                 properties:
@@ -1962,7 +1975,7 @@ spec:
                                       container.
                                     properties:
                                       limits:
-                                        description: Describes the maximum amount
+                                        description: Limits describe the maximum amount
                                           of compute resources allowed.
                                         properties:
                                           cpu:
@@ -1983,8 +1996,8 @@ spec:
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       request:
-                                        description: Describes the minimum amount
-                                          of compute resources required.
+                                        description: Request describes the minimum
+                                          amount of compute resources required.
                                         properties:
                                           cpu:
                                             anyOf:
@@ -2060,21 +2073,25 @@ spec:
                   description: Development environment default configuration options.
                   properties:
                     defaultNamespace:
+                      default:
+                        template: <username>-che
                       description: User's default namespace.
                       properties:
                         template:
-                          description: If you don't create the user namespaces in
-                            advance, this field defines the Kubernetes namespace created
-                            when you start your first workspace. You can use `<username>`,
-                            `<userid>` and `<workspaceid>` placeholders, such as che-workspace-<username>.
+                          default: <username>-che
+                          description: If you don't create user namespaces in advance,
+                            this field defines the Kubernetes namespace created when
+                            you start your first workspace. You can use `<username>`
+                            and `<userid>` placeholders, such as che-workspace-<username>.
+                          pattern: <username>|<userid>
                           type: string
                       type: object
                     defaultPlugins:
-                      description: Default plug-ins applied to DevWorkspaces.
+                      description: Default plug-ins applied to Dev Workspaces.
                       items:
                         properties:
                           editor:
-                            description: The editor ID to specify default plug-ins
+                            description: The editor id to specify default plug-ins
                               for.
                             type: string
                           plugins:
@@ -2091,6 +2108,8 @@ spec:
                         the workspace pods.
                       type: object
                     storage:
+                      default:
+                        pvcStrategy: common
                       description: Workspaces persistent storage.
                       properties:
                         pvc:
@@ -2098,8 +2117,8 @@ spec:
                           properties:
                             claimSize:
                               description: Persistent Volume Claim size. To update
-                                the claim size, the storage class that provisions
-                                it must support resizing.
+                                the claim size, Storage class that provisions it must
+                                support resize.
                               type: string
                             storageClass:
                               description: Storage class for the Persistent Volume
@@ -2110,8 +2129,10 @@ spec:
                         pvcStrategy:
                           default: common
                           description: Persistent volume claim strategy for the Che
-                            server. Only the `common` strategy (all workspaces PVCs
-                            in one volume) is supported . For details, see https://github.com/eclipse/che/issues/21185.
+                            server.
+                          enum:
+                            - common
+                            - per-workspace
                           type: string
                       type: object
                     tolerations:
@@ -2170,26 +2191,38 @@ spec:
                       type: object
                   type: object
                 networking:
-                  description: Networking, Che authentication, and TLS configuration.
+                  description: Networking, Che authentication and TLS configuration.
                   properties:
                     annotations:
                       additionalProperties:
                         type: string
-                      description: 'Defines annotations which will be set for an Ingress
+                      description: 'Defines annotations which will be set to an ingress
                         (a route for OpenShift platform). The defaults for kubernetes
                         platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout:
                         "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
                       type: object
                     auth:
+                      default:
+                        gateway:
+                          configLabels:
+                            app: che
+                            component: che-gateway-config
                       description: Authentication settings.
                       properties:
                         gateway:
+                          default:
+                            configLabels:
+                              app: che
+                              component: che-gateway-config
                           description: Gateway settings.
                           properties:
                             configLabels:
                               additionalProperties:
                                 type: string
-                              description: Gate configuration labels.
+                              default:
+                                app: che
+                                component: che-gateway-config
+                              description: Gateway configuration labels.
                               type: object
                             deployment:
                               description: 'Deployment override options. Since gateway
@@ -2197,9 +2230,8 @@ spec:
                                 be distinguished in the configuration by their names:
                                 - `gateway` - `configbump` - `oauth-proxy` - `kube-rbac-proxy`'
                               properties:
-                                containers:
-                                  description: List of containers belonging to the
-                                    pod.
+                                container:
+                                  description: A single application container.
                                   items:
                                     description: Container custom settings.
                                     properties:
@@ -2221,8 +2253,8 @@ spec:
                                           this container.
                                         properties:
                                           limits:
-                                            description: Describes the maximum amount
-                                              of compute resources allowed.
+                                            description: Limits describe the maximum
+                                              amount of compute resources allowed.
                                             properties:
                                               cpu:
                                                 anyOf:
@@ -2242,8 +2274,8 @@ spec:
                                                 x-kubernetes-int-or-string: true
                                             type: object
                                           request:
-                                            description: Describes the minimum amount
-                                              of compute resources required.
+                                            description: Request describes the minimum
+                                              amount of compute resources required.
                                             properties:
                                               cpu:
                                                 anyOf:
@@ -2299,13 +2331,13 @@ spec:
                       type: object
                     domain:
                       description: 'For an OpenShift cluster, the Operator uses the
-                        domain to generate a hostname for the route. The generated
-                        hostname follows this pattern: che-<che-namespace>.<domain>.
-                        The <che-namespace> is the namespace where the CheCluster
-                        CRD is created. In conjunction with labels, it creates a route
-                        served by a non-default Ingress controller. For a Kubernetes
-                        cluster, it contains a global ingress domain. There are no
-                        default values: you must specify them.'
+                        domain to generate a hostname for a route. The generated hostname
+                        follows this pattern: che-<che-namespace>.<domain>. The <che-namespace>
+                        is the namespace where the CheCluster CRD is created. In a
+                        conjunction with labels it creates a route, which is served
+                        by a non-default Ingress controller. For Kubernetes cluster
+                        it contains a global ingress domain. This MUST be explicitly
+                        specified: there are no defaults.'
                       type: string
                     hostname:
                       description: The public hostname of the installed Che server.
@@ -2313,7 +2345,7 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: Defines labels which will be set for an Ingress
+                      description: Defines labels which will be set to an ingress
                         (a route for OpenShift platform).
                       type: object
                     tlsSecretName:
@@ -2325,36 +2357,36 @@ spec:
                   type: object
               type: object
             status:
-              description: Defines the observed state of Che installation.
+              description: CheClusterStatus defines the observed state of Che installation.
               properties:
                 chePhase:
                   description: Specifies the current phase of the Che deployment.
                   type: string
                 cheURL:
-                  description: Public URL of the Che server.
+                  description: Public URL to the Che server.
                   type: string
                 cheVersion:
-                  description: Currently installed Che version.
+                  description: Current installed Che version.
                   type: string
                 devfileRegistryURL:
-                  description: The public URL of the internal devfile registry.
+                  description: The public URL to the internal devfile registry.
                   type: string
                 gatewayPhase:
                   description: Specifies the current phase of the gateway deployment.
                   type: string
                 message:
                   description: A human readable message indicating details about why
-                    the Che deployment is in the current phase.
+                    the Che deployment is in current phase.
                   type: string
                 pluginRegistryURL:
-                  description: The public URL of the internal plug-in registry.
+                  description: The public URL to the internal plug-in registry.
                   type: string
                 postgresVersion:
                   description: The PostgreSQL version of the image in use.
                   type: string
                 reason:
                   description: A brief CamelCase message indicating details about
-                    why the Che deployment is in the current phase.
+                    why the Che deployment is in current phase.
                   type: string
                 workspaceBaseDomain:
                   description: The resolved workspace base domain. This is either

--- a/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
@@ -1300,8 +1300,8 @@ spec:
                         deployment:
                           description: Deployment override options.
                           properties:
-                            container:
-                              description: A single application container.
+                            containers:
+                              description: List of containers belonging to the pod.
                               items:
                                 description: Container custom settings.
                                 properties:
@@ -1323,7 +1323,7 @@ spec:
                                       container.
                                     properties:
                                       limits:
-                                        description: Limits describe the maximum amount
+                                        description: Describes the maximum amount
                                           of compute resources allowed.
                                         properties:
                                           cpu:
@@ -1344,8 +1344,8 @@ spec:
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       request:
-                                        description: Request describes the minimum
-                                          amount of compute resources required.
+                                        description: Describes the minimum amount
+                                          of compute resources required.
                                         properties:
                                           cpu:
                                             anyOf:
@@ -1388,9 +1388,9 @@ spec:
                             type: string
                           description: A map of additional environment variables applied
                             in the generated `che` ConfigMap to be used by the Che
-                            server, in addition to the values already generated from
+                            server in addition to the values already generated from
                             other fields of the `CheCluster` custom resource (CR).
-                            If the `extraProperties` fields contains a property normally
+                            If the `extraProperties` field contains a property normally
                             generated in `che` ConfigMap from other CR fields, the
                             value defined in the `extraProperties` is used instead.
                           type: object
@@ -1415,23 +1415,23 @@ spec:
                                 bypassing the proxy. Specify wild card domain use
                                 the following form `.<DOMAIN>`, for example:    -
                                 localhost    - my.host.com    - 123.42.12.32 Use only
-                                when a proxy configuration is required. Operator respects
-                                OpenShift cluster-wide proxy configuration, defining
-                                `nonProxyHosts` in a custom resource leads to merging
-                                non-proxy hosts lists from the cluster proxy configuration,
-                                and the ones defined in the custom resources. See
-                                the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html.
+                                when a proxy configuration is required. The Operator
+                                respects OpenShift cluster-wide proxy configuration,
+                                defining `nonProxyHosts` in a custom resource leads
+                                to merging non-proxy hosts lists from the cluster
+                                proxy configuration, and the ones defined in the custom
+                                resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html.
                                 See also the `proxyURL` fields.'
                               items:
                                 type: string
                               type: array
                             port:
                               description: Proxy server port.
-                              type: integer
+                              type: string
                             url:
                               description: 'URL (protocol+hostname) of the proxy server.
-                                Use only when a proxy configuration is required. Operator
-                                respects OpenShift cluster-wide proxy configuration,
+                                Use only when a proxy configuration is required. The
+                                Operator respects OpenShift cluster-wide proxy configuration,
                                 defining `url` in a custom resource leads to overriding
                                 the cluster proxy configuration. See the following
                                 page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html.
@@ -1440,14 +1440,14 @@ spec:
                           type: object
                       type: object
                     dashboard:
-                      description: Configuration settings related to the Dashboard
+                      description: Configuration settings related to the dashboard
                         used by the Che installation.
                       properties:
                         deployment:
                           description: Deployment override options.
                           properties:
-                            container:
-                              description: A single application container.
+                            containers:
+                              description: List of containers belonging to the pod.
                               items:
                                 description: Container custom settings.
                                 properties:
@@ -1469,7 +1469,7 @@ spec:
                                       container.
                                     properties:
                                       limits:
-                                        description: Limits describe the maximum amount
+                                        description: Describes the maximum amount
                                           of compute resources allowed.
                                         properties:
                                           cpu:
@@ -1490,8 +1490,8 @@ spec:
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       request:
-                                        description: Request describes the minimum
-                                          amount of compute resources required.
+                                        description: Describes the minimum amount
+                                          of compute resources required.
                                         properties:
                                           cpu:
                                             anyOf:
@@ -1554,14 +1554,14 @@ spec:
                         credentialsSecretName:
                           description: The secret that contains PostgreSQL `user`
                             and `password` that the Che server uses to connect to
-                            the DB. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org`
+                            the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org`
                             label.
                           type: string
                         deployment:
                           description: Deployment override options.
                           properties:
-                            container:
-                              description: A single application container.
+                            containers:
+                              description: List of containers belonging to the pod.
                               items:
                                 description: Container custom settings.
                                 properties:
@@ -1583,7 +1583,7 @@ spec:
                                       container.
                                     properties:
                                       limits:
-                                        description: Limits describe the maximum amount
+                                        description: Describes the maximum amount
                                           of compute resources allowed.
                                         properties:
                                           cpu:
@@ -1604,8 +1604,8 @@ spec:
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       request:
-                                        description: Request describes the minimum
-                                          amount of compute resources required.
+                                        description: Describes the minimum amount
+                                          of compute resources required.
                                         properties:
                                           cpu:
                                             anyOf:
@@ -1650,12 +1650,12 @@ spec:
                             is deployed as part of the Che installation. When `externalDb`
                             is set as `true`, no dedicated database is deployed by
                             the Operator and you need to provide connection details
-                            to the external DB you want to use.
+                            about the external database you want to use.
                           type: boolean
                         postgresDb:
                           default: dbche
                           description: PostgreSQL database name that the Che server
-                            uses to connect to the DB.
+                            uses to connect to the database.
                           type: string
                         postgresHostName:
                           default: postgres
@@ -1676,8 +1676,8 @@ spec:
                           properties:
                             claimSize:
                               description: Persistent Volume Claim size. To update
-                                the claim size, Storage class that provisions it must
-                                support resize.
+                                the claim size, the storage class that provisions
+                                it must support resizing.
                               type: string
                             storageClass:
                               description: Storage class for the Persistent Volume
@@ -1687,13 +1687,13 @@ spec:
                           type: object
                       type: object
                     devWorkspace:
-                      description: DevWorkspace operator configuration.
+                      description: DevWorkspace Operator configuration.
                       properties:
                         deployment:
                           description: Deployment override options.
                           properties:
-                            container:
-                              description: A single application container.
+                            containers:
+                              description: List of containers belonging to the pod.
                               items:
                                 description: Container custom settings.
                                 properties:
@@ -1715,7 +1715,7 @@ spec:
                                       container.
                                     properties:
                                       limits:
-                                        description: Limits describe the maximum amount
+                                        description: Describes the maximum amount
                                           of compute resources allowed.
                                         properties:
                                           cpu:
@@ -1736,8 +1736,8 @@ spec:
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       request:
-                                        description: Request describes the minimum
-                                          amount of compute resources required.
+                                        description: Describes the minimum amount
+                                          of compute resources required.
                                         properties:
                                           cpu:
                                             anyOf:
@@ -1781,14 +1781,14 @@ spec:
                           type: string
                       type: object
                     devfileRegistry:
-                      description: Configuration settings related to the Devfile registry
+                      description: Configuration settings related to the devfile registry
                         used by the Che installation.
                       properties:
                         deployment:
                           description: Deployment override options.
                           properties:
-                            container:
-                              description: A single application container.
+                            containers:
+                              description: List of containers belonging to the pod.
                               items:
                                 description: Container custom settings.
                                 properties:
@@ -1810,7 +1810,7 @@ spec:
                                       container.
                                     properties:
                                       limits:
-                                        description: Limits describe the maximum amount
+                                        description: Describes the maximum amount
                                           of compute resources allowed.
                                         properties:
                                           cpu:
@@ -1831,8 +1831,8 @@ spec:
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       request:
-                                        description: Request describes the minimum
-                                          amount of compute resources required.
+                                        description: Describes the minimum amount
+                                          of compute resources required.
                                         properties:
                                           cpu:
                                             anyOf:
@@ -1904,8 +1904,8 @@ spec:
                             for pulling commercially-supported images.
                           type: boolean
                         spec:
-                          description: A Kubernetes Image Puller spec  to configure
-                            the image puller in the CheCluster
+                          description: A Kubernetes Image Puller spec to configure
+                            the image puller in the CheCluster.
                           properties:
                             affinity:
                               type: string
@@ -1952,8 +1952,8 @@ spec:
                         deployment:
                           description: Deployment override options.
                           properties:
-                            container:
-                              description: A single application container.
+                            containers:
+                              description: List of containers belonging to the pod.
                               items:
                                 description: Container custom settings.
                                 properties:
@@ -1975,7 +1975,7 @@ spec:
                                       container.
                                     properties:
                                       limits:
-                                        description: Limits describe the maximum amount
+                                        description: Describes the maximum amount
                                           of compute resources allowed.
                                         properties:
                                           cpu:
@@ -1996,8 +1996,8 @@ spec:
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       request:
-                                        description: Request describes the minimum
-                                          amount of compute resources required.
+                                        description: Describes the minimum amount
+                                          of compute resources required.
                                         properties:
                                           cpu:
                                             anyOf:
@@ -2079,19 +2079,19 @@ spec:
                       properties:
                         template:
                           default: <username>-che
-                          description: If you don't create user namespaces in advance,
-                            this field defines the Kubernetes namespace created when
-                            you start your first workspace. You can use `<username>`
+                          description: If you don't create the user namespaces in
+                            advance, this field defines the Kubernetes namespace created
+                            when you start your first workspace. You can use `<username>`
                             and `<userid>` placeholders, such as che-workspace-<username>.
                           pattern: <username>|<userid>
                           type: string
                       type: object
                     defaultPlugins:
-                      description: Default plug-ins applied to Dev Workspaces.
+                      description: Default plug-ins applied to DevWorkspaces.
                       items:
                         properties:
                           editor:
-                            description: The editor id to specify default plug-ins
+                            description: The editor ID to specify default plug-ins
                               for.
                             type: string
                           plugins:
@@ -2117,8 +2117,8 @@ spec:
                           properties:
                             claimSize:
                               description: Persistent Volume Claim size. To update
-                                the claim size, Storage class that provisions it must
-                                support resize.
+                                the claim size, the storage class that provisions
+                                it must support resizing.
                               type: string
                             storageClass:
                               description: Storage class for the Persistent Volume
@@ -2129,7 +2129,8 @@ spec:
                         pvcStrategy:
                           default: common
                           description: Persistent volume claim strategy for the Che
-                            server.
+                            server. Only the `common` strategy (all workspaces PVCs
+                            in one volume) is supported . For details, see https://github.com/eclipse/che/issues/21185.
                           enum:
                             - common
                             - per-workspace
@@ -2191,12 +2192,12 @@ spec:
                       type: object
                   type: object
                 networking:
-                  description: Networking, Che authentication and TLS configuration.
+                  description: Networking, Che authentication, and TLS configuration.
                   properties:
                     annotations:
                       additionalProperties:
                         type: string
-                      description: 'Defines annotations which will be set to an ingress
+                      description: 'Defines annotations which will be set for an Ingress
                         (a route for OpenShift platform). The defaults for kubernetes
                         platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout:
                         "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
@@ -2230,8 +2231,9 @@ spec:
                                 be distinguished in the configuration by their names:
                                 - `gateway` - `configbump` - `oauth-proxy` - `kube-rbac-proxy`'
                               properties:
-                                container:
-                                  description: A single application container.
+                                containers:
+                                  description: List of containers belonging to the
+                                    pod.
                                   items:
                                     description: Container custom settings.
                                     properties:
@@ -2253,8 +2255,8 @@ spec:
                                           this container.
                                         properties:
                                           limits:
-                                            description: Limits describe the maximum
-                                              amount of compute resources allowed.
+                                            description: Describes the maximum amount
+                                              of compute resources allowed.
                                             properties:
                                               cpu:
                                                 anyOf:
@@ -2274,8 +2276,8 @@ spec:
                                                 x-kubernetes-int-or-string: true
                                             type: object
                                           request:
-                                            description: Request describes the minimum
-                                              amount of compute resources required.
+                                            description: Describes the minimum amount
+                                              of compute resources required.
                                             properties:
                                               cpu:
                                                 anyOf:
@@ -2331,13 +2333,13 @@ spec:
                       type: object
                     domain:
                       description: 'For an OpenShift cluster, the Operator uses the
-                        domain to generate a hostname for a route. The generated hostname
-                        follows this pattern: che-<che-namespace>.<domain>. The <che-namespace>
-                        is the namespace where the CheCluster CRD is created. In a
-                        conjunction with labels it creates a route, which is served
-                        by a non-default Ingress controller. For Kubernetes cluster
-                        it contains a global ingress domain. This MUST be explicitly
-                        specified: there are no defaults.'
+                        domain to generate a hostname for the route. The generated
+                        hostname follows this pattern: che-<che-namespace>.<domain>.
+                        The <che-namespace> is the namespace where the CheCluster
+                        CRD is created. In conjunction with labels, it creates a route
+                        served by a non-default Ingress controller. For a Kubernetes
+                        cluster, it contains a global ingress domain. There are no
+                        default values: you must specify them.'
                       type: string
                     hostname:
                       description: The public hostname of the installed Che server.
@@ -2345,7 +2347,7 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: Defines labels which will be set to an ingress
+                      description: Defines labels which will be set for an Ingress
                         (a route for OpenShift platform).
                       type: object
                     tlsSecretName:
@@ -2357,36 +2359,36 @@ spec:
                   type: object
               type: object
             status:
-              description: CheClusterStatus defines the observed state of Che installation.
+              description: Defines the observed state of Che installation.
               properties:
                 chePhase:
                   description: Specifies the current phase of the Che deployment.
                   type: string
                 cheURL:
-                  description: Public URL to the Che server.
+                  description: Public URL of the Che server.
                   type: string
                 cheVersion:
-                  description: Current installed Che version.
+                  description: Currently installed Che version.
                   type: string
                 devfileRegistryURL:
-                  description: The public URL to the internal devfile registry.
+                  description: The public URL of the internal devfile registry.
                   type: string
                 gatewayPhase:
                   description: Specifies the current phase of the gateway deployment.
                   type: string
                 message:
                   description: A human readable message indicating details about why
-                    the Che deployment is in current phase.
+                    the Che deployment is in the current phase.
                   type: string
                 pluginRegistryURL:
-                  description: The public URL to the internal plug-in registry.
+                  description: The public URL of the internal plug-in registry.
                   type: string
                 postgresVersion:
                   description: The PostgreSQL version of the image in use.
                   type: string
                 reason:
                   description: A brief CamelCase message indicating details about
-                    why the Che deployment is in current phase.
+                    why the Che deployment is in the current phase.
                   type: string
                 workspaceBaseDomain:
                   description: The resolved workspace base domain. This is either

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -1234,6 +1234,20 @@ spec:
             description: Desired configuration of Eclipse Che installation.
             properties:
               components:
+                default:
+                  cheServer:
+                    debug: false
+                    logLevel: INFO
+                  database:
+                    credentialsSecretName: postgres-credentials
+                    externalDb: false
+                    postgresDb: dbche
+                    postgresHostName: postgres
+                    postgresPort: "5432"
+                    pvc:
+                      claimSize: 1Gi
+                  metrics:
+                    enable: true
                 description: Che components configuration.
                 properties:
                   cheServer:
@@ -1275,6 +1289,10 @@ spec:
                                   description: Image pull policy. Default value is
                                     `Always` for `nightly`, `next` or `latest` images,
                                     and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1419,6 +1437,10 @@ spec:
                                   description: Image pull policy. Default value is
                                     `Always` for `nightly`, `next` or `latest` images,
                                     and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1533,6 +1555,10 @@ spec:
                                   description: Image pull policy. Default value is
                                     `Always` for `nightly`, `next` or `latest` images,
                                     and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1663,6 +1689,10 @@ spec:
                                   description: Image pull policy. Default value is
                                     `Always` for `nightly`, `next` or `latest` images,
                                     and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1756,6 +1786,10 @@ spec:
                                   description: Image pull policy. Default value is
                                     `Always` for `nightly`, `next` or `latest` images,
                                     and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1919,6 +1953,10 @@ spec:
                                   description: Image pull policy. Default value is
                                     `Always` for `nightly`, `next` or `latest` images,
                                     and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -2021,6 +2059,11 @@ spec:
                     type: string
                 type: object
               devEnvironments:
+                default:
+                  defaultNamespace:
+                    template: <username>-che
+                  storage:
+                    pvcStrategy: common
                 description: Development environment default configuration options.
                 properties:
                   defaultNamespace:
@@ -2141,6 +2184,12 @@ spec:
                     type: object
                 type: object
               networking:
+                default:
+                  auth:
+                    gateway:
+                      configLabels:
+                        app: che
+                        component: che-gateway-config
                 description: Networking, Che authentication, and TLS configuration.
                 properties:
                   annotations:
@@ -2194,6 +2243,10 @@ spec:
                                       description: Image pull policy. Default value
                                         is `Always` for `nightly`, `next` or `latest`
                                         images, and `IfNotPresent` in other cases.
+                                      enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
                                       type: string
                                     name:
                                       description: Container name.

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -1499,6 +1499,7 @@ spec:
                     type: object
                   database:
                     default:
+                      credentialsSecretName: postgres-credentials
                       externalDb: false
                       postgresDb: dbche
                       postgresHostName: postgres
@@ -1509,6 +1510,7 @@ spec:
                       by the Che installation.
                     properties:
                       credentialsSecretName:
+                        default: postgres-credentials
                         description: The secret that contains PostgreSQL `user` and
                           `password` that the Che server uses to connect to the database.
                           The secret must have a `app.kubernetes.io/part-of=che.eclipse.org`

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -1261,8 +1261,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1284,8 +1284,8 @@ spec:
                                     container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount
-                                        of compute resources allowed.
+                                      description: Describes the maximum amount of
+                                        compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1304,8 +1304,8 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount
-                                        of compute resources required.
+                                      description: Describes the minimum amount of
+                                        compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1346,10 +1346,10 @@ spec:
                         additionalProperties:
                           type: string
                         description: A map of additional environment variables applied
-                          in the generated `che` ConfigMap to be used by the Che server,
+                          in the generated `che` ConfigMap to be used by the Che server
                           in addition to the values already generated from other fields
                           of the `CheCluster` custom resource (CR). If the `extraProperties`
-                          fields contains a property normally generated in `che` ConfigMap
+                          field contains a property normally generated in `che` ConfigMap
                           from other CR fields, the value defined in the `extraProperties`
                           is used instead.
                         type: object
@@ -1374,7 +1374,7 @@ spec:
                               bypassing the proxy. Specify wild card domain use the
                               following form `.<DOMAIN>`, for example:    - localhost    -
                               my.host.com    - 123.42.12.32 Use only when a proxy
-                              configuration is required. Operator respects OpenShift
+                              configuration is required. The Operator respects OpenShift
                               cluster-wide proxy configuration, defining `nonProxyHosts`
                               in a custom resource leads to merging non-proxy hosts
                               lists from the cluster proxy configuration, and the
@@ -1386,11 +1386,11 @@ spec:
                             type: array
                           port:
                             description: Proxy server port.
-                            type: integer
+                            type: string
                           url:
                             description: 'URL (protocol+hostname) of the proxy server.
-                              Use only when a proxy configuration is required. Operator
-                              respects OpenShift cluster-wide proxy configuration,
+                              Use only when a proxy configuration is required. The
+                              Operator respects OpenShift cluster-wide proxy configuration,
                               defining `url` in a custom resource leads to overriding
                               the cluster proxy configuration. See the following page:
                               https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html.
@@ -1399,14 +1399,14 @@ spec:
                         type: object
                     type: object
                   dashboard:
-                    description: Configuration settings related to the Dashboard used
+                    description: Configuration settings related to the dashboard used
                       by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1428,8 +1428,8 @@ spec:
                                     container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount
-                                        of compute resources allowed.
+                                      description: Describes the maximum amount of
+                                        compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1448,8 +1448,8 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount
-                                        of compute resources required.
+                                      description: Describes the minimum amount of
+                                        compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1510,15 +1510,15 @@ spec:
                     properties:
                       credentialsSecretName:
                         description: The secret that contains PostgreSQL `user` and
-                          `password` that the Che server uses to connect to the DB.
+                          `password` that the Che server uses to connect to the database.
                           The secret must have a `app.kubernetes.io/part-of=che.eclipse.org`
                           label.
                         type: string
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1540,8 +1540,8 @@ spec:
                                     container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount
-                                        of compute resources allowed.
+                                      description: Describes the maximum amount of
+                                        compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1560,8 +1560,8 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount
-                                        of compute resources required.
+                                      description: Describes the minimum amount of
+                                        compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1604,13 +1604,13 @@ spec:
                           database. By default, a dedicated PostgreSQL database is
                           deployed as part of the Che installation. When `externalDb`
                           is set as `true`, no dedicated database is deployed by the
-                          Operator and you need to provide connection details to the
-                          external DB you want to use.
+                          Operator and you need to provide connection details about
+                          the external database you want to use.
                         type: boolean
                       postgresDb:
                         default: dbche
                         description: PostgreSQL database name that the Che server
-                          uses to connect to the DB.
+                          uses to connect to the database.
                         type: string
                       postgresHostName:
                         default: postgres
@@ -1631,8 +1631,8 @@ spec:
                         properties:
                           claimSize:
                             description: Persistent Volume Claim size. To update the
-                              claim size, Storage class that provisions it must support
-                              resize.
+                              claim size, the storage class that provisions it must
+                              support resizing.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim.
@@ -1642,13 +1642,13 @@ spec:
                         type: object
                     type: object
                   devWorkspace:
-                    description: DevWorkspace operator configuration.
+                    description: DevWorkspace Operator configuration.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1670,8 +1670,8 @@ spec:
                                     container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount
-                                        of compute resources allowed.
+                                      description: Describes the maximum amount of
+                                        compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1690,8 +1690,8 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount
-                                        of compute resources required.
+                                      description: Describes the minimum amount of
+                                        compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1734,14 +1734,14 @@ spec:
                         type: string
                     type: object
                   devfileRegistry:
-                    description: Configuration settings related to the Devfile registry
+                    description: Configuration settings related to the devfile registry
                       used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1763,8 +1763,8 @@ spec:
                                     container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount
-                                        of compute resources allowed.
+                                      description: Describes the maximum amount of
+                                        compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1783,8 +1783,8 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount
-                                        of compute resources required.
+                                      description: Describes the minimum amount of
+                                        compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1855,8 +1855,8 @@ spec:
                           images.
                         type: boolean
                       spec:
-                        description: A Kubernetes Image Puller spec  to configure
-                          the image puller in the CheCluster
+                        description: A Kubernetes Image Puller spec to configure the
+                          image puller in the CheCluster.
                         properties:
                           affinity:
                             type: string
@@ -1903,8 +1903,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1926,8 +1926,8 @@ spec:
                                     container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount
-                                        of compute resources allowed.
+                                      description: Describes the maximum amount of
+                                        compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1946,8 +1946,8 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount
-                                        of compute resources required.
+                                      description: Describes the minimum amount of
+                                        compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -2028,7 +2028,7 @@ spec:
                     properties:
                       template:
                         default: <username>-che
-                        description: If you don't create user namespaces in advance,
+                        description: If you don't create the user namespaces in advance,
                           this field defines the Kubernetes namespace created when
                           you start your first workspace. You can use `<username>`
                           and `<userid>` placeholders, such as che-workspace-<username>.
@@ -2036,11 +2036,11 @@ spec:
                         type: string
                     type: object
                   defaultPlugins:
-                    description: Default plug-ins applied to Dev Workspaces.
+                    description: Default plug-ins applied to DevWorkspaces.
                     items:
                       properties:
                         editor:
-                          description: The editor id to specify default plug-ins for.
+                          description: The editor ID to specify default plug-ins for.
                           type: string
                         plugins:
                           description: Default plug-in URIs for the specified editor.
@@ -2065,8 +2065,8 @@ spec:
                         properties:
                           claimSize:
                             description: Persistent Volume Claim size. To update the
-                              claim size, Storage class that provisions it must support
-                              resize.
+                              claim size, the storage class that provisions it must
+                              support resizing.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim.
@@ -2077,7 +2077,8 @@ spec:
                       pvcStrategy:
                         default: common
                         description: Persistent volume claim strategy for the Che
-                          server.
+                          server. Only the `common` strategy (all workspaces PVCs
+                          in one volume) is supported . For details, see https://github.com/eclipse/che/issues/21185.
                         enum:
                         - common
                         - per-workspace
@@ -2138,12 +2139,12 @@ spec:
                     type: object
                 type: object
               networking:
-                description: Networking, Che authentication and TLS configuration.
+                description: Networking, Che authentication, and TLS configuration.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Defines annotations which will be set to an ingress
+                    description: 'Defines annotations which will be set for an Ingress
                       (a route for OpenShift platform). The defaults for kubernetes
                       platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout:
                       "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
@@ -2177,8 +2178,8 @@ spec:
                               be distinguished in the configuration by their names:
                               - `gateway` - `configbump` - `oauth-proxy` - `kube-rbac-proxy`'
                             properties:
-                              container:
-                                description: A single application container.
+                              containers:
+                                description: List of containers belonging to the pod.
                                 items:
                                   description: Container custom settings.
                                   properties:
@@ -2200,8 +2201,8 @@ spec:
                                         container.
                                       properties:
                                         limits:
-                                          description: Limits describe the maximum
-                                            amount of compute resources allowed.
+                                          description: Describes the maximum amount
+                                            of compute resources allowed.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -2221,8 +2222,8 @@ spec:
                                               x-kubernetes-int-or-string: true
                                           type: object
                                         request:
-                                          description: Request describes the minimum
-                                            amount of compute resources required.
+                                          description: Describes the minimum amount
+                                            of compute resources required.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -2277,13 +2278,12 @@ spec:
                     type: object
                   domain:
                     description: 'For an OpenShift cluster, the Operator uses the
-                      domain to generate a hostname for a route. The generated hostname
+                      domain to generate a hostname for the route. The generated hostname
                       follows this pattern: che-<che-namespace>.<domain>. The <che-namespace>
-                      is the namespace where the CheCluster CRD is created. In a conjunction
-                      with labels it creates a route, which is served by a non-default
-                      Ingress controller. For Kubernetes cluster it contains a global
-                      ingress domain. This MUST be explicitly specified: there are
-                      no defaults.'
+                      is the namespace where the CheCluster CRD is created. In conjunction
+                      with labels, it creates a route served by a non-default Ingress
+                      controller. For a Kubernetes cluster, it contains a global ingress
+                      domain. There are no default values: you must specify them.'
                     type: string
                   hostname:
                     description: The public hostname of the installed Che server.
@@ -2291,7 +2291,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: Defines labels which will be set to an ingress (a
+                    description: Defines labels which will be set for an Ingress (a
                       route for OpenShift platform).
                     type: object
                   tlsSecretName:
@@ -2303,36 +2303,36 @@ spec:
                 type: object
             type: object
           status:
-            description: CheClusterStatus defines the observed state of Che installation.
+            description: Defines the observed state of Che installation.
             properties:
               chePhase:
                 description: Specifies the current phase of the Che deployment.
                 type: string
               cheURL:
-                description: Public URL to the Che server.
+                description: Public URL of the Che server.
                 type: string
               cheVersion:
-                description: Current installed Che version.
+                description: Currently installed Che version.
                 type: string
               devfileRegistryURL:
-                description: The public URL to the internal devfile registry.
+                description: The public URL of the internal devfile registry.
                 type: string
               gatewayPhase:
                 description: Specifies the current phase of the gateway deployment.
                 type: string
               message:
                 description: A human readable message indicating details about why
-                  the Che deployment is in current phase.
+                  the Che deployment is in the current phase.
                 type: string
               pluginRegistryURL:
-                description: The public URL to the internal plug-in registry.
+                description: The public URL of the internal plug-in registry.
                 type: string
               postgresVersion:
                 description: The PostgreSQL version of the image in use.
                 type: string
               reason:
                 description: A brief CamelCase message indicating details about why
-                  the Che deployment is in current phase.
+                  the Che deployment is in the current phase.
                 type: string
               workspaceBaseDomain:
                 description: The resolved workspace base domain. This is either the

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -1237,6 +1237,9 @@ spec:
                 description: Che components configuration.
                 properties:
                   cheServer:
+                    default:
+                      debug: false
+                      logLevel: INFO
                     description: General configuration settings related to the Che
                       server.
                     properties:
@@ -1252,13 +1255,14 @@ spec:
                           type: string
                         type: array
                       debug:
+                        default: false
                         description: Enables the debug mode for Che server.
                         type: boolean
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1280,8 +1284,8 @@ spec:
                                     container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of
-                                        compute resources allowed.
+                                      description: Limits describe the maximum amount
+                                        of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1300,8 +1304,8 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of
-                                        compute resources required.
+                                      description: Request describes the minimum amount
+                                        of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1342,10 +1346,10 @@ spec:
                         additionalProperties:
                           type: string
                         description: A map of additional environment variables applied
-                          in the generated `che` ConfigMap to be used by the Che server
+                          in the generated `che` ConfigMap to be used by the Che server,
                           in addition to the values already generated from other fields
                           of the `CheCluster` custom resource (CR). If the `extraProperties`
-                          field contains a property normally generated in `che` ConfigMap
+                          fields contains a property normally generated in `che` ConfigMap
                           from other CR fields, the value defined in the `extraProperties`
                           is used instead.
                         type: object
@@ -1370,7 +1374,7 @@ spec:
                               bypassing the proxy. Specify wild card domain use the
                               following form `.<DOMAIN>`, for example:    - localhost    -
                               my.host.com    - 123.42.12.32 Use only when a proxy
-                              configuration is required. The Operator respects OpenShift
+                              configuration is required. Operator respects OpenShift
                               cluster-wide proxy configuration, defining `nonProxyHosts`
                               in a custom resource leads to merging non-proxy hosts
                               lists from the cluster proxy configuration, and the
@@ -1382,11 +1386,11 @@ spec:
                             type: array
                           port:
                             description: Proxy server port.
-                            type: string
+                            type: integer
                           url:
                             description: 'URL (protocol+hostname) of the proxy server.
-                              Use only when a proxy configuration is required. The
-                              Operator respects OpenShift cluster-wide proxy configuration,
+                              Use only when a proxy configuration is required. Operator
+                              respects OpenShift cluster-wide proxy configuration,
                               defining `url` in a custom resource leads to overriding
                               the cluster proxy configuration. See the following page:
                               https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html.
@@ -1395,14 +1399,14 @@ spec:
                         type: object
                     type: object
                   dashboard:
-                    description: Configuration settings related to the dashboard used
+                    description: Configuration settings related to the Dashboard used
                       by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1424,8 +1428,8 @@ spec:
                                     container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of
-                                        compute resources allowed.
+                                      description: Limits describe the maximum amount
+                                        of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1444,8 +1448,8 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of
-                                        compute resources required.
+                                      description: Request describes the minimum amount
+                                        of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1494,21 +1498,27 @@ spec:
                         type: object
                     type: object
                   database:
+                    default:
+                      externalDb: false
+                      postgresDb: dbche
+                      postgresHostName: postgres
+                      postgresPort: "5432"
+                      pvc:
+                        claimSize: 1Gi
                     description: Configuration settings related to the database used
                       by the Che installation.
                     properties:
                       credentialsSecretName:
-                        default: postgres-credentials
                         description: The secret that contains PostgreSQL `user` and
-                          `password` that the Che server uses to connect to the database.
+                          `password` that the Che server uses to connect to the DB.
                           The secret must have a `app.kubernetes.io/part-of=che.eclipse.org`
                           label.
                         type: string
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1530,8 +1540,8 @@ spec:
                                     container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of
-                                        compute resources allowed.
+                                      description: Limits describe the maximum amount
+                                        of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1550,8 +1560,8 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of
-                                        compute resources required.
+                                      description: Request describes the minimum amount
+                                        of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1589,17 +1599,18 @@ spec:
                             type: object
                         type: object
                       externalDb:
+                        default: false
                         description: Instructs the Operator to deploy a dedicated
                           database. By default, a dedicated PostgreSQL database is
                           deployed as part of the Che installation. When `externalDb`
                           is set as `true`, no dedicated database is deployed by the
-                          Operator and you need to provide connection details about
-                          the external database you want to use.
+                          Operator and you need to provide connection details to the
+                          external DB you want to use.
                         type: boolean
                       postgresDb:
                         default: dbche
                         description: PostgreSQL database name that the Che server
-                          uses to connect to the database.
+                          uses to connect to the DB.
                         type: string
                       postgresHostName:
                         default: postgres
@@ -1614,12 +1625,14 @@ spec:
                           See field `externalDb`.
                         type: string
                       pvc:
+                        default:
+                          claimSize: 1Gi
                         description: PVC settings for PostgreSQL database.
                         properties:
                           claimSize:
                             description: Persistent Volume Claim size. To update the
-                              claim size, the storage class that provisions it must
-                              support resizing.
+                              claim size, Storage class that provisions it must support
+                              resize.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim.
@@ -1629,13 +1642,13 @@ spec:
                         type: object
                     type: object
                   devWorkspace:
-                    description: DevWorkspace Operator configuration.
+                    description: DevWorkspace operator configuration.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1657,8 +1670,8 @@ spec:
                                     container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of
-                                        compute resources allowed.
+                                      description: Limits describe the maximum amount
+                                        of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1677,8 +1690,8 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of
-                                        compute resources required.
+                                      description: Request describes the minimum amount
+                                        of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1721,14 +1734,14 @@ spec:
                         type: string
                     type: object
                   devfileRegistry:
-                    description: Configuration settings related to the devfile registry
+                    description: Configuration settings related to the Devfile registry
                       used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1750,8 +1763,8 @@ spec:
                                     container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of
-                                        compute resources allowed.
+                                      description: Limits describe the maximum amount
+                                        of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1770,8 +1783,8 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of
-                                        compute resources required.
+                                      description: Request describes the minimum amount
+                                        of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1842,8 +1855,8 @@ spec:
                           images.
                         type: boolean
                       spec:
-                        description: A Kubernetes Image Puller spec to configure the
-                          image puller in the CheCluster.
+                        description: A Kubernetes Image Puller spec  to configure
+                          the image puller in the CheCluster
                         properties:
                           affinity:
                             type: string
@@ -1872,10 +1885,10 @@ spec:
                           nodeSelector:
                             type: string
                         type: object
-                    required:
-                    - enable
                     type: object
                   metrics:
+                    default:
+                      enable: true
                     description: Che server metrics configuration.
                     properties:
                       enable:
@@ -1890,8 +1903,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1913,8 +1926,8 @@ spec:
                                     container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of
-                                        compute resources allowed.
+                                      description: Limits describe the maximum amount
+                                        of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1933,8 +1946,8 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of
-                                        compute resources required.
+                                      description: Request describes the minimum amount
+                                        of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -2009,21 +2022,25 @@ spec:
                 description: Development environment default configuration options.
                 properties:
                   defaultNamespace:
+                    default:
+                      template: <username>-che
                     description: User's default namespace.
                     properties:
                       template:
-                        description: If you don't create the user namespaces in advance,
+                        default: <username>-che
+                        description: If you don't create user namespaces in advance,
                           this field defines the Kubernetes namespace created when
-                          you start your first workspace. You can use `<username>`,
-                          `<userid>` and `<workspaceid>` placeholders, such as che-workspace-<username>.
+                          you start your first workspace. You can use `<username>`
+                          and `<userid>` placeholders, such as che-workspace-<username>.
+                        pattern: <username>|<userid>
                         type: string
                     type: object
                   defaultPlugins:
-                    description: Default plug-ins applied to DevWorkspaces.
+                    description: Default plug-ins applied to Dev Workspaces.
                     items:
                       properties:
                         editor:
-                          description: The editor ID to specify default plug-ins for.
+                          description: The editor id to specify default plug-ins for.
                           type: string
                         plugins:
                           description: Default plug-in URIs for the specified editor.
@@ -2039,6 +2056,8 @@ spec:
                       workspace pods.
                     type: object
                   storage:
+                    default:
+                      pvcStrategy: common
                     description: Workspaces persistent storage.
                     properties:
                       pvc:
@@ -2046,8 +2065,8 @@ spec:
                         properties:
                           claimSize:
                             description: Persistent Volume Claim size. To update the
-                              claim size, the storage class that provisions it must
-                              support resizing.
+                              claim size, Storage class that provisions it must support
+                              resize.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim.
@@ -2058,8 +2077,10 @@ spec:
                       pvcStrategy:
                         default: common
                         description: Persistent volume claim strategy for the Che
-                          server. Only the `common` strategy (all workspaces PVCs
-                          in one volume) is supported . For details, see https://github.com/eclipse/che/issues/21185.
+                          server.
+                        enum:
+                        - common
+                        - per-workspace
                         type: string
                     type: object
                   tolerations:
@@ -2117,26 +2138,38 @@ spec:
                     type: object
                 type: object
               networking:
-                description: Networking, Che authentication, and TLS configuration.
+                description: Networking, Che authentication and TLS configuration.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Defines annotations which will be set for an Ingress
+                    description: 'Defines annotations which will be set to an ingress
                       (a route for OpenShift platform). The defaults for kubernetes
                       platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout:
                       "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
                     type: object
                   auth:
+                    default:
+                      gateway:
+                        configLabels:
+                          app: che
+                          component: che-gateway-config
                     description: Authentication settings.
                     properties:
                       gateway:
+                        default:
+                          configLabels:
+                            app: che
+                            component: che-gateway-config
                         description: Gateway settings.
                         properties:
                           configLabels:
                             additionalProperties:
                               type: string
-                            description: Gate configuration labels.
+                            default:
+                              app: che
+                              component: che-gateway-config
+                            description: Gateway configuration labels.
                             type: object
                           deployment:
                             description: 'Deployment override options. Since gateway
@@ -2144,8 +2177,8 @@ spec:
                               be distinguished in the configuration by their names:
                               - `gateway` - `configbump` - `oauth-proxy` - `kube-rbac-proxy`'
                             properties:
-                              containers:
-                                description: List of containers belonging to the pod.
+                              container:
+                                description: A single application container.
                                 items:
                                   description: Container custom settings.
                                   properties:
@@ -2167,8 +2200,8 @@ spec:
                                         container.
                                       properties:
                                         limits:
-                                          description: Describes the maximum amount
-                                            of compute resources allowed.
+                                          description: Limits describe the maximum
+                                            amount of compute resources allowed.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -2188,8 +2221,8 @@ spec:
                                               x-kubernetes-int-or-string: true
                                           type: object
                                         request:
-                                          description: Describes the minimum amount
-                                            of compute resources required.
+                                          description: Request describes the minimum
+                                            amount of compute resources required.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -2244,12 +2277,13 @@ spec:
                     type: object
                   domain:
                     description: 'For an OpenShift cluster, the Operator uses the
-                      domain to generate a hostname for the route. The generated hostname
+                      domain to generate a hostname for a route. The generated hostname
                       follows this pattern: che-<che-namespace>.<domain>. The <che-namespace>
-                      is the namespace where the CheCluster CRD is created. In conjunction
-                      with labels, it creates a route served by a non-default Ingress
-                      controller. For a Kubernetes cluster, it contains a global ingress
-                      domain. There are no default values: you must specify them.'
+                      is the namespace where the CheCluster CRD is created. In a conjunction
+                      with labels it creates a route, which is served by a non-default
+                      Ingress controller. For Kubernetes cluster it contains a global
+                      ingress domain. This MUST be explicitly specified: there are
+                      no defaults.'
                     type: string
                   hostname:
                     description: The public hostname of the installed Che server.
@@ -2257,7 +2291,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: Defines labels which will be set for an Ingress (a
+                    description: Defines labels which will be set to an ingress (a
                       route for OpenShift platform).
                     type: object
                   tlsSecretName:
@@ -2269,36 +2303,36 @@ spec:
                 type: object
             type: object
           status:
-            description: Defines the observed state of Che installation.
+            description: CheClusterStatus defines the observed state of Che installation.
             properties:
               chePhase:
                 description: Specifies the current phase of the Che deployment.
                 type: string
               cheURL:
-                description: Public URL of the Che server.
+                description: Public URL to the Che server.
                 type: string
               cheVersion:
-                description: Currently installed Che version.
+                description: Current installed Che version.
                 type: string
               devfileRegistryURL:
-                description: The public URL of the internal devfile registry.
+                description: The public URL to the internal devfile registry.
                 type: string
               gatewayPhase:
                 description: Specifies the current phase of the gateway deployment.
                 type: string
               message:
                 description: A human readable message indicating details about why
-                  the Che deployment is in the current phase.
+                  the Che deployment is in current phase.
                 type: string
               pluginRegistryURL:
-                description: The public URL of the internal plug-in registry.
+                description: The public URL to the internal plug-in registry.
                 type: string
               postgresVersion:
                 description: The PostgreSQL version of the image in use.
                 type: string
               reason:
                 description: A brief CamelCase message indicating details about why
-                  the Che deployment is in the current phase.
+                  the Che deployment is in current phase.
                 type: string
               workspaceBaseDomain:
                 description: The resolved workspace base domain. This is either the

--- a/config/samples/org_v2_checluster.yaml
+++ b/config/samples/org_v2_checluster.yaml
@@ -16,20 +16,7 @@ metadata:
   name: eclipse-che
   namespace: eclipse-che
 spec:
-  devEnvironments:
-    defaultNamespace:
-      template: '<username>-che'
-    storage:
-      pvcStrategy: 'common'
-  components:
-    database:
-      externalDb: false
-    metrics:
-      enable: true
-  networking:
-    domain: ''
-    tlsSecretName: ''
-    auth:
-      identityProviderURL: ''
-      oAuthClientName: ''
-      oAuthSecret: ''
+  components: {}
+  devEnvironments: {}
+  networking: {}
+  containerRegistry: {}

--- a/controllers/che/checluster_validator.go
+++ b/controllers/che/checluster_validator.go
@@ -14,7 +14,6 @@ package che
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 	"github.com/eclipse-che/che-operator/pkg/common/chetypes"
@@ -22,15 +21,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const (
-	NamespaceStrategyErrorMessage = "Namespace strategies other than 'per user' is not supported anymore. Using the <username> or <userid> placeholder is required in the 'spec.server.workspaceNamespaceDefault' field. The current value is: %s"
-)
-
 // CheClusterValidator checks CheCluster CR configuration.
-// It detect:
+// It detects:
 // - configurations which miss required field(s) to deploy Che
-// - self-contradictory configurations
-// - configurations with which it is impossible to deploy Che
 type CheClusterValidator struct {
 	deploy.Reconcilable
 }
@@ -44,11 +37,6 @@ func (v *CheClusterValidator) Reconcile(ctx *chetypes.DeployContext) (reconcile.
 		if ctx.CheCluster.Spec.Networking.Domain == "" {
 			return reconcile.Result{}, false, fmt.Errorf("Required field \"spec.networking.domain\" is not set")
 		}
-	}
-
-	workspaceNamespaceDefault := ctx.CheCluster.GetDefaultNamespace()
-	if strings.Index(workspaceNamespaceDefault, "<username>") == -1 && strings.Index(workspaceNamespaceDefault, "<userid>") == -1 {
-		return reconcile.Result{}, false, fmt.Errorf(NamespaceStrategyErrorMessage, workspaceNamespaceDefault)
 	}
 
 	return reconcile.Result{}, true, nil

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -994,6 +994,7 @@ spec:
                     type: object
                   database:
                     default:
+                      credentialsSecretName: postgres-credentials
                       externalDb: false
                       postgresDb: dbche
                       postgresHostName: postgres
@@ -1003,6 +1004,7 @@ spec:
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
+                        default: postgres-credentials
                         description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -789,6 +789,20 @@ spec:
             description: Desired configuration of Eclipse Che installation.
             properties:
               components:
+                default:
+                  cheServer:
+                    debug: false
+                    logLevel: INFO
+                  database:
+                    credentialsSecretName: postgres-credentials
+                    externalDb: false
+                    postgresDb: dbche
+                    postgresHostName: postgres
+                    postgresPort: "5432"
+                    pvc:
+                      claimSize: 1Gi
+                  metrics:
+                    enable: true
                 description: Che components configuration.
                 properties:
                   cheServer:
@@ -819,6 +833,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -922,6 +940,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1020,6 +1042,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1124,6 +1150,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1203,6 +1233,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1339,6 +1373,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1424,6 +1462,11 @@ spec:
                     type: string
                 type: object
               devEnvironments:
+                default:
+                  defaultNamespace:
+                    template: <username>-che
+                  storage:
+                    pvcStrategy: common
                 description: Development environment default configuration options.
                 properties:
                   defaultNamespace:
@@ -1511,6 +1554,12 @@ spec:
                     type: object
                 type: object
               networking:
+                default:
+                  auth:
+                    gateway:
+                      configLabels:
+                        app: che
+                        component: che-gateway-config
                 description: Networking, Che authentication, and TLS configuration.
                 properties:
                   annotations:
@@ -1554,6 +1603,10 @@ spec:
                                       type: string
                                     imagePullPolicy:
                                       description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                      enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
                                       type: string
                                     name:
                                       description: Container name.

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -809,8 +809,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -827,7 +827,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -845,7 +845,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -881,7 +881,7 @@ spec:
                       extraProperties:
                         additionalProperties:
                           type: string
-                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server, in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` fields contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
+                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` field contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
                         type: object
                       logLevel:
                         default: INFO
@@ -894,26 +894,26 @@ spec:
                             description: The secret name that contains `user` and `password` for a proxy server. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                             type: string
                           nonProxyHosts:
-                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
+                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
                             items:
                               type: string
                             type: array
                           port:
                             description: Proxy server port.
-                            type: integer
+                            type: string
                           url:
-                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
+                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
                             type: string
                         type: object
                     type: object
                   dashboard:
-                    description: Configuration settings related to the Dashboard used by the Che installation.
+                    description: Configuration settings related to the dashboard used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -930,7 +930,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -948,7 +948,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1003,13 +1003,13 @@ spec:
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
-                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the DB. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
+                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1026,7 +1026,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1044,7 +1044,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1079,11 +1079,11 @@ spec:
                         type: object
                       externalDb:
                         default: false
-                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details to the external DB you want to use.
+                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details about the external database you want to use.
                         type: boolean
                       postgresDb:
                         default: dbche
-                        description: PostgreSQL database name that the Che server uses to connect to the DB.
+                        description: PostgreSQL database name that the Che server uses to connect to the database.
                         type: string
                       postgresHostName:
                         default: postgres
@@ -1099,7 +1099,7 @@ spec:
                         description: PVC settings for PostgreSQL database.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
+                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1107,13 +1107,13 @@ spec:
                         type: object
                     type: object
                   devWorkspace:
-                    description: DevWorkspace operator configuration.
+                    description: DevWorkspace Operator configuration.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1130,7 +1130,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1148,7 +1148,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1186,13 +1186,13 @@ spec:
                         type: string
                     type: object
                   devfileRegistry:
-                    description: Configuration settings related to the Devfile registry used by the Che installation.
+                    description: Configuration settings related to the devfile registry used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1209,7 +1209,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1227,7 +1227,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1281,7 +1281,7 @@ spec:
                         description: Install and configure the community supported Kubernetes Image Puller Operator. When you set the value to `true` without providing any specs, it creates a default Kubernetes Image Puller object managed by the Operator. When you set the value to `false`, the Kubernetes Image Puller object is deleted, and the Operator uninstalled, regardless of whether a spec is provided. If you leave the `spec.images` field empty, a set of recommended workspace-related images is automatically detected and pre-pulled after installation. Note that while this Operator and its behavior is community-supported, its payload may be commercially-supported for pulling commercially-supported images.
                         type: boolean
                       spec:
-                        description: A Kubernetes Image Puller spec  to configure the image puller in the CheCluster
+                        description: A Kubernetes Image Puller spec to configure the image puller in the CheCluster.
                         properties:
                           affinity:
                             type: string
@@ -1327,8 +1327,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1345,7 +1345,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1363,7 +1363,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1431,16 +1431,16 @@ spec:
                     properties:
                       template:
                         default: <username>-che
-                        description: If you don't create user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
+                        description: If you don't create the user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
                         pattern: <username>|<userid>
                         type: string
                     type: object
                   defaultPlugins:
-                    description: Default plug-ins applied to Dev Workspaces.
+                    description: Default plug-ins applied to DevWorkspaces.
                     items:
                       properties:
                         editor:
-                          description: The editor id to specify default plug-ins for.
+                          description: The editor ID to specify default plug-ins for.
                           type: string
                         plugins:
                           description: Default plug-in URIs for the specified editor.
@@ -1463,7 +1463,7 @@ spec:
                         description: PVC settings.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
+                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1471,7 +1471,7 @@ spec:
                         type: object
                       pvcStrategy:
                         default: common
-                        description: Persistent volume claim strategy for the Che server.
+                        description: Persistent volume claim strategy for the Che server. Only the `common` strategy (all workspaces PVCs in one volume) is supported . For details, see https://github.com/eclipse/che/issues/21185.
                         enum:
                         - common
                         - per-workspace
@@ -1509,12 +1509,12 @@ spec:
                     type: object
                 type: object
               networking:
-                description: Networking, Che authentication and TLS configuration.
+                description: Networking, Che authentication, and TLS configuration.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Defines annotations which will be set to an ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
+                    description: 'Defines annotations which will be set for an Ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
                     type: object
                   auth:
                     default:
@@ -1542,8 +1542,8 @@ spec:
                           deployment:
                             description: 'Deployment override options. Since gateway deployment consists of several containers, they must be distinguished in the configuration by their names: - `gateway` - `configbump` - `oauth-proxy` - `kube-rbac-proxy`'
                             properties:
-                              container:
-                                description: A single application container.
+                              containers:
+                                description: List of containers belonging to the pod.
                                 items:
                                   description: Container custom settings.
                                   properties:
@@ -1560,7 +1560,7 @@ spec:
                                       description: Compute resources required by this container.
                                       properties:
                                         limits:
-                                          description: Limits describe the maximum amount of compute resources allowed.
+                                          description: Describes the maximum amount of compute resources allowed.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1578,7 +1578,7 @@ spec:
                                               x-kubernetes-int-or-string: true
                                           type: object
                                         request:
-                                          description: Request describes the minimum amount of compute resources required.
+                                          description: Describes the minimum amount of compute resources required.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1623,7 +1623,7 @@ spec:
                         type: string
                     type: object
                   domain:
-                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for a route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In a conjunction with labels it creates a route, which is served by a non-default Ingress controller. For Kubernetes cluster it contains a global ingress domain. This MUST be explicitly specified: there are no defaults.'
+                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for the route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In conjunction with labels, it creates a route served by a non-default Ingress controller. For a Kubernetes cluster, it contains a global ingress domain. There are no default values: you must specify them.'
                     type: string
                   hostname:
                     description: The public hostname of the installed Che server.
@@ -1631,7 +1631,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: Defines labels which will be set to an ingress (a route for OpenShift platform).
+                    description: Defines labels which will be set for an Ingress (a route for OpenShift platform).
                     type: object
                   tlsSecretName:
                     description: The name of the secret used to set up Ingress TLS termination. If the field is an empty string, the default cluster certificate is used. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
@@ -1639,34 +1639,34 @@ spec:
                 type: object
             type: object
           status:
-            description: CheClusterStatus defines the observed state of Che installation.
+            description: Defines the observed state of Che installation.
             properties:
               chePhase:
                 description: Specifies the current phase of the Che deployment.
                 type: string
               cheURL:
-                description: Public URL to the Che server.
+                description: Public URL of the Che server.
                 type: string
               cheVersion:
-                description: Current installed Che version.
+                description: Currently installed Che version.
                 type: string
               devfileRegistryURL:
-                description: The public URL to the internal devfile registry.
+                description: The public URL of the internal devfile registry.
                 type: string
               gatewayPhase:
                 description: Specifies the current phase of the gateway deployment.
                 type: string
               message:
-                description: A human readable message indicating details about why the Che deployment is in current phase.
+                description: A human readable message indicating details about why the Che deployment is in the current phase.
                 type: string
               pluginRegistryURL:
-                description: The public URL to the internal plug-in registry.
+                description: The public URL of the internal plug-in registry.
                 type: string
               postgresVersion:
                 description: The PostgreSQL version of the image in use.
                 type: string
               reason:
-                description: A brief CamelCase message indicating details about why the Che deployment is in current phase.
+                description: A brief CamelCase message indicating details about why the Che deployment is in the current phase.
                 type: string
               workspaceBaseDomain:
                 description: The resolved workspace base domain. This is either the copy of the explicitly defined property of the same name in the spec or, if it is undefined in the spec and we're running on OpenShift, the automatically resolved basedomain for routes.

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -792,6 +792,9 @@ spec:
                 description: Che components configuration.
                 properties:
                   cheServer:
+                    default:
+                      debug: false
+                      logLevel: INFO
                     description: General configuration settings related to the Che server.
                     properties:
                       clusterRoles:
@@ -800,13 +803,14 @@ spec:
                           type: string
                         type: array
                       debug:
+                        default: false
                         description: Enables the debug mode for Che server.
                         type: boolean
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -823,7 +827,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -841,7 +845,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -877,7 +881,7 @@ spec:
                       extraProperties:
                         additionalProperties:
                           type: string
-                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` field contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
+                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server, in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` fields contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
                         type: object
                       logLevel:
                         default: INFO
@@ -890,26 +894,26 @@ spec:
                             description: The secret name that contains `user` and `password` for a proxy server. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                             type: string
                           nonProxyHosts:
-                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
+                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
                             items:
                               type: string
                             type: array
                           port:
                             description: Proxy server port.
-                            type: string
+                            type: integer
                           url:
-                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
+                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
                             type: string
                         type: object
                     type: object
                   dashboard:
-                    description: Configuration settings related to the dashboard used by the Che installation.
+                    description: Configuration settings related to the Dashboard used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -926,7 +930,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -944,7 +948,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -989,17 +993,23 @@ spec:
                         type: object
                     type: object
                   database:
+                    default:
+                      externalDb: false
+                      postgresDb: dbche
+                      postgresHostName: postgres
+                      postgresPort: "5432"
+                      pvc:
+                        claimSize: 1Gi
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
-                        default: postgres-credentials
-                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
+                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the DB. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1016,7 +1026,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1034,7 +1044,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1068,11 +1078,12 @@ spec:
                             type: object
                         type: object
                       externalDb:
-                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details about the external database you want to use.
+                        default: false
+                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details to the external DB you want to use.
                         type: boolean
                       postgresDb:
                         default: dbche
-                        description: PostgreSQL database name that the Che server uses to connect to the database.
+                        description: PostgreSQL database name that the Che server uses to connect to the DB.
                         type: string
                       postgresHostName:
                         default: postgres
@@ -1083,10 +1094,12 @@ spec:
                         description: PostgreSQL Database port the Che server connects to. Override this value only when using an external database. See field `externalDb`.
                         type: string
                       pvc:
+                        default:
+                          claimSize: 1Gi
                         description: PVC settings for PostgreSQL database.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
+                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1094,13 +1107,13 @@ spec:
                         type: object
                     type: object
                   devWorkspace:
-                    description: DevWorkspace Operator configuration.
+                    description: DevWorkspace operator configuration.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1117,7 +1130,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1135,7 +1148,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1173,13 +1186,13 @@ spec:
                         type: string
                     type: object
                   devfileRegistry:
-                    description: Configuration settings related to the devfile registry used by the Che installation.
+                    description: Configuration settings related to the Devfile registry used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1196,7 +1209,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1214,7 +1227,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1268,7 +1281,7 @@ spec:
                         description: Install and configure the community supported Kubernetes Image Puller Operator. When you set the value to `true` without providing any specs, it creates a default Kubernetes Image Puller object managed by the Operator. When you set the value to `false`, the Kubernetes Image Puller object is deleted, and the Operator uninstalled, regardless of whether a spec is provided. If you leave the `spec.images` field empty, a set of recommended workspace-related images is automatically detected and pre-pulled after installation. Note that while this Operator and its behavior is community-supported, its payload may be commercially-supported for pulling commercially-supported images.
                         type: boolean
                       spec:
-                        description: A Kubernetes Image Puller spec to configure the image puller in the CheCluster.
+                        description: A Kubernetes Image Puller spec  to configure the image puller in the CheCluster
                         properties:
                           affinity:
                             type: string
@@ -1297,10 +1310,10 @@ spec:
                           nodeSelector:
                             type: string
                         type: object
-                    required:
-                    - enable
                     type: object
                   metrics:
+                    default:
+                      enable: true
                     description: Che server metrics configuration.
                     properties:
                       enable:
@@ -1314,8 +1327,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1332,7 +1345,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1350,7 +1363,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1412,18 +1425,22 @@ spec:
                 description: Development environment default configuration options.
                 properties:
                   defaultNamespace:
+                    default:
+                      template: <username>-che
                     description: User's default namespace.
                     properties:
                       template:
-                        description: If you don't create the user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>`, `<userid>` and `<workspaceid>` placeholders, such as che-workspace-<username>.
+                        default: <username>-che
+                        description: If you don't create user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
+                        pattern: <username>|<userid>
                         type: string
                     type: object
                   defaultPlugins:
-                    description: Default plug-ins applied to DevWorkspaces.
+                    description: Default plug-ins applied to Dev Workspaces.
                     items:
                       properties:
                         editor:
-                          description: The editor ID to specify default plug-ins for.
+                          description: The editor id to specify default plug-ins for.
                           type: string
                         plugins:
                           description: Default plug-in URIs for the specified editor.
@@ -1438,13 +1455,15 @@ spec:
                     description: The node selector limits the nodes that can run the workspace pods.
                     type: object
                   storage:
+                    default:
+                      pvcStrategy: common
                     description: Workspaces persistent storage.
                     properties:
                       pvc:
                         description: PVC settings.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
+                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1452,7 +1471,10 @@ spec:
                         type: object
                       pvcStrategy:
                         default: common
-                        description: Persistent volume claim strategy for the Che server. Only the `common` strategy (all workspaces PVCs in one volume) is supported . For details, see https://github.com/eclipse/che/issues/21185.
+                        description: Persistent volume claim strategy for the Che server.
+                        enum:
+                        - common
+                        - per-workspace
                         type: string
                     type: object
                   tolerations:
@@ -1487,29 +1509,41 @@ spec:
                     type: object
                 type: object
               networking:
-                description: Networking, Che authentication, and TLS configuration.
+                description: Networking, Che authentication and TLS configuration.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Defines annotations which will be set for an Ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
+                    description: 'Defines annotations which will be set to an ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
                     type: object
                   auth:
+                    default:
+                      gateway:
+                        configLabels:
+                          app: che
+                          component: che-gateway-config
                     description: Authentication settings.
                     properties:
                       gateway:
+                        default:
+                          configLabels:
+                            app: che
+                            component: che-gateway-config
                         description: Gateway settings.
                         properties:
                           configLabels:
                             additionalProperties:
                               type: string
-                            description: Gate configuration labels.
+                            default:
+                              app: che
+                              component: che-gateway-config
+                            description: Gateway configuration labels.
                             type: object
                           deployment:
                             description: 'Deployment override options. Since gateway deployment consists of several containers, they must be distinguished in the configuration by their names: - `gateway` - `configbump` - `oauth-proxy` - `kube-rbac-proxy`'
                             properties:
-                              containers:
-                                description: List of containers belonging to the pod.
+                              container:
+                                description: A single application container.
                                 items:
                                   description: Container custom settings.
                                   properties:
@@ -1526,7 +1560,7 @@ spec:
                                       description: Compute resources required by this container.
                                       properties:
                                         limits:
-                                          description: Describes the maximum amount of compute resources allowed.
+                                          description: Limits describe the maximum amount of compute resources allowed.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1544,7 +1578,7 @@ spec:
                                               x-kubernetes-int-or-string: true
                                           type: object
                                         request:
-                                          description: Describes the minimum amount of compute resources required.
+                                          description: Request describes the minimum amount of compute resources required.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1589,7 +1623,7 @@ spec:
                         type: string
                     type: object
                   domain:
-                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for the route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In conjunction with labels, it creates a route served by a non-default Ingress controller. For a Kubernetes cluster, it contains a global ingress domain. There are no default values: you must specify them.'
+                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for a route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In a conjunction with labels it creates a route, which is served by a non-default Ingress controller. For Kubernetes cluster it contains a global ingress domain. This MUST be explicitly specified: there are no defaults.'
                     type: string
                   hostname:
                     description: The public hostname of the installed Che server.
@@ -1597,7 +1631,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: Defines labels which will be set for an Ingress (a route for OpenShift platform).
+                    description: Defines labels which will be set to an ingress (a route for OpenShift platform).
                     type: object
                   tlsSecretName:
                     description: The name of the secret used to set up Ingress TLS termination. If the field is an empty string, the default cluster certificate is used. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
@@ -1605,34 +1639,34 @@ spec:
                 type: object
             type: object
           status:
-            description: Defines the observed state of Che installation.
+            description: CheClusterStatus defines the observed state of Che installation.
             properties:
               chePhase:
                 description: Specifies the current phase of the Che deployment.
                 type: string
               cheURL:
-                description: Public URL of the Che server.
+                description: Public URL to the Che server.
                 type: string
               cheVersion:
-                description: Currently installed Che version.
+                description: Current installed Che version.
                 type: string
               devfileRegistryURL:
-                description: The public URL of the internal devfile registry.
+                description: The public URL to the internal devfile registry.
                 type: string
               gatewayPhase:
                 description: Specifies the current phase of the gateway deployment.
                 type: string
               message:
-                description: A human readable message indicating details about why the Che deployment is in the current phase.
+                description: A human readable message indicating details about why the Che deployment is in current phase.
                 type: string
               pluginRegistryURL:
-                description: The public URL of the internal plug-in registry.
+                description: The public URL to the internal plug-in registry.
                 type: string
               postgresVersion:
                 description: The PostgreSQL version of the image in use.
                 type: string
               reason:
-                description: A brief CamelCase message indicating details about why the Che deployment is in the current phase.
+                description: A brief CamelCase message indicating details about why the Che deployment is in current phase.
                 type: string
               workspaceBaseDomain:
                 description: The resolved workspace base domain. This is either the copy of the explicitly defined property of the same name in the spec or, if it is undefined in the spec and we're running on OpenShift, the automatically resolved basedomain for routes.

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -804,8 +804,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -822,7 +822,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -840,7 +840,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -876,7 +876,7 @@ spec:
                       extraProperties:
                         additionalProperties:
                           type: string
-                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server, in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` fields contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
+                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` field contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
                         type: object
                       logLevel:
                         default: INFO
@@ -889,26 +889,26 @@ spec:
                             description: The secret name that contains `user` and `password` for a proxy server. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                             type: string
                           nonProxyHosts:
-                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
+                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
                             items:
                               type: string
                             type: array
                           port:
                             description: Proxy server port.
-                            type: integer
+                            type: string
                           url:
-                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
+                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
                             type: string
                         type: object
                     type: object
                   dashboard:
-                    description: Configuration settings related to the Dashboard used by the Che installation.
+                    description: Configuration settings related to the dashboard used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -925,7 +925,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -943,7 +943,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -998,13 +998,13 @@ spec:
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
-                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the DB. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
+                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1021,7 +1021,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1039,7 +1039,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1074,11 +1074,11 @@ spec:
                         type: object
                       externalDb:
                         default: false
-                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details to the external DB you want to use.
+                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details about the external database you want to use.
                         type: boolean
                       postgresDb:
                         default: dbche
-                        description: PostgreSQL database name that the Che server uses to connect to the DB.
+                        description: PostgreSQL database name that the Che server uses to connect to the database.
                         type: string
                       postgresHostName:
                         default: postgres
@@ -1094,7 +1094,7 @@ spec:
                         description: PVC settings for PostgreSQL database.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
+                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1102,13 +1102,13 @@ spec:
                         type: object
                     type: object
                   devWorkspace:
-                    description: DevWorkspace operator configuration.
+                    description: DevWorkspace Operator configuration.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1125,7 +1125,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1143,7 +1143,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1181,13 +1181,13 @@ spec:
                         type: string
                     type: object
                   devfileRegistry:
-                    description: Configuration settings related to the Devfile registry used by the Che installation.
+                    description: Configuration settings related to the devfile registry used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1204,7 +1204,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1222,7 +1222,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1276,7 +1276,7 @@ spec:
                         description: Install and configure the community supported Kubernetes Image Puller Operator. When you set the value to `true` without providing any specs, it creates a default Kubernetes Image Puller object managed by the Operator. When you set the value to `false`, the Kubernetes Image Puller object is deleted, and the Operator uninstalled, regardless of whether a spec is provided. If you leave the `spec.images` field empty, a set of recommended workspace-related images is automatically detected and pre-pulled after installation. Note that while this Operator and its behavior is community-supported, its payload may be commercially-supported for pulling commercially-supported images.
                         type: boolean
                       spec:
-                        description: A Kubernetes Image Puller spec  to configure the image puller in the CheCluster
+                        description: A Kubernetes Image Puller spec to configure the image puller in the CheCluster.
                         properties:
                           affinity:
                             type: string
@@ -1322,8 +1322,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1340,7 +1340,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1358,7 +1358,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1426,16 +1426,16 @@ spec:
                     properties:
                       template:
                         default: <username>-che
-                        description: If you don't create user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
+                        description: If you don't create the user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
                         pattern: <username>|<userid>
                         type: string
                     type: object
                   defaultPlugins:
-                    description: Default plug-ins applied to Dev Workspaces.
+                    description: Default plug-ins applied to DevWorkspaces.
                     items:
                       properties:
                         editor:
-                          description: The editor id to specify default plug-ins for.
+                          description: The editor ID to specify default plug-ins for.
                           type: string
                         plugins:
                           description: Default plug-in URIs for the specified editor.
@@ -1458,7 +1458,7 @@ spec:
                         description: PVC settings.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
+                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1466,7 +1466,7 @@ spec:
                         type: object
                       pvcStrategy:
                         default: common
-                        description: Persistent volume claim strategy for the Che server.
+                        description: Persistent volume claim strategy for the Che server. Only the `common` strategy (all workspaces PVCs in one volume) is supported . For details, see https://github.com/eclipse/che/issues/21185.
                         enum:
                         - common
                         - per-workspace
@@ -1504,12 +1504,12 @@ spec:
                     type: object
                 type: object
               networking:
-                description: Networking, Che authentication and TLS configuration.
+                description: Networking, Che authentication, and TLS configuration.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Defines annotations which will be set to an ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
+                    description: 'Defines annotations which will be set for an Ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
                     type: object
                   auth:
                     default:
@@ -1537,8 +1537,8 @@ spec:
                           deployment:
                             description: 'Deployment override options. Since gateway deployment consists of several containers, they must be distinguished in the configuration by their names: - `gateway` - `configbump` - `oauth-proxy` - `kube-rbac-proxy`'
                             properties:
-                              container:
-                                description: A single application container.
+                              containers:
+                                description: List of containers belonging to the pod.
                                 items:
                                   description: Container custom settings.
                                   properties:
@@ -1555,7 +1555,7 @@ spec:
                                       description: Compute resources required by this container.
                                       properties:
                                         limits:
-                                          description: Limits describe the maximum amount of compute resources allowed.
+                                          description: Describes the maximum amount of compute resources allowed.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1573,7 +1573,7 @@ spec:
                                               x-kubernetes-int-or-string: true
                                           type: object
                                         request:
-                                          description: Request describes the minimum amount of compute resources required.
+                                          description: Describes the minimum amount of compute resources required.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1618,7 +1618,7 @@ spec:
                         type: string
                     type: object
                   domain:
-                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for a route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In a conjunction with labels it creates a route, which is served by a non-default Ingress controller. For Kubernetes cluster it contains a global ingress domain. This MUST be explicitly specified: there are no defaults.'
+                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for the route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In conjunction with labels, it creates a route served by a non-default Ingress controller. For a Kubernetes cluster, it contains a global ingress domain. There are no default values: you must specify them.'
                     type: string
                   hostname:
                     description: The public hostname of the installed Che server.
@@ -1626,7 +1626,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: Defines labels which will be set to an ingress (a route for OpenShift platform).
+                    description: Defines labels which will be set for an Ingress (a route for OpenShift platform).
                     type: object
                   tlsSecretName:
                     description: The name of the secret used to set up Ingress TLS termination. If the field is an empty string, the default cluster certificate is used. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
@@ -1634,34 +1634,34 @@ spec:
                 type: object
             type: object
           status:
-            description: CheClusterStatus defines the observed state of Che installation.
+            description: Defines the observed state of Che installation.
             properties:
               chePhase:
                 description: Specifies the current phase of the Che deployment.
                 type: string
               cheURL:
-                description: Public URL to the Che server.
+                description: Public URL of the Che server.
                 type: string
               cheVersion:
-                description: Current installed Che version.
+                description: Currently installed Che version.
                 type: string
               devfileRegistryURL:
-                description: The public URL to the internal devfile registry.
+                description: The public URL of the internal devfile registry.
                 type: string
               gatewayPhase:
                 description: Specifies the current phase of the gateway deployment.
                 type: string
               message:
-                description: A human readable message indicating details about why the Che deployment is in current phase.
+                description: A human readable message indicating details about why the Che deployment is in the current phase.
                 type: string
               pluginRegistryURL:
-                description: The public URL to the internal plug-in registry.
+                description: The public URL of the internal plug-in registry.
                 type: string
               postgresVersion:
                 description: The PostgreSQL version of the image in use.
                 type: string
               reason:
-                description: A brief CamelCase message indicating details about why the Che deployment is in current phase.
+                description: A brief CamelCase message indicating details about why the Che deployment is in the current phase.
                 type: string
               workspaceBaseDomain:
                 description: The resolved workspace base domain. This is either the copy of the explicitly defined property of the same name in the spec or, if it is undefined in the spec and we're running on OpenShift, the automatically resolved basedomain for routes.

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -787,6 +787,9 @@ spec:
                 description: Che components configuration.
                 properties:
                   cheServer:
+                    default:
+                      debug: false
+                      logLevel: INFO
                     description: General configuration settings related to the Che server.
                     properties:
                       clusterRoles:
@@ -795,13 +798,14 @@ spec:
                           type: string
                         type: array
                       debug:
+                        default: false
                         description: Enables the debug mode for Che server.
                         type: boolean
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -818,7 +822,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -836,7 +840,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -872,7 +876,7 @@ spec:
                       extraProperties:
                         additionalProperties:
                           type: string
-                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` field contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
+                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server, in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` fields contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
                         type: object
                       logLevel:
                         default: INFO
@@ -885,26 +889,26 @@ spec:
                             description: The secret name that contains `user` and `password` for a proxy server. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                             type: string
                           nonProxyHosts:
-                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
+                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
                             items:
                               type: string
                             type: array
                           port:
                             description: Proxy server port.
-                            type: string
+                            type: integer
                           url:
-                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
+                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
                             type: string
                         type: object
                     type: object
                   dashboard:
-                    description: Configuration settings related to the dashboard used by the Che installation.
+                    description: Configuration settings related to the Dashboard used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -921,7 +925,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -939,7 +943,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -984,17 +988,23 @@ spec:
                         type: object
                     type: object
                   database:
+                    default:
+                      externalDb: false
+                      postgresDb: dbche
+                      postgresHostName: postgres
+                      postgresPort: "5432"
+                      pvc:
+                        claimSize: 1Gi
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
-                        default: postgres-credentials
-                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
+                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the DB. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1011,7 +1021,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1029,7 +1039,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1063,11 +1073,12 @@ spec:
                             type: object
                         type: object
                       externalDb:
-                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details about the external database you want to use.
+                        default: false
+                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details to the external DB you want to use.
                         type: boolean
                       postgresDb:
                         default: dbche
-                        description: PostgreSQL database name that the Che server uses to connect to the database.
+                        description: PostgreSQL database name that the Che server uses to connect to the DB.
                         type: string
                       postgresHostName:
                         default: postgres
@@ -1078,10 +1089,12 @@ spec:
                         description: PostgreSQL Database port the Che server connects to. Override this value only when using an external database. See field `externalDb`.
                         type: string
                       pvc:
+                        default:
+                          claimSize: 1Gi
                         description: PVC settings for PostgreSQL database.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
+                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1089,13 +1102,13 @@ spec:
                         type: object
                     type: object
                   devWorkspace:
-                    description: DevWorkspace Operator configuration.
+                    description: DevWorkspace operator configuration.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1112,7 +1125,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1130,7 +1143,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1168,13 +1181,13 @@ spec:
                         type: string
                     type: object
                   devfileRegistry:
-                    description: Configuration settings related to the devfile registry used by the Che installation.
+                    description: Configuration settings related to the Devfile registry used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1191,7 +1204,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1209,7 +1222,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1263,7 +1276,7 @@ spec:
                         description: Install and configure the community supported Kubernetes Image Puller Operator. When you set the value to `true` without providing any specs, it creates a default Kubernetes Image Puller object managed by the Operator. When you set the value to `false`, the Kubernetes Image Puller object is deleted, and the Operator uninstalled, regardless of whether a spec is provided. If you leave the `spec.images` field empty, a set of recommended workspace-related images is automatically detected and pre-pulled after installation. Note that while this Operator and its behavior is community-supported, its payload may be commercially-supported for pulling commercially-supported images.
                         type: boolean
                       spec:
-                        description: A Kubernetes Image Puller spec to configure the image puller in the CheCluster.
+                        description: A Kubernetes Image Puller spec  to configure the image puller in the CheCluster
                         properties:
                           affinity:
                             type: string
@@ -1292,10 +1305,10 @@ spec:
                           nodeSelector:
                             type: string
                         type: object
-                    required:
-                    - enable
                     type: object
                   metrics:
+                    default:
+                      enable: true
                     description: Che server metrics configuration.
                     properties:
                       enable:
@@ -1309,8 +1322,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1327,7 +1340,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1345,7 +1358,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1407,18 +1420,22 @@ spec:
                 description: Development environment default configuration options.
                 properties:
                   defaultNamespace:
+                    default:
+                      template: <username>-che
                     description: User's default namespace.
                     properties:
                       template:
-                        description: If you don't create the user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>`, `<userid>` and `<workspaceid>` placeholders, such as che-workspace-<username>.
+                        default: <username>-che
+                        description: If you don't create user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
+                        pattern: <username>|<userid>
                         type: string
                     type: object
                   defaultPlugins:
-                    description: Default plug-ins applied to DevWorkspaces.
+                    description: Default plug-ins applied to Dev Workspaces.
                     items:
                       properties:
                         editor:
-                          description: The editor ID to specify default plug-ins for.
+                          description: The editor id to specify default plug-ins for.
                           type: string
                         plugins:
                           description: Default plug-in URIs for the specified editor.
@@ -1433,13 +1450,15 @@ spec:
                     description: The node selector limits the nodes that can run the workspace pods.
                     type: object
                   storage:
+                    default:
+                      pvcStrategy: common
                     description: Workspaces persistent storage.
                     properties:
                       pvc:
                         description: PVC settings.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
+                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1447,7 +1466,10 @@ spec:
                         type: object
                       pvcStrategy:
                         default: common
-                        description: Persistent volume claim strategy for the Che server. Only the `common` strategy (all workspaces PVCs in one volume) is supported . For details, see https://github.com/eclipse/che/issues/21185.
+                        description: Persistent volume claim strategy for the Che server.
+                        enum:
+                        - common
+                        - per-workspace
                         type: string
                     type: object
                   tolerations:
@@ -1482,29 +1504,41 @@ spec:
                     type: object
                 type: object
               networking:
-                description: Networking, Che authentication, and TLS configuration.
+                description: Networking, Che authentication and TLS configuration.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Defines annotations which will be set for an Ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
+                    description: 'Defines annotations which will be set to an ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
                     type: object
                   auth:
+                    default:
+                      gateway:
+                        configLabels:
+                          app: che
+                          component: che-gateway-config
                     description: Authentication settings.
                     properties:
                       gateway:
+                        default:
+                          configLabels:
+                            app: che
+                            component: che-gateway-config
                         description: Gateway settings.
                         properties:
                           configLabels:
                             additionalProperties:
                               type: string
-                            description: Gate configuration labels.
+                            default:
+                              app: che
+                              component: che-gateway-config
+                            description: Gateway configuration labels.
                             type: object
                           deployment:
                             description: 'Deployment override options. Since gateway deployment consists of several containers, they must be distinguished in the configuration by their names: - `gateway` - `configbump` - `oauth-proxy` - `kube-rbac-proxy`'
                             properties:
-                              containers:
-                                description: List of containers belonging to the pod.
+                              container:
+                                description: A single application container.
                                 items:
                                   description: Container custom settings.
                                   properties:
@@ -1521,7 +1555,7 @@ spec:
                                       description: Compute resources required by this container.
                                       properties:
                                         limits:
-                                          description: Describes the maximum amount of compute resources allowed.
+                                          description: Limits describe the maximum amount of compute resources allowed.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1539,7 +1573,7 @@ spec:
                                               x-kubernetes-int-or-string: true
                                           type: object
                                         request:
-                                          description: Describes the minimum amount of compute resources required.
+                                          description: Request describes the minimum amount of compute resources required.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1584,7 +1618,7 @@ spec:
                         type: string
                     type: object
                   domain:
-                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for the route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In conjunction with labels, it creates a route served by a non-default Ingress controller. For a Kubernetes cluster, it contains a global ingress domain. There are no default values: you must specify them.'
+                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for a route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In a conjunction with labels it creates a route, which is served by a non-default Ingress controller. For Kubernetes cluster it contains a global ingress domain. This MUST be explicitly specified: there are no defaults.'
                     type: string
                   hostname:
                     description: The public hostname of the installed Che server.
@@ -1592,7 +1626,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: Defines labels which will be set for an Ingress (a route for OpenShift platform).
+                    description: Defines labels which will be set to an ingress (a route for OpenShift platform).
                     type: object
                   tlsSecretName:
                     description: The name of the secret used to set up Ingress TLS termination. If the field is an empty string, the default cluster certificate is used. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
@@ -1600,34 +1634,34 @@ spec:
                 type: object
             type: object
           status:
-            description: Defines the observed state of Che installation.
+            description: CheClusterStatus defines the observed state of Che installation.
             properties:
               chePhase:
                 description: Specifies the current phase of the Che deployment.
                 type: string
               cheURL:
-                description: Public URL of the Che server.
+                description: Public URL to the Che server.
                 type: string
               cheVersion:
-                description: Currently installed Che version.
+                description: Current installed Che version.
                 type: string
               devfileRegistryURL:
-                description: The public URL of the internal devfile registry.
+                description: The public URL to the internal devfile registry.
                 type: string
               gatewayPhase:
                 description: Specifies the current phase of the gateway deployment.
                 type: string
               message:
-                description: A human readable message indicating details about why the Che deployment is in the current phase.
+                description: A human readable message indicating details about why the Che deployment is in current phase.
                 type: string
               pluginRegistryURL:
-                description: The public URL of the internal plug-in registry.
+                description: The public URL to the internal plug-in registry.
                 type: string
               postgresVersion:
                 description: The PostgreSQL version of the image in use.
                 type: string
               reason:
-                description: A brief CamelCase message indicating details about why the Che deployment is in the current phase.
+                description: A brief CamelCase message indicating details about why the Che deployment is in current phase.
                 type: string
               workspaceBaseDomain:
                 description: The resolved workspace base domain. This is either the copy of the explicitly defined property of the same name in the spec or, if it is undefined in the spec and we're running on OpenShift, the automatically resolved basedomain for routes.

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -989,6 +989,7 @@ spec:
                     type: object
                   database:
                     default:
+                      credentialsSecretName: postgres-credentials
                       externalDb: false
                       postgresDb: dbche
                       postgresHostName: postgres
@@ -998,6 +999,7 @@ spec:
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
+                        default: postgres-credentials
                         description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -784,6 +784,20 @@ spec:
             description: Desired configuration of Eclipse Che installation.
             properties:
               components:
+                default:
+                  cheServer:
+                    debug: false
+                    logLevel: INFO
+                  database:
+                    credentialsSecretName: postgres-credentials
+                    externalDb: false
+                    postgresDb: dbche
+                    postgresHostName: postgres
+                    postgresPort: "5432"
+                    pvc:
+                      claimSize: 1Gi
+                  metrics:
+                    enable: true
                 description: Che components configuration.
                 properties:
                   cheServer:
@@ -814,6 +828,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -917,6 +935,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1015,6 +1037,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1119,6 +1145,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1198,6 +1228,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1334,6 +1368,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1419,6 +1457,11 @@ spec:
                     type: string
                 type: object
               devEnvironments:
+                default:
+                  defaultNamespace:
+                    template: <username>-che
+                  storage:
+                    pvcStrategy: common
                 description: Development environment default configuration options.
                 properties:
                   defaultNamespace:
@@ -1506,6 +1549,12 @@ spec:
                     type: object
                 type: object
               networking:
+                default:
+                  auth:
+                    gateway:
+                      configLabels:
+                        app: che
+                        component: che-gateway-config
                 description: Networking, Che authentication, and TLS configuration.
                 properties:
                   annotations:
@@ -1549,6 +1598,10 @@ spec:
                                       type: string
                                     imagePullPolicy:
                                       description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                      enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
                                       type: string
                                     name:
                                       description: Container name.

--- a/deploy/deployment/kubernetes/org_v2_checluster.yaml
+++ b/deploy/deployment/kubernetes/org_v2_checluster.yaml
@@ -16,20 +16,7 @@ metadata:
   name: eclipse-che
   namespace: eclipse-che
 spec:
-  devEnvironments:
-    defaultNamespace:
-      template: '<username>-che'
-    storage:
-      pvcStrategy: 'common'
-  components:
-    database:
-      externalDb: false
-    metrics:
-      enable: true
-  networking:
-    domain: ''
-    tlsSecretName: ''
-    auth:
-      identityProviderURL: ''
-      oAuthClientName: ''
-      oAuthSecret: ''
+  components: {}
+  devEnvironments: {}
+  networking: {}
+  containerRegistry: {}

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -994,6 +994,7 @@ spec:
                     type: object
                   database:
                     default:
+                      credentialsSecretName: postgres-credentials
                       externalDb: false
                       postgresDb: dbche
                       postgresHostName: postgres
@@ -1003,6 +1004,7 @@ spec:
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
+                        default: postgres-credentials
                         description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -789,6 +789,20 @@ spec:
             description: Desired configuration of Eclipse Che installation.
             properties:
               components:
+                default:
+                  cheServer:
+                    debug: false
+                    logLevel: INFO
+                  database:
+                    credentialsSecretName: postgres-credentials
+                    externalDb: false
+                    postgresDb: dbche
+                    postgresHostName: postgres
+                    postgresPort: "5432"
+                    pvc:
+                      claimSize: 1Gi
+                  metrics:
+                    enable: true
                 description: Che components configuration.
                 properties:
                   cheServer:
@@ -819,6 +833,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -922,6 +940,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1020,6 +1042,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1124,6 +1150,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1203,6 +1233,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1339,6 +1373,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1424,6 +1462,11 @@ spec:
                     type: string
                 type: object
               devEnvironments:
+                default:
+                  defaultNamespace:
+                    template: <username>-che
+                  storage:
+                    pvcStrategy: common
                 description: Development environment default configuration options.
                 properties:
                   defaultNamespace:
@@ -1511,6 +1554,12 @@ spec:
                     type: object
                 type: object
               networking:
+                default:
+                  auth:
+                    gateway:
+                      configLabels:
+                        app: che
+                        component: che-gateway-config
                 description: Networking, Che authentication, and TLS configuration.
                 properties:
                   annotations:
@@ -1554,6 +1603,10 @@ spec:
                                       type: string
                                     imagePullPolicy:
                                       description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                      enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
                                       type: string
                                     name:
                                       description: Container name.

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -809,8 +809,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -827,7 +827,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -845,7 +845,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -881,7 +881,7 @@ spec:
                       extraProperties:
                         additionalProperties:
                           type: string
-                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server, in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` fields contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
+                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` field contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
                         type: object
                       logLevel:
                         default: INFO
@@ -894,26 +894,26 @@ spec:
                             description: The secret name that contains `user` and `password` for a proxy server. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                             type: string
                           nonProxyHosts:
-                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
+                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
                             items:
                               type: string
                             type: array
                           port:
                             description: Proxy server port.
-                            type: integer
+                            type: string
                           url:
-                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
+                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
                             type: string
                         type: object
                     type: object
                   dashboard:
-                    description: Configuration settings related to the Dashboard used by the Che installation.
+                    description: Configuration settings related to the dashboard used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -930,7 +930,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -948,7 +948,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1003,13 +1003,13 @@ spec:
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
-                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the DB. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
+                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1026,7 +1026,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1044,7 +1044,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1079,11 +1079,11 @@ spec:
                         type: object
                       externalDb:
                         default: false
-                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details to the external DB you want to use.
+                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details about the external database you want to use.
                         type: boolean
                       postgresDb:
                         default: dbche
-                        description: PostgreSQL database name that the Che server uses to connect to the DB.
+                        description: PostgreSQL database name that the Che server uses to connect to the database.
                         type: string
                       postgresHostName:
                         default: postgres
@@ -1099,7 +1099,7 @@ spec:
                         description: PVC settings for PostgreSQL database.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
+                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1107,13 +1107,13 @@ spec:
                         type: object
                     type: object
                   devWorkspace:
-                    description: DevWorkspace operator configuration.
+                    description: DevWorkspace Operator configuration.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1130,7 +1130,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1148,7 +1148,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1186,13 +1186,13 @@ spec:
                         type: string
                     type: object
                   devfileRegistry:
-                    description: Configuration settings related to the Devfile registry used by the Che installation.
+                    description: Configuration settings related to the devfile registry used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1209,7 +1209,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1227,7 +1227,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1281,7 +1281,7 @@ spec:
                         description: Install and configure the community supported Kubernetes Image Puller Operator. When you set the value to `true` without providing any specs, it creates a default Kubernetes Image Puller object managed by the Operator. When you set the value to `false`, the Kubernetes Image Puller object is deleted, and the Operator uninstalled, regardless of whether a spec is provided. If you leave the `spec.images` field empty, a set of recommended workspace-related images is automatically detected and pre-pulled after installation. Note that while this Operator and its behavior is community-supported, its payload may be commercially-supported for pulling commercially-supported images.
                         type: boolean
                       spec:
-                        description: A Kubernetes Image Puller spec  to configure the image puller in the CheCluster
+                        description: A Kubernetes Image Puller spec to configure the image puller in the CheCluster.
                         properties:
                           affinity:
                             type: string
@@ -1327,8 +1327,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1345,7 +1345,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1363,7 +1363,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1431,16 +1431,16 @@ spec:
                     properties:
                       template:
                         default: <username>-che
-                        description: If you don't create user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
+                        description: If you don't create the user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
                         pattern: <username>|<userid>
                         type: string
                     type: object
                   defaultPlugins:
-                    description: Default plug-ins applied to Dev Workspaces.
+                    description: Default plug-ins applied to DevWorkspaces.
                     items:
                       properties:
                         editor:
-                          description: The editor id to specify default plug-ins for.
+                          description: The editor ID to specify default plug-ins for.
                           type: string
                         plugins:
                           description: Default plug-in URIs for the specified editor.
@@ -1463,7 +1463,7 @@ spec:
                         description: PVC settings.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
+                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1471,7 +1471,7 @@ spec:
                         type: object
                       pvcStrategy:
                         default: common
-                        description: Persistent volume claim strategy for the Che server.
+                        description: Persistent volume claim strategy for the Che server. Only the `common` strategy (all workspaces PVCs in one volume) is supported . For details, see https://github.com/eclipse/che/issues/21185.
                         enum:
                         - common
                         - per-workspace
@@ -1509,12 +1509,12 @@ spec:
                     type: object
                 type: object
               networking:
-                description: Networking, Che authentication and TLS configuration.
+                description: Networking, Che authentication, and TLS configuration.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Defines annotations which will be set to an ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
+                    description: 'Defines annotations which will be set for an Ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
                     type: object
                   auth:
                     default:
@@ -1542,8 +1542,8 @@ spec:
                           deployment:
                             description: 'Deployment override options. Since gateway deployment consists of several containers, they must be distinguished in the configuration by their names: - `gateway` - `configbump` - `oauth-proxy` - `kube-rbac-proxy`'
                             properties:
-                              container:
-                                description: A single application container.
+                              containers:
+                                description: List of containers belonging to the pod.
                                 items:
                                   description: Container custom settings.
                                   properties:
@@ -1560,7 +1560,7 @@ spec:
                                       description: Compute resources required by this container.
                                       properties:
                                         limits:
-                                          description: Limits describe the maximum amount of compute resources allowed.
+                                          description: Describes the maximum amount of compute resources allowed.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1578,7 +1578,7 @@ spec:
                                               x-kubernetes-int-or-string: true
                                           type: object
                                         request:
-                                          description: Request describes the minimum amount of compute resources required.
+                                          description: Describes the minimum amount of compute resources required.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1623,7 +1623,7 @@ spec:
                         type: string
                     type: object
                   domain:
-                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for a route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In a conjunction with labels it creates a route, which is served by a non-default Ingress controller. For Kubernetes cluster it contains a global ingress domain. This MUST be explicitly specified: there are no defaults.'
+                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for the route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In conjunction with labels, it creates a route served by a non-default Ingress controller. For a Kubernetes cluster, it contains a global ingress domain. There are no default values: you must specify them.'
                     type: string
                   hostname:
                     description: The public hostname of the installed Che server.
@@ -1631,7 +1631,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: Defines labels which will be set to an ingress (a route for OpenShift platform).
+                    description: Defines labels which will be set for an Ingress (a route for OpenShift platform).
                     type: object
                   tlsSecretName:
                     description: The name of the secret used to set up Ingress TLS termination. If the field is an empty string, the default cluster certificate is used. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
@@ -1639,34 +1639,34 @@ spec:
                 type: object
             type: object
           status:
-            description: CheClusterStatus defines the observed state of Che installation.
+            description: Defines the observed state of Che installation.
             properties:
               chePhase:
                 description: Specifies the current phase of the Che deployment.
                 type: string
               cheURL:
-                description: Public URL to the Che server.
+                description: Public URL of the Che server.
                 type: string
               cheVersion:
-                description: Current installed Che version.
+                description: Currently installed Che version.
                 type: string
               devfileRegistryURL:
-                description: The public URL to the internal devfile registry.
+                description: The public URL of the internal devfile registry.
                 type: string
               gatewayPhase:
                 description: Specifies the current phase of the gateway deployment.
                 type: string
               message:
-                description: A human readable message indicating details about why the Che deployment is in current phase.
+                description: A human readable message indicating details about why the Che deployment is in the current phase.
                 type: string
               pluginRegistryURL:
-                description: The public URL to the internal plug-in registry.
+                description: The public URL of the internal plug-in registry.
                 type: string
               postgresVersion:
                 description: The PostgreSQL version of the image in use.
                 type: string
               reason:
-                description: A brief CamelCase message indicating details about why the Che deployment is in current phase.
+                description: A brief CamelCase message indicating details about why the Che deployment is in the current phase.
                 type: string
               workspaceBaseDomain:
                 description: The resolved workspace base domain. This is either the copy of the explicitly defined property of the same name in the spec or, if it is undefined in the spec and we're running on OpenShift, the automatically resolved basedomain for routes.

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -792,6 +792,9 @@ spec:
                 description: Che components configuration.
                 properties:
                   cheServer:
+                    default:
+                      debug: false
+                      logLevel: INFO
                     description: General configuration settings related to the Che server.
                     properties:
                       clusterRoles:
@@ -800,13 +803,14 @@ spec:
                           type: string
                         type: array
                       debug:
+                        default: false
                         description: Enables the debug mode for Che server.
                         type: boolean
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -823,7 +827,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -841,7 +845,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -877,7 +881,7 @@ spec:
                       extraProperties:
                         additionalProperties:
                           type: string
-                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` field contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
+                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server, in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` fields contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
                         type: object
                       logLevel:
                         default: INFO
@@ -890,26 +894,26 @@ spec:
                             description: The secret name that contains `user` and `password` for a proxy server. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                             type: string
                           nonProxyHosts:
-                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
+                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
                             items:
                               type: string
                             type: array
                           port:
                             description: Proxy server port.
-                            type: string
+                            type: integer
                           url:
-                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
+                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
                             type: string
                         type: object
                     type: object
                   dashboard:
-                    description: Configuration settings related to the dashboard used by the Che installation.
+                    description: Configuration settings related to the Dashboard used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -926,7 +930,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -944,7 +948,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -989,17 +993,23 @@ spec:
                         type: object
                     type: object
                   database:
+                    default:
+                      externalDb: false
+                      postgresDb: dbche
+                      postgresHostName: postgres
+                      postgresPort: "5432"
+                      pvc:
+                        claimSize: 1Gi
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
-                        default: postgres-credentials
-                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
+                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the DB. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1016,7 +1026,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1034,7 +1044,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1068,11 +1078,12 @@ spec:
                             type: object
                         type: object
                       externalDb:
-                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details about the external database you want to use.
+                        default: false
+                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details to the external DB you want to use.
                         type: boolean
                       postgresDb:
                         default: dbche
-                        description: PostgreSQL database name that the Che server uses to connect to the database.
+                        description: PostgreSQL database name that the Che server uses to connect to the DB.
                         type: string
                       postgresHostName:
                         default: postgres
@@ -1083,10 +1094,12 @@ spec:
                         description: PostgreSQL Database port the Che server connects to. Override this value only when using an external database. See field `externalDb`.
                         type: string
                       pvc:
+                        default:
+                          claimSize: 1Gi
                         description: PVC settings for PostgreSQL database.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
+                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1094,13 +1107,13 @@ spec:
                         type: object
                     type: object
                   devWorkspace:
-                    description: DevWorkspace Operator configuration.
+                    description: DevWorkspace operator configuration.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1117,7 +1130,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1135,7 +1148,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1173,13 +1186,13 @@ spec:
                         type: string
                     type: object
                   devfileRegistry:
-                    description: Configuration settings related to the devfile registry used by the Che installation.
+                    description: Configuration settings related to the Devfile registry used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1196,7 +1209,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1214,7 +1227,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1268,7 +1281,7 @@ spec:
                         description: Install and configure the community supported Kubernetes Image Puller Operator. When you set the value to `true` without providing any specs, it creates a default Kubernetes Image Puller object managed by the Operator. When you set the value to `false`, the Kubernetes Image Puller object is deleted, and the Operator uninstalled, regardless of whether a spec is provided. If you leave the `spec.images` field empty, a set of recommended workspace-related images is automatically detected and pre-pulled after installation. Note that while this Operator and its behavior is community-supported, its payload may be commercially-supported for pulling commercially-supported images.
                         type: boolean
                       spec:
-                        description: A Kubernetes Image Puller spec to configure the image puller in the CheCluster.
+                        description: A Kubernetes Image Puller spec  to configure the image puller in the CheCluster
                         properties:
                           affinity:
                             type: string
@@ -1297,10 +1310,10 @@ spec:
                           nodeSelector:
                             type: string
                         type: object
-                    required:
-                    - enable
                     type: object
                   metrics:
+                    default:
+                      enable: true
                     description: Che server metrics configuration.
                     properties:
                       enable:
@@ -1314,8 +1327,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1332,7 +1345,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1350,7 +1363,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1412,18 +1425,22 @@ spec:
                 description: Development environment default configuration options.
                 properties:
                   defaultNamespace:
+                    default:
+                      template: <username>-che
                     description: User's default namespace.
                     properties:
                       template:
-                        description: If you don't create the user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>`, `<userid>` and `<workspaceid>` placeholders, such as che-workspace-<username>.
+                        default: <username>-che
+                        description: If you don't create user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
+                        pattern: <username>|<userid>
                         type: string
                     type: object
                   defaultPlugins:
-                    description: Default plug-ins applied to DevWorkspaces.
+                    description: Default plug-ins applied to Dev Workspaces.
                     items:
                       properties:
                         editor:
-                          description: The editor ID to specify default plug-ins for.
+                          description: The editor id to specify default plug-ins for.
                           type: string
                         plugins:
                           description: Default plug-in URIs for the specified editor.
@@ -1438,13 +1455,15 @@ spec:
                     description: The node selector limits the nodes that can run the workspace pods.
                     type: object
                   storage:
+                    default:
+                      pvcStrategy: common
                     description: Workspaces persistent storage.
                     properties:
                       pvc:
                         description: PVC settings.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
+                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1452,7 +1471,10 @@ spec:
                         type: object
                       pvcStrategy:
                         default: common
-                        description: Persistent volume claim strategy for the Che server. Only the `common` strategy (all workspaces PVCs in one volume) is supported . For details, see https://github.com/eclipse/che/issues/21185.
+                        description: Persistent volume claim strategy for the Che server.
+                        enum:
+                        - common
+                        - per-workspace
                         type: string
                     type: object
                   tolerations:
@@ -1487,29 +1509,41 @@ spec:
                     type: object
                 type: object
               networking:
-                description: Networking, Che authentication, and TLS configuration.
+                description: Networking, Che authentication and TLS configuration.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Defines annotations which will be set for an Ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
+                    description: 'Defines annotations which will be set to an ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
                     type: object
                   auth:
+                    default:
+                      gateway:
+                        configLabels:
+                          app: che
+                          component: che-gateway-config
                     description: Authentication settings.
                     properties:
                       gateway:
+                        default:
+                          configLabels:
+                            app: che
+                            component: che-gateway-config
                         description: Gateway settings.
                         properties:
                           configLabels:
                             additionalProperties:
                               type: string
-                            description: Gate configuration labels.
+                            default:
+                              app: che
+                              component: che-gateway-config
+                            description: Gateway configuration labels.
                             type: object
                           deployment:
                             description: 'Deployment override options. Since gateway deployment consists of several containers, they must be distinguished in the configuration by their names: - `gateway` - `configbump` - `oauth-proxy` - `kube-rbac-proxy`'
                             properties:
-                              containers:
-                                description: List of containers belonging to the pod.
+                              container:
+                                description: A single application container.
                                 items:
                                   description: Container custom settings.
                                   properties:
@@ -1526,7 +1560,7 @@ spec:
                                       description: Compute resources required by this container.
                                       properties:
                                         limits:
-                                          description: Describes the maximum amount of compute resources allowed.
+                                          description: Limits describe the maximum amount of compute resources allowed.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1544,7 +1578,7 @@ spec:
                                               x-kubernetes-int-or-string: true
                                           type: object
                                         request:
-                                          description: Describes the minimum amount of compute resources required.
+                                          description: Request describes the minimum amount of compute resources required.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1589,7 +1623,7 @@ spec:
                         type: string
                     type: object
                   domain:
-                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for the route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In conjunction with labels, it creates a route served by a non-default Ingress controller. For a Kubernetes cluster, it contains a global ingress domain. There are no default values: you must specify them.'
+                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for a route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In a conjunction with labels it creates a route, which is served by a non-default Ingress controller. For Kubernetes cluster it contains a global ingress domain. This MUST be explicitly specified: there are no defaults.'
                     type: string
                   hostname:
                     description: The public hostname of the installed Che server.
@@ -1597,7 +1631,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: Defines labels which will be set for an Ingress (a route for OpenShift platform).
+                    description: Defines labels which will be set to an ingress (a route for OpenShift platform).
                     type: object
                   tlsSecretName:
                     description: The name of the secret used to set up Ingress TLS termination. If the field is an empty string, the default cluster certificate is used. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
@@ -1605,34 +1639,34 @@ spec:
                 type: object
             type: object
           status:
-            description: Defines the observed state of Che installation.
+            description: CheClusterStatus defines the observed state of Che installation.
             properties:
               chePhase:
                 description: Specifies the current phase of the Che deployment.
                 type: string
               cheURL:
-                description: Public URL of the Che server.
+                description: Public URL to the Che server.
                 type: string
               cheVersion:
-                description: Currently installed Che version.
+                description: Current installed Che version.
                 type: string
               devfileRegistryURL:
-                description: The public URL of the internal devfile registry.
+                description: The public URL to the internal devfile registry.
                 type: string
               gatewayPhase:
                 description: Specifies the current phase of the gateway deployment.
                 type: string
               message:
-                description: A human readable message indicating details about why the Che deployment is in the current phase.
+                description: A human readable message indicating details about why the Che deployment is in current phase.
                 type: string
               pluginRegistryURL:
-                description: The public URL of the internal plug-in registry.
+                description: The public URL to the internal plug-in registry.
                 type: string
               postgresVersion:
                 description: The PostgreSQL version of the image in use.
                 type: string
               reason:
-                description: A brief CamelCase message indicating details about why the Che deployment is in the current phase.
+                description: A brief CamelCase message indicating details about why the Che deployment is in current phase.
                 type: string
               workspaceBaseDomain:
                 description: The resolved workspace base domain. This is either the copy of the explicitly defined property of the same name in the spec or, if it is undefined in the spec and we're running on OpenShift, the automatically resolved basedomain for routes.

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -804,8 +804,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -822,7 +822,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -840,7 +840,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -876,7 +876,7 @@ spec:
                       extraProperties:
                         additionalProperties:
                           type: string
-                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server, in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` fields contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
+                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` field contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
                         type: object
                       logLevel:
                         default: INFO
@@ -889,26 +889,26 @@ spec:
                             description: The secret name that contains `user` and `password` for a proxy server. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                             type: string
                           nonProxyHosts:
-                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
+                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
                             items:
                               type: string
                             type: array
                           port:
                             description: Proxy server port.
-                            type: integer
+                            type: string
                           url:
-                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
+                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
                             type: string
                         type: object
                     type: object
                   dashboard:
-                    description: Configuration settings related to the Dashboard used by the Che installation.
+                    description: Configuration settings related to the dashboard used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -925,7 +925,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -943,7 +943,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -998,13 +998,13 @@ spec:
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
-                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the DB. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
+                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1021,7 +1021,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1039,7 +1039,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1074,11 +1074,11 @@ spec:
                         type: object
                       externalDb:
                         default: false
-                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details to the external DB you want to use.
+                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details about the external database you want to use.
                         type: boolean
                       postgresDb:
                         default: dbche
-                        description: PostgreSQL database name that the Che server uses to connect to the DB.
+                        description: PostgreSQL database name that the Che server uses to connect to the database.
                         type: string
                       postgresHostName:
                         default: postgres
@@ -1094,7 +1094,7 @@ spec:
                         description: PVC settings for PostgreSQL database.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
+                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1102,13 +1102,13 @@ spec:
                         type: object
                     type: object
                   devWorkspace:
-                    description: DevWorkspace operator configuration.
+                    description: DevWorkspace Operator configuration.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1125,7 +1125,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1143,7 +1143,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1181,13 +1181,13 @@ spec:
                         type: string
                     type: object
                   devfileRegistry:
-                    description: Configuration settings related to the Devfile registry used by the Che installation.
+                    description: Configuration settings related to the devfile registry used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1204,7 +1204,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1222,7 +1222,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1276,7 +1276,7 @@ spec:
                         description: Install and configure the community supported Kubernetes Image Puller Operator. When you set the value to `true` without providing any specs, it creates a default Kubernetes Image Puller object managed by the Operator. When you set the value to `false`, the Kubernetes Image Puller object is deleted, and the Operator uninstalled, regardless of whether a spec is provided. If you leave the `spec.images` field empty, a set of recommended workspace-related images is automatically detected and pre-pulled after installation. Note that while this Operator and its behavior is community-supported, its payload may be commercially-supported for pulling commercially-supported images.
                         type: boolean
                       spec:
-                        description: A Kubernetes Image Puller spec  to configure the image puller in the CheCluster
+                        description: A Kubernetes Image Puller spec to configure the image puller in the CheCluster.
                         properties:
                           affinity:
                             type: string
@@ -1322,8 +1322,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1340,7 +1340,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1358,7 +1358,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1426,16 +1426,16 @@ spec:
                     properties:
                       template:
                         default: <username>-che
-                        description: If you don't create user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
+                        description: If you don't create the user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
                         pattern: <username>|<userid>
                         type: string
                     type: object
                   defaultPlugins:
-                    description: Default plug-ins applied to Dev Workspaces.
+                    description: Default plug-ins applied to DevWorkspaces.
                     items:
                       properties:
                         editor:
-                          description: The editor id to specify default plug-ins for.
+                          description: The editor ID to specify default plug-ins for.
                           type: string
                         plugins:
                           description: Default plug-in URIs for the specified editor.
@@ -1458,7 +1458,7 @@ spec:
                         description: PVC settings.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
+                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1466,7 +1466,7 @@ spec:
                         type: object
                       pvcStrategy:
                         default: common
-                        description: Persistent volume claim strategy for the Che server.
+                        description: Persistent volume claim strategy for the Che server. Only the `common` strategy (all workspaces PVCs in one volume) is supported . For details, see https://github.com/eclipse/che/issues/21185.
                         enum:
                         - common
                         - per-workspace
@@ -1504,12 +1504,12 @@ spec:
                     type: object
                 type: object
               networking:
-                description: Networking, Che authentication and TLS configuration.
+                description: Networking, Che authentication, and TLS configuration.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Defines annotations which will be set to an ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
+                    description: 'Defines annotations which will be set for an Ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
                     type: object
                   auth:
                     default:
@@ -1537,8 +1537,8 @@ spec:
                           deployment:
                             description: 'Deployment override options. Since gateway deployment consists of several containers, they must be distinguished in the configuration by their names: - `gateway` - `configbump` - `oauth-proxy` - `kube-rbac-proxy`'
                             properties:
-                              container:
-                                description: A single application container.
+                              containers:
+                                description: List of containers belonging to the pod.
                                 items:
                                   description: Container custom settings.
                                   properties:
@@ -1555,7 +1555,7 @@ spec:
                                       description: Compute resources required by this container.
                                       properties:
                                         limits:
-                                          description: Limits describe the maximum amount of compute resources allowed.
+                                          description: Describes the maximum amount of compute resources allowed.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1573,7 +1573,7 @@ spec:
                                               x-kubernetes-int-or-string: true
                                           type: object
                                         request:
-                                          description: Request describes the minimum amount of compute resources required.
+                                          description: Describes the minimum amount of compute resources required.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1618,7 +1618,7 @@ spec:
                         type: string
                     type: object
                   domain:
-                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for a route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In a conjunction with labels it creates a route, which is served by a non-default Ingress controller. For Kubernetes cluster it contains a global ingress domain. This MUST be explicitly specified: there are no defaults.'
+                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for the route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In conjunction with labels, it creates a route served by a non-default Ingress controller. For a Kubernetes cluster, it contains a global ingress domain. There are no default values: you must specify them.'
                     type: string
                   hostname:
                     description: The public hostname of the installed Che server.
@@ -1626,7 +1626,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: Defines labels which will be set to an ingress (a route for OpenShift platform).
+                    description: Defines labels which will be set for an Ingress (a route for OpenShift platform).
                     type: object
                   tlsSecretName:
                     description: The name of the secret used to set up Ingress TLS termination. If the field is an empty string, the default cluster certificate is used. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
@@ -1634,34 +1634,34 @@ spec:
                 type: object
             type: object
           status:
-            description: CheClusterStatus defines the observed state of Che installation.
+            description: Defines the observed state of Che installation.
             properties:
               chePhase:
                 description: Specifies the current phase of the Che deployment.
                 type: string
               cheURL:
-                description: Public URL to the Che server.
+                description: Public URL of the Che server.
                 type: string
               cheVersion:
-                description: Current installed Che version.
+                description: Currently installed Che version.
                 type: string
               devfileRegistryURL:
-                description: The public URL to the internal devfile registry.
+                description: The public URL of the internal devfile registry.
                 type: string
               gatewayPhase:
                 description: Specifies the current phase of the gateway deployment.
                 type: string
               message:
-                description: A human readable message indicating details about why the Che deployment is in current phase.
+                description: A human readable message indicating details about why the Che deployment is in the current phase.
                 type: string
               pluginRegistryURL:
-                description: The public URL to the internal plug-in registry.
+                description: The public URL of the internal plug-in registry.
                 type: string
               postgresVersion:
                 description: The PostgreSQL version of the image in use.
                 type: string
               reason:
-                description: A brief CamelCase message indicating details about why the Che deployment is in current phase.
+                description: A brief CamelCase message indicating details about why the Che deployment is in the current phase.
                 type: string
               workspaceBaseDomain:
                 description: The resolved workspace base domain. This is either the copy of the explicitly defined property of the same name in the spec or, if it is undefined in the spec and we're running on OpenShift, the automatically resolved basedomain for routes.

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -787,6 +787,9 @@ spec:
                 description: Che components configuration.
                 properties:
                   cheServer:
+                    default:
+                      debug: false
+                      logLevel: INFO
                     description: General configuration settings related to the Che server.
                     properties:
                       clusterRoles:
@@ -795,13 +798,14 @@ spec:
                           type: string
                         type: array
                       debug:
+                        default: false
                         description: Enables the debug mode for Che server.
                         type: boolean
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -818,7 +822,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -836,7 +840,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -872,7 +876,7 @@ spec:
                       extraProperties:
                         additionalProperties:
                           type: string
-                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` field contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
+                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server, in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` fields contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
                         type: object
                       logLevel:
                         default: INFO
@@ -885,26 +889,26 @@ spec:
                             description: The secret name that contains `user` and `password` for a proxy server. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                             type: string
                           nonProxyHosts:
-                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
+                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
                             items:
                               type: string
                             type: array
                           port:
                             description: Proxy server port.
-                            type: string
+                            type: integer
                           url:
-                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
+                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
                             type: string
                         type: object
                     type: object
                   dashboard:
-                    description: Configuration settings related to the dashboard used by the Che installation.
+                    description: Configuration settings related to the Dashboard used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -921,7 +925,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -939,7 +943,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -984,17 +988,23 @@ spec:
                         type: object
                     type: object
                   database:
+                    default:
+                      externalDb: false
+                      postgresDb: dbche
+                      postgresHostName: postgres
+                      postgresPort: "5432"
+                      pvc:
+                        claimSize: 1Gi
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
-                        default: postgres-credentials
-                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
+                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the DB. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1011,7 +1021,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1029,7 +1039,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1063,11 +1073,12 @@ spec:
                             type: object
                         type: object
                       externalDb:
-                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details about the external database you want to use.
+                        default: false
+                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details to the external DB you want to use.
                         type: boolean
                       postgresDb:
                         default: dbche
-                        description: PostgreSQL database name that the Che server uses to connect to the database.
+                        description: PostgreSQL database name that the Che server uses to connect to the DB.
                         type: string
                       postgresHostName:
                         default: postgres
@@ -1078,10 +1089,12 @@ spec:
                         description: PostgreSQL Database port the Che server connects to. Override this value only when using an external database. See field `externalDb`.
                         type: string
                       pvc:
+                        default:
+                          claimSize: 1Gi
                         description: PVC settings for PostgreSQL database.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
+                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1089,13 +1102,13 @@ spec:
                         type: object
                     type: object
                   devWorkspace:
-                    description: DevWorkspace Operator configuration.
+                    description: DevWorkspace operator configuration.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1112,7 +1125,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1130,7 +1143,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1168,13 +1181,13 @@ spec:
                         type: string
                     type: object
                   devfileRegistry:
-                    description: Configuration settings related to the devfile registry used by the Che installation.
+                    description: Configuration settings related to the Devfile registry used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1191,7 +1204,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1209,7 +1222,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1263,7 +1276,7 @@ spec:
                         description: Install and configure the community supported Kubernetes Image Puller Operator. When you set the value to `true` without providing any specs, it creates a default Kubernetes Image Puller object managed by the Operator. When you set the value to `false`, the Kubernetes Image Puller object is deleted, and the Operator uninstalled, regardless of whether a spec is provided. If you leave the `spec.images` field empty, a set of recommended workspace-related images is automatically detected and pre-pulled after installation. Note that while this Operator and its behavior is community-supported, its payload may be commercially-supported for pulling commercially-supported images.
                         type: boolean
                       spec:
-                        description: A Kubernetes Image Puller spec to configure the image puller in the CheCluster.
+                        description: A Kubernetes Image Puller spec  to configure the image puller in the CheCluster
                         properties:
                           affinity:
                             type: string
@@ -1292,10 +1305,10 @@ spec:
                           nodeSelector:
                             type: string
                         type: object
-                    required:
-                    - enable
                     type: object
                   metrics:
+                    default:
+                      enable: true
                     description: Che server metrics configuration.
                     properties:
                       enable:
@@ -1309,8 +1322,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1327,7 +1340,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1345,7 +1358,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1407,18 +1420,22 @@ spec:
                 description: Development environment default configuration options.
                 properties:
                   defaultNamespace:
+                    default:
+                      template: <username>-che
                     description: User's default namespace.
                     properties:
                       template:
-                        description: If you don't create the user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>`, `<userid>` and `<workspaceid>` placeholders, such as che-workspace-<username>.
+                        default: <username>-che
+                        description: If you don't create user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
+                        pattern: <username>|<userid>
                         type: string
                     type: object
                   defaultPlugins:
-                    description: Default plug-ins applied to DevWorkspaces.
+                    description: Default plug-ins applied to Dev Workspaces.
                     items:
                       properties:
                         editor:
-                          description: The editor ID to specify default plug-ins for.
+                          description: The editor id to specify default plug-ins for.
                           type: string
                         plugins:
                           description: Default plug-in URIs for the specified editor.
@@ -1433,13 +1450,15 @@ spec:
                     description: The node selector limits the nodes that can run the workspace pods.
                     type: object
                   storage:
+                    default:
+                      pvcStrategy: common
                     description: Workspaces persistent storage.
                     properties:
                       pvc:
                         description: PVC settings.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
+                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1447,7 +1466,10 @@ spec:
                         type: object
                       pvcStrategy:
                         default: common
-                        description: Persistent volume claim strategy for the Che server. Only the `common` strategy (all workspaces PVCs in one volume) is supported . For details, see https://github.com/eclipse/che/issues/21185.
+                        description: Persistent volume claim strategy for the Che server.
+                        enum:
+                        - common
+                        - per-workspace
                         type: string
                     type: object
                   tolerations:
@@ -1482,29 +1504,41 @@ spec:
                     type: object
                 type: object
               networking:
-                description: Networking, Che authentication, and TLS configuration.
+                description: Networking, Che authentication and TLS configuration.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Defines annotations which will be set for an Ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
+                    description: 'Defines annotations which will be set to an ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
                     type: object
                   auth:
+                    default:
+                      gateway:
+                        configLabels:
+                          app: che
+                          component: che-gateway-config
                     description: Authentication settings.
                     properties:
                       gateway:
+                        default:
+                          configLabels:
+                            app: che
+                            component: che-gateway-config
                         description: Gateway settings.
                         properties:
                           configLabels:
                             additionalProperties:
                               type: string
-                            description: Gate configuration labels.
+                            default:
+                              app: che
+                              component: che-gateway-config
+                            description: Gateway configuration labels.
                             type: object
                           deployment:
                             description: 'Deployment override options. Since gateway deployment consists of several containers, they must be distinguished in the configuration by their names: - `gateway` - `configbump` - `oauth-proxy` - `kube-rbac-proxy`'
                             properties:
-                              containers:
-                                description: List of containers belonging to the pod.
+                              container:
+                                description: A single application container.
                                 items:
                                   description: Container custom settings.
                                   properties:
@@ -1521,7 +1555,7 @@ spec:
                                       description: Compute resources required by this container.
                                       properties:
                                         limits:
-                                          description: Describes the maximum amount of compute resources allowed.
+                                          description: Limits describe the maximum amount of compute resources allowed.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1539,7 +1573,7 @@ spec:
                                               x-kubernetes-int-or-string: true
                                           type: object
                                         request:
-                                          description: Describes the minimum amount of compute resources required.
+                                          description: Request describes the minimum amount of compute resources required.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1584,7 +1618,7 @@ spec:
                         type: string
                     type: object
                   domain:
-                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for the route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In conjunction with labels, it creates a route served by a non-default Ingress controller. For a Kubernetes cluster, it contains a global ingress domain. There are no default values: you must specify them.'
+                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for a route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In a conjunction with labels it creates a route, which is served by a non-default Ingress controller. For Kubernetes cluster it contains a global ingress domain. This MUST be explicitly specified: there are no defaults.'
                     type: string
                   hostname:
                     description: The public hostname of the installed Che server.
@@ -1592,7 +1626,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: Defines labels which will be set for an Ingress (a route for OpenShift platform).
+                    description: Defines labels which will be set to an ingress (a route for OpenShift platform).
                     type: object
                   tlsSecretName:
                     description: The name of the secret used to set up Ingress TLS termination. If the field is an empty string, the default cluster certificate is used. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
@@ -1600,34 +1634,34 @@ spec:
                 type: object
             type: object
           status:
-            description: Defines the observed state of Che installation.
+            description: CheClusterStatus defines the observed state of Che installation.
             properties:
               chePhase:
                 description: Specifies the current phase of the Che deployment.
                 type: string
               cheURL:
-                description: Public URL of the Che server.
+                description: Public URL to the Che server.
                 type: string
               cheVersion:
-                description: Currently installed Che version.
+                description: Current installed Che version.
                 type: string
               devfileRegistryURL:
-                description: The public URL of the internal devfile registry.
+                description: The public URL to the internal devfile registry.
                 type: string
               gatewayPhase:
                 description: Specifies the current phase of the gateway deployment.
                 type: string
               message:
-                description: A human readable message indicating details about why the Che deployment is in the current phase.
+                description: A human readable message indicating details about why the Che deployment is in current phase.
                 type: string
               pluginRegistryURL:
-                description: The public URL of the internal plug-in registry.
+                description: The public URL to the internal plug-in registry.
                 type: string
               postgresVersion:
                 description: The PostgreSQL version of the image in use.
                 type: string
               reason:
-                description: A brief CamelCase message indicating details about why the Che deployment is in the current phase.
+                description: A brief CamelCase message indicating details about why the Che deployment is in current phase.
                 type: string
               workspaceBaseDomain:
                 description: The resolved workspace base domain. This is either the copy of the explicitly defined property of the same name in the spec or, if it is undefined in the spec and we're running on OpenShift, the automatically resolved basedomain for routes.

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -989,6 +989,7 @@ spec:
                     type: object
                   database:
                     default:
+                      credentialsSecretName: postgres-credentials
                       externalDb: false
                       postgresDb: dbche
                       postgresHostName: postgres
@@ -998,6 +999,7 @@ spec:
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
+                        default: postgres-credentials
                         description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -784,6 +784,20 @@ spec:
             description: Desired configuration of Eclipse Che installation.
             properties:
               components:
+                default:
+                  cheServer:
+                    debug: false
+                    logLevel: INFO
+                  database:
+                    credentialsSecretName: postgres-credentials
+                    externalDb: false
+                    postgresDb: dbche
+                    postgresHostName: postgres
+                    postgresPort: "5432"
+                    pvc:
+                      claimSize: 1Gi
+                  metrics:
+                    enable: true
                 description: Che components configuration.
                 properties:
                   cheServer:
@@ -814,6 +828,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -917,6 +935,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1015,6 +1037,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1119,6 +1145,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1198,6 +1228,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1334,6 +1368,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1419,6 +1457,11 @@ spec:
                     type: string
                 type: object
               devEnvironments:
+                default:
+                  defaultNamespace:
+                    template: <username>-che
+                  storage:
+                    pvcStrategy: common
                 description: Development environment default configuration options.
                 properties:
                   defaultNamespace:
@@ -1506,6 +1549,12 @@ spec:
                     type: object
                 type: object
               networking:
+                default:
+                  auth:
+                    gateway:
+                      configLabels:
+                        app: che
+                        component: che-gateway-config
                 description: Networking, Che authentication, and TLS configuration.
                 properties:
                   annotations:
@@ -1549,6 +1598,10 @@ spec:
                                       type: string
                                     imagePullPolicy:
                                       description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                      enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
                                       type: string
                                     name:
                                       description: Container name.

--- a/deploy/deployment/openshift/org_v2_checluster.yaml
+++ b/deploy/deployment/openshift/org_v2_checluster.yaml
@@ -16,20 +16,7 @@ metadata:
   name: eclipse-che
   namespace: eclipse-che
 spec:
-  devEnvironments:
-    defaultNamespace:
-      template: '<username>-che'
-    storage:
-      pvcStrategy: 'common'
-  components:
-    database:
-      externalDb: false
-    metrics:
-      enable: true
-  networking:
-    domain: ''
-    tlsSecretName: ''
-    auth:
-      identityProviderURL: ''
-      oAuthClientName: ''
-      oAuthSecret: ''
+  components: {}
+  devEnvironments: {}
+  networking: {}
+  containerRegistry: {}

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -804,8 +804,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -822,7 +822,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -840,7 +840,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -876,7 +876,7 @@ spec:
                       extraProperties:
                         additionalProperties:
                           type: string
-                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server, in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` fields contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
+                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` field contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
                         type: object
                       logLevel:
                         default: INFO
@@ -889,26 +889,26 @@ spec:
                             description: The secret name that contains `user` and `password` for a proxy server. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                             type: string
                           nonProxyHosts:
-                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
+                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
                             items:
                               type: string
                             type: array
                           port:
                             description: Proxy server port.
-                            type: integer
+                            type: string
                           url:
-                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
+                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
                             type: string
                         type: object
                     type: object
                   dashboard:
-                    description: Configuration settings related to the Dashboard used by the Che installation.
+                    description: Configuration settings related to the dashboard used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -925,7 +925,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -943,7 +943,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -998,13 +998,13 @@ spec:
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
-                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the DB. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
+                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1021,7 +1021,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1039,7 +1039,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1074,11 +1074,11 @@ spec:
                         type: object
                       externalDb:
                         default: false
-                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details to the external DB you want to use.
+                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details about the external database you want to use.
                         type: boolean
                       postgresDb:
                         default: dbche
-                        description: PostgreSQL database name that the Che server uses to connect to the DB.
+                        description: PostgreSQL database name that the Che server uses to connect to the database.
                         type: string
                       postgresHostName:
                         default: postgres
@@ -1094,7 +1094,7 @@ spec:
                         description: PVC settings for PostgreSQL database.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
+                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1102,13 +1102,13 @@ spec:
                         type: object
                     type: object
                   devWorkspace:
-                    description: DevWorkspace operator configuration.
+                    description: DevWorkspace Operator configuration.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1125,7 +1125,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1143,7 +1143,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1181,13 +1181,13 @@ spec:
                         type: string
                     type: object
                   devfileRegistry:
-                    description: Configuration settings related to the Devfile registry used by the Che installation.
+                    description: Configuration settings related to the devfile registry used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1204,7 +1204,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1222,7 +1222,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1276,7 +1276,7 @@ spec:
                         description: Install and configure the community supported Kubernetes Image Puller Operator. When you set the value to `true` without providing any specs, it creates a default Kubernetes Image Puller object managed by the Operator. When you set the value to `false`, the Kubernetes Image Puller object is deleted, and the Operator uninstalled, regardless of whether a spec is provided. If you leave the `spec.images` field empty, a set of recommended workspace-related images is automatically detected and pre-pulled after installation. Note that while this Operator and its behavior is community-supported, its payload may be commercially-supported for pulling commercially-supported images.
                         type: boolean
                       spec:
-                        description: A Kubernetes Image Puller spec  to configure the image puller in the CheCluster
+                        description: A Kubernetes Image Puller spec to configure the image puller in the CheCluster.
                         properties:
                           affinity:
                             type: string
@@ -1322,8 +1322,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          container:
-                            description: A single application container.
+                          containers:
+                            description: List of containers belonging to the pod.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1340,7 +1340,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Limits describe the maximum amount of compute resources allowed.
+                                      description: Describes the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1358,7 +1358,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Request describes the minimum amount of compute resources required.
+                                      description: Describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1426,16 +1426,16 @@ spec:
                     properties:
                       template:
                         default: <username>-che
-                        description: If you don't create user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
+                        description: If you don't create the user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
                         pattern: <username>|<userid>
                         type: string
                     type: object
                   defaultPlugins:
-                    description: Default plug-ins applied to Dev Workspaces.
+                    description: Default plug-ins applied to DevWorkspaces.
                     items:
                       properties:
                         editor:
-                          description: The editor id to specify default plug-ins for.
+                          description: The editor ID to specify default plug-ins for.
                           type: string
                         plugins:
                           description: Default plug-in URIs for the specified editor.
@@ -1458,7 +1458,7 @@ spec:
                         description: PVC settings.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
+                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1466,7 +1466,7 @@ spec:
                         type: object
                       pvcStrategy:
                         default: common
-                        description: Persistent volume claim strategy for the Che server.
+                        description: Persistent volume claim strategy for the Che server. Only the `common` strategy (all workspaces PVCs in one volume) is supported . For details, see https://github.com/eclipse/che/issues/21185.
                         enum:
                         - common
                         - per-workspace
@@ -1504,12 +1504,12 @@ spec:
                     type: object
                 type: object
               networking:
-                description: Networking, Che authentication and TLS configuration.
+                description: Networking, Che authentication, and TLS configuration.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Defines annotations which will be set to an ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
+                    description: 'Defines annotations which will be set for an Ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
                     type: object
                   auth:
                     default:
@@ -1537,8 +1537,8 @@ spec:
                           deployment:
                             description: 'Deployment override options. Since gateway deployment consists of several containers, they must be distinguished in the configuration by their names: - `gateway` - `configbump` - `oauth-proxy` - `kube-rbac-proxy`'
                             properties:
-                              container:
-                                description: A single application container.
+                              containers:
+                                description: List of containers belonging to the pod.
                                 items:
                                   description: Container custom settings.
                                   properties:
@@ -1555,7 +1555,7 @@ spec:
                                       description: Compute resources required by this container.
                                       properties:
                                         limits:
-                                          description: Limits describe the maximum amount of compute resources allowed.
+                                          description: Describes the maximum amount of compute resources allowed.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1573,7 +1573,7 @@ spec:
                                               x-kubernetes-int-or-string: true
                                           type: object
                                         request:
-                                          description: Request describes the minimum amount of compute resources required.
+                                          description: Describes the minimum amount of compute resources required.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1618,7 +1618,7 @@ spec:
                         type: string
                     type: object
                   domain:
-                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for a route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In a conjunction with labels it creates a route, which is served by a non-default Ingress controller. For Kubernetes cluster it contains a global ingress domain. This MUST be explicitly specified: there are no defaults.'
+                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for the route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In conjunction with labels, it creates a route served by a non-default Ingress controller. For a Kubernetes cluster, it contains a global ingress domain. There are no default values: you must specify them.'
                     type: string
                   hostname:
                     description: The public hostname of the installed Che server.
@@ -1626,7 +1626,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: Defines labels which will be set to an ingress (a route for OpenShift platform).
+                    description: Defines labels which will be set for an Ingress (a route for OpenShift platform).
                     type: object
                   tlsSecretName:
                     description: The name of the secret used to set up Ingress TLS termination. If the field is an empty string, the default cluster certificate is used. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
@@ -1634,34 +1634,34 @@ spec:
                 type: object
             type: object
           status:
-            description: CheClusterStatus defines the observed state of Che installation.
+            description: Defines the observed state of Che installation.
             properties:
               chePhase:
                 description: Specifies the current phase of the Che deployment.
                 type: string
               cheURL:
-                description: Public URL to the Che server.
+                description: Public URL of the Che server.
                 type: string
               cheVersion:
-                description: Current installed Che version.
+                description: Currently installed Che version.
                 type: string
               devfileRegistryURL:
-                description: The public URL to the internal devfile registry.
+                description: The public URL of the internal devfile registry.
                 type: string
               gatewayPhase:
                 description: Specifies the current phase of the gateway deployment.
                 type: string
               message:
-                description: A human readable message indicating details about why the Che deployment is in current phase.
+                description: A human readable message indicating details about why the Che deployment is in the current phase.
                 type: string
               pluginRegistryURL:
-                description: The public URL to the internal plug-in registry.
+                description: The public URL of the internal plug-in registry.
                 type: string
               postgresVersion:
                 description: The PostgreSQL version of the image in use.
                 type: string
               reason:
-                description: A brief CamelCase message indicating details about why the Che deployment is in current phase.
+                description: A brief CamelCase message indicating details about why the Che deployment is in the current phase.
                 type: string
               workspaceBaseDomain:
                 description: The resolved workspace base domain. This is either the copy of the explicitly defined property of the same name in the spec or, if it is undefined in the spec and we're running on OpenShift, the automatically resolved basedomain for routes.

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -787,6 +787,9 @@ spec:
                 description: Che components configuration.
                 properties:
                   cheServer:
+                    default:
+                      debug: false
+                      logLevel: INFO
                     description: General configuration settings related to the Che server.
                     properties:
                       clusterRoles:
@@ -795,13 +798,14 @@ spec:
                           type: string
                         type: array
                       debug:
+                        default: false
                         description: Enables the debug mode for Che server.
                         type: boolean
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -818,7 +822,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -836,7 +840,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -872,7 +876,7 @@ spec:
                       extraProperties:
                         additionalProperties:
                           type: string
-                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` field contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
+                        description: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server, in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` fields contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
                         type: object
                       logLevel:
                         default: INFO
@@ -885,26 +889,26 @@ spec:
                             description: The secret name that contains `user` and `password` for a proxy server. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                             type: string
                           nonProxyHosts:
-                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
+                            description: 'A list of hosts that can be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>`, for example:    - localhost    - my.host.com    - 123.42.12.32 Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyURL` fields.'
                             items:
                               type: string
                             type: array
                           port:
                             description: Proxy server port.
-                            type: string
+                            type: integer
                           url:
-                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
+                            description: 'URL (protocol+hostname) of the proxy server. Use only when a proxy configuration is required. Operator respects OpenShift cluster-wide proxy configuration, defining `url` in a custom resource leads to overriding the cluster proxy configuration. See the following page: https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html. See also the `proxyPort` and `nonProxyHosts` fields.'
                             type: string
                         type: object
                     type: object
                   dashboard:
-                    description: Configuration settings related to the dashboard used by the Che installation.
+                    description: Configuration settings related to the Dashboard used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -921,7 +925,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -939,7 +943,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -984,17 +988,23 @@ spec:
                         type: object
                     type: object
                   database:
+                    default:
+                      externalDb: false
+                      postgresDb: dbche
+                      postgresHostName: postgres
+                      postgresPort: "5432"
+                      pvc:
+                        claimSize: 1Gi
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
-                        default: postgres-credentials
-                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
+                        description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the DB. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1011,7 +1021,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1029,7 +1039,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1063,11 +1073,12 @@ spec:
                             type: object
                         type: object
                       externalDb:
-                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details about the external database you want to use.
+                        default: false
+                        description: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is set as `true`, no dedicated database is deployed by the Operator and you need to provide connection details to the external DB you want to use.
                         type: boolean
                       postgresDb:
                         default: dbche
-                        description: PostgreSQL database name that the Che server uses to connect to the database.
+                        description: PostgreSQL database name that the Che server uses to connect to the DB.
                         type: string
                       postgresHostName:
                         default: postgres
@@ -1078,10 +1089,12 @@ spec:
                         description: PostgreSQL Database port the Che server connects to. Override this value only when using an external database. See field `externalDb`.
                         type: string
                       pvc:
+                        default:
+                          claimSize: 1Gi
                         description: PVC settings for PostgreSQL database.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
+                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1089,13 +1102,13 @@ spec:
                         type: object
                     type: object
                   devWorkspace:
-                    description: DevWorkspace Operator configuration.
+                    description: DevWorkspace operator configuration.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1112,7 +1125,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1130,7 +1143,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1168,13 +1181,13 @@ spec:
                         type: string
                     type: object
                   devfileRegistry:
-                    description: Configuration settings related to the devfile registry used by the Che installation.
+                    description: Configuration settings related to the Devfile registry used by the Che installation.
                     properties:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1191,7 +1204,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1209,7 +1222,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1263,7 +1276,7 @@ spec:
                         description: Install and configure the community supported Kubernetes Image Puller Operator. When you set the value to `true` without providing any specs, it creates a default Kubernetes Image Puller object managed by the Operator. When you set the value to `false`, the Kubernetes Image Puller object is deleted, and the Operator uninstalled, regardless of whether a spec is provided. If you leave the `spec.images` field empty, a set of recommended workspace-related images is automatically detected and pre-pulled after installation. Note that while this Operator and its behavior is community-supported, its payload may be commercially-supported for pulling commercially-supported images.
                         type: boolean
                       spec:
-                        description: A Kubernetes Image Puller spec to configure the image puller in the CheCluster.
+                        description: A Kubernetes Image Puller spec  to configure the image puller in the CheCluster
                         properties:
                           affinity:
                             type: string
@@ -1292,10 +1305,10 @@ spec:
                           nodeSelector:
                             type: string
                         type: object
-                    required:
-                    - enable
                     type: object
                   metrics:
+                    default:
+                      enable: true
                     description: Che server metrics configuration.
                     properties:
                       enable:
@@ -1309,8 +1322,8 @@ spec:
                       deployment:
                         description: Deployment override options.
                         properties:
-                          containers:
-                            description: List of containers belonging to the pod.
+                          container:
+                            description: A single application container.
                             items:
                               description: Container custom settings.
                               properties:
@@ -1327,7 +1340,7 @@ spec:
                                   description: Compute resources required by this container.
                                   properties:
                                     limits:
-                                      description: Describes the maximum amount of compute resources allowed.
+                                      description: Limits describe the maximum amount of compute resources allowed.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1345,7 +1358,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     request:
-                                      description: Describes the minimum amount of compute resources required.
+                                      description: Request describes the minimum amount of compute resources required.
                                       properties:
                                         cpu:
                                           anyOf:
@@ -1407,18 +1420,22 @@ spec:
                 description: Development environment default configuration options.
                 properties:
                   defaultNamespace:
+                    default:
+                      template: <username>-che
                     description: User's default namespace.
                     properties:
                       template:
-                        description: If you don't create the user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>`, `<userid>` and `<workspaceid>` placeholders, such as che-workspace-<username>.
+                        default: <username>-che
+                        description: If you don't create user namespaces in advance, this field defines the Kubernetes namespace created when you start your first workspace. You can use `<username>` and `<userid>` placeholders, such as che-workspace-<username>.
+                        pattern: <username>|<userid>
                         type: string
                     type: object
                   defaultPlugins:
-                    description: Default plug-ins applied to DevWorkspaces.
+                    description: Default plug-ins applied to Dev Workspaces.
                     items:
                       properties:
                         editor:
-                          description: The editor ID to specify default plug-ins for.
+                          description: The editor id to specify default plug-ins for.
                           type: string
                         plugins:
                           description: Default plug-in URIs for the specified editor.
@@ -1433,13 +1450,15 @@ spec:
                     description: The node selector limits the nodes that can run the workspace pods.
                     type: object
                   storage:
+                    default:
+                      pvcStrategy: common
                     description: Workspaces persistent storage.
                     properties:
                       pvc:
                         description: PVC settings.
                         properties:
                           claimSize:
-                            description: Persistent Volume Claim size. To update the claim size, the storage class that provisions it must support resizing.
+                            description: Persistent Volume Claim size. To update the claim size, Storage class that provisions it must support resize.
                             type: string
                           storageClass:
                             description: Storage class for the Persistent Volume Claim. When omitted or left blank, a default storage class is used.
@@ -1447,7 +1466,10 @@ spec:
                         type: object
                       pvcStrategy:
                         default: common
-                        description: Persistent volume claim strategy for the Che server. Only the `common` strategy (all workspaces PVCs in one volume) is supported . For details, see https://github.com/eclipse/che/issues/21185.
+                        description: Persistent volume claim strategy for the Che server.
+                        enum:
+                        - common
+                        - per-workspace
                         type: string
                     type: object
                   tolerations:
@@ -1482,29 +1504,41 @@ spec:
                     type: object
                 type: object
               networking:
-                description: Networking, Che authentication, and TLS configuration.
+                description: Networking, Che authentication and TLS configuration.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Defines annotations which will be set for an Ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
+                    description: 'Defines annotations which will be set to an ingress (a route for OpenShift platform). The defaults for kubernetes platforms are:     kubernetes.io/ingress.class:                       "nginx"     nginx.ingress.kubernetes.io/proxy-read-timeout:    "3600",     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600",     nginx.ingress.kubernetes.io/ssl-redirect:          "true"'
                     type: object
                   auth:
+                    default:
+                      gateway:
+                        configLabels:
+                          app: che
+                          component: che-gateway-config
                     description: Authentication settings.
                     properties:
                       gateway:
+                        default:
+                          configLabels:
+                            app: che
+                            component: che-gateway-config
                         description: Gateway settings.
                         properties:
                           configLabels:
                             additionalProperties:
                               type: string
-                            description: Gate configuration labels.
+                            default:
+                              app: che
+                              component: che-gateway-config
+                            description: Gateway configuration labels.
                             type: object
                           deployment:
                             description: 'Deployment override options. Since gateway deployment consists of several containers, they must be distinguished in the configuration by their names: - `gateway` - `configbump` - `oauth-proxy` - `kube-rbac-proxy`'
                             properties:
-                              containers:
-                                description: List of containers belonging to the pod.
+                              container:
+                                description: A single application container.
                                 items:
                                   description: Container custom settings.
                                   properties:
@@ -1521,7 +1555,7 @@ spec:
                                       description: Compute resources required by this container.
                                       properties:
                                         limits:
-                                          description: Describes the maximum amount of compute resources allowed.
+                                          description: Limits describe the maximum amount of compute resources allowed.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1539,7 +1573,7 @@ spec:
                                               x-kubernetes-int-or-string: true
                                           type: object
                                         request:
-                                          description: Describes the minimum amount of compute resources required.
+                                          description: Request describes the minimum amount of compute resources required.
                                           properties:
                                             cpu:
                                               anyOf:
@@ -1584,7 +1618,7 @@ spec:
                         type: string
                     type: object
                   domain:
-                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for the route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In conjunction with labels, it creates a route served by a non-default Ingress controller. For a Kubernetes cluster, it contains a global ingress domain. There are no default values: you must specify them.'
+                    description: 'For an OpenShift cluster, the Operator uses the domain to generate a hostname for a route. The generated hostname follows this pattern: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In a conjunction with labels it creates a route, which is served by a non-default Ingress controller. For Kubernetes cluster it contains a global ingress domain. This MUST be explicitly specified: there are no defaults.'
                     type: string
                   hostname:
                     description: The public hostname of the installed Che server.
@@ -1592,7 +1626,7 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: Defines labels which will be set for an Ingress (a route for OpenShift platform).
+                    description: Defines labels which will be set to an ingress (a route for OpenShift platform).
                     type: object
                   tlsSecretName:
                     description: The name of the secret used to set up Ingress TLS termination. If the field is an empty string, the default cluster certificate is used. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
@@ -1600,34 +1634,34 @@ spec:
                 type: object
             type: object
           status:
-            description: Defines the observed state of Che installation.
+            description: CheClusterStatus defines the observed state of Che installation.
             properties:
               chePhase:
                 description: Specifies the current phase of the Che deployment.
                 type: string
               cheURL:
-                description: Public URL of the Che server.
+                description: Public URL to the Che server.
                 type: string
               cheVersion:
-                description: Currently installed Che version.
+                description: Current installed Che version.
                 type: string
               devfileRegistryURL:
-                description: The public URL of the internal devfile registry.
+                description: The public URL to the internal devfile registry.
                 type: string
               gatewayPhase:
                 description: Specifies the current phase of the gateway deployment.
                 type: string
               message:
-                description: A human readable message indicating details about why the Che deployment is in the current phase.
+                description: A human readable message indicating details about why the Che deployment is in current phase.
                 type: string
               pluginRegistryURL:
-                description: The public URL of the internal plug-in registry.
+                description: The public URL to the internal plug-in registry.
                 type: string
               postgresVersion:
                 description: The PostgreSQL version of the image in use.
                 type: string
               reason:
-                description: A brief CamelCase message indicating details about why the Che deployment is in the current phase.
+                description: A brief CamelCase message indicating details about why the Che deployment is in current phase.
                 type: string
               workspaceBaseDomain:
                 description: The resolved workspace base domain. This is either the copy of the explicitly defined property of the same name in the spec or, if it is undefined in the spec and we're running on OpenShift, the automatically resolved basedomain for routes.

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -989,6 +989,7 @@ spec:
                     type: object
                   database:
                     default:
+                      credentialsSecretName: postgres-credentials
                       externalDb: false
                       postgresDb: dbche
                       postgresHostName: postgres
@@ -998,6 +999,7 @@ spec:
                     description: Configuration settings related to the database used by the Che installation.
                     properties:
                       credentialsSecretName:
+                        default: postgres-credentials
                         description: The secret that contains PostgreSQL `user` and `password` that the Che server uses to connect to the database. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                       deployment:

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -784,6 +784,20 @@ spec:
             description: Desired configuration of Eclipse Che installation.
             properties:
               components:
+                default:
+                  cheServer:
+                    debug: false
+                    logLevel: INFO
+                  database:
+                    credentialsSecretName: postgres-credentials
+                    externalDb: false
+                    postgresDb: dbche
+                    postgresHostName: postgres
+                    postgresPort: "5432"
+                    pvc:
+                      claimSize: 1Gi
+                  metrics:
+                    enable: true
                 description: Che components configuration.
                 properties:
                   cheServer:
@@ -814,6 +828,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -917,6 +935,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1015,6 +1037,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1119,6 +1145,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1198,6 +1228,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1334,6 +1368,10 @@ spec:
                                   type: string
                                 imagePullPolicy:
                                   description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                  enum:
+                                  - Always
+                                  - IfNotPresent
+                                  - Never
                                   type: string
                                 name:
                                   description: Container name.
@@ -1419,6 +1457,11 @@ spec:
                     type: string
                 type: object
               devEnvironments:
+                default:
+                  defaultNamespace:
+                    template: <username>-che
+                  storage:
+                    pvcStrategy: common
                 description: Development environment default configuration options.
                 properties:
                   defaultNamespace:
@@ -1506,6 +1549,12 @@ spec:
                     type: object
                 type: object
               networking:
+                default:
+                  auth:
+                    gateway:
+                      configLabels:
+                        app: che
+                        component: che-gateway-config
                 description: Networking, Che authentication, and TLS configuration.
                 properties:
                   annotations:
@@ -1549,6 +1598,10 @@ spec:
                                       type: string
                                     imagePullPolicy:
                                       description: Image pull policy. Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
+                                      enum:
+                                      - Always
+                                      - IfNotPresent
+                                      - Never
                                       type: string
                                     name:
                                       description: Container name.

--- a/helmcharts/next/templates/org_v2_checluster.yaml
+++ b/helmcharts/next/templates/org_v2_checluster.yaml
@@ -16,20 +16,10 @@ metadata:
   name: eclipse-che
   namespace: eclipse-che
 spec:
-  devEnvironments:
-    defaultNamespace:
-      template: '<username>-che'
-    storage:
-      pvcStrategy: 'common'
-  components:
-    database:
-      externalDb: false
-    metrics:
-      enable: true
-  networking:
-    domain: '{{ .Values.networking.domain }}'
-    tlsSecretName: 'che-tls'
-    auth:
-      identityProviderURL: '{{ .Values.networking.auth.identityProviderURL }}'
-      oAuthClientName: '{{ .Values.networking.auth.oAuthClientName }}'
-      oAuthSecret: '{{ .Values.networking.auth.oAuthSecret }}'
+  components: {}
+  devEnvironments: {}
+  networking: {tlsSecretName: che-tls, domain: '{{ .Values.networking.domain }}',
+    auth: {oAuthSecret: '{{ .Values.networking.auth.oAuthSecret }}', oAuthClientName: '{{
+        .Values.networking.auth.oAuthClientName }}', identityProviderURL: '{{ .Values.networking.auth.identityProviderURL
+        }}'}}
+  containerRegistry: {}

--- a/helmcharts/next/templates/org_v2_checluster.yaml
+++ b/helmcharts/next/templates/org_v2_checluster.yaml
@@ -18,8 +18,11 @@ metadata:
 spec:
   components: {}
   devEnvironments: {}
-  networking: {tlsSecretName: che-tls, domain: '{{ .Values.networking.domain }}',
-    auth: {oAuthSecret: '{{ .Values.networking.auth.oAuthSecret }}', oAuthClientName: '{{
-        .Values.networking.auth.oAuthClientName }}', identityProviderURL: '{{ .Values.networking.auth.identityProviderURL
-        }}'}}
+  networking:
+    tlsSecretName: che-tls
+    domain: '{{ .Values.networking.domain }}'
+    auth:
+      oAuthSecret: '{{ .Values.networking.auth.oAuthSecret }}'
+      oAuthClientName: '{{ .Values.networking.auth.oAuthClientName }}'
+      identityProviderURL: '{{ .Values.networking.auth.identityProviderURL }}'
   containerRegistry: {}

--- a/pkg/common/k8s-helper/k8s_helper.go
+++ b/pkg/common/k8s-helper/k8s_helper.go
@@ -16,8 +16,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 
-	"github.com/eclipse-che/che-operator/pkg/common/test"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/sirupsen/logrus"
@@ -42,7 +42,7 @@ func New() *K8sHelper {
 		return k8sHelper
 	}
 
-	if test.IsTestMode() {
+	if isTestMode() {
 		return initializeForTesting()
 	}
 
@@ -180,4 +180,7 @@ func initialize() *K8sHelper {
 	}
 
 	return k8sHelper
+}
+func isTestMode() bool {
+	return len(os.Getenv("MOCK_API")) != 0
 }


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Set CheCluster defaults

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20804

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

```
oc create namespace eclipse-che
oc apply -f config/crd/bases/org.eclipse.che_checlusters.yaml
oc apply -f config/samples/org_v2_checluster.yaml -n eclipse-che 
oc get checluster/eclipse-che -o yaml -n eclipse-che
```

Check defaults values are set:

```
spec:
  components:
    cheServer:
      debug: false
      logLevel: INFO
    database:
      credentialsSecretName: postgres-credentials
      externalDb: false
      postgresDb: dbche
      postgresHostName: postgres
      postgresPort: "5432"
      pvc:
        claimSize: 1Gi
    metrics:
      enable: true
  containerRegistry: {}
  devEnvironments:
    defaultNamespace:
      template: <username>-che
    storage:
      pvcStrategy: common
  networking:
    auth:
      gateway:
        configLabels:
          app: che
          component: che-gateway-config

```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
