### PR TITLE
fix: prepare-community-operators-update.sh

### DIFF
--- a/olm/prepare-community-operators-update.sh
+++ b/olm/prepare-community-operators-update.sh
@@ -22,7 +22,7 @@ CURRENT_DIR=$(pwd)
 SCRIPT=$(readlink -f "${BASH_SOURCE[0]}")
 BASE_DIR=$(dirname "$(dirname "$SCRIPT")")
 STABLE_CHANNELS=("stable")
-OPERATOR_REPO=$(dirname "$BASE_DIR")
+OPERATOR_REPO=$(dirname $(dirname $(readlink -f "${BASH_SOURCE[0]}")))
 source "${OPERATOR_REPO}/.github/bin/common.sh"
 
 base_branch="main"


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
fix: prepare-community-operators-update.sh
