### PR TITLE
fix: workspaces policies

### DIFF
--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.50.0-620.next
+  name: eclipse-che-preview-openshift.v7.50.0-621.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -539,6 +539,7 @@ spec:
                 - pods/exec
               verbs:
                 - create
+                - get
             - apiGroups:
                 - apps
               resources:
@@ -1387,7 +1388,7 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.50.0-620.next
+  version: 7.50.0-621.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/config/rbac/cluster_role.yaml
+++ b/config/rbac/cluster_role.yaml
@@ -154,6 +154,7 @@ rules:
       - pods/exec
     verbs:
       - create
+      - get
   - apiGroups:
       - apps
     resources:

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -3933,6 +3933,7 @@ rules:
   - pods/exec
   verbs:
   - create
+  - get
 - apiGroups:
   - apps
   resources:

--- a/deploy/deployment/kubernetes/objects/che-operator.ClusterRole.yaml
+++ b/deploy/deployment/kubernetes/objects/che-operator.ClusterRole.yaml
@@ -153,6 +153,7 @@ rules:
   - pods/exec
   verbs:
   - create
+  - get
 - apiGroups:
   - apps
   resources:

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -3933,6 +3933,7 @@ rules:
   - pods/exec
   verbs:
   - create
+  - get
 - apiGroups:
   - apps
   resources:

--- a/deploy/deployment/openshift/objects/che-operator.ClusterRole.yaml
+++ b/deploy/deployment/openshift/objects/che-operator.ClusterRole.yaml
@@ -153,6 +153,7 @@ rules:
   - pods/exec
   verbs:
   - create
+  - get
 - apiGroups:
   - apps
   resources:

--- a/helmcharts/next/templates/che-operator.ClusterRole.yaml
+++ b/helmcharts/next/templates/che-operator.ClusterRole.yaml
@@ -153,6 +153,7 @@ rules:
   - pods/exec
   verbs:
   - create
+  - get
 - apiGroups:
   - apps
   resources:

--- a/pkg/deploy/rbac/workspace_permissions.go
+++ b/pkg/deploy/rbac/workspace_permissions.go
@@ -269,7 +269,7 @@ func (c *WorkspacePermissionsReconciler) getWorkspacesPolicies() []rbacv1.Policy
 		{
 			APIGroups: []string{""},
 			Resources: []string{"pods/exec"},
-			Verbs:     []string{"create"},
+			Verbs:     []string{"get", "create"},
 		},
 		{
 			APIGroups: []string{""},


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
This PR added the verb "get" to the "pods/exec" section 
```
rules:
  - verbs:
      - create
      - get
    apiGroups:
      - ''
    resources:
      - pods/exec
```
since the [client](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-backend/src/devworkspace-client/services/api/kubeConfigApi.ts#L211-L223) in the [che-dashboard](https://github.com/eclipse-che/che-dashboard)  
```
...
        const url = `${k8sServer}/api/v1/namespaces/${namespace}/pods/${pod}/exec?${queryStr}`;

        const client = new WebSocket(url, PROTOCOLS, opts);
...
```
needs to send an HTTP GET to negotiate a WebSocket. 



### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

```bash
cat EOF << > /tmp/patch.yaml
<PATCH_CONTENT>
EOF

chectl server:deploy \
     --installer operator \
     --platform <PLATFORM_TO_DEPLOY> \
     --che-operator-image <CUSTOM_OPERATOR_IMAGE> \
     --che-operator-cr-patch-yaml /tmp/patch.yaml
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
