### PR TITLE
fix: Update RELATED_IMAGE in deployment files on release

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -127,10 +127,6 @@ releaseOperatorCode() {
   echo "[INFO] releaseOperatorCode :: Replacing tags"
   replaceImagesTags
 
-  echo "[INFO] releaseOperatorCode :: Updating deployment files"
-  make gen-deployment
-  make fmt
-
   local operatorYaml=$RELEASE_DIR/config/manager/manager.yaml
   echo "[INFO] releaseOperatorCode :: Validate changes for $operatorYaml"
   checkImageReferences $operatorYaml
@@ -193,6 +189,13 @@ releaseHelmPackage() {
   make update-helmcharts CHANNEL=stable
   git add -A helmcharts/stable
   git commit -m "ci: Update Helm Charts to $RELEASE" --signoff
+}
+
+releaseDeploymentFiles() {
+  echo "[INFO] releaseDeploymentFiles :: release deployment files"
+  make gen-deployment
+  make fmt
+  git commit -m "ci: Update Deployment Files" --signoff
 }
 
 releaseOlmFiles() {
@@ -286,6 +289,8 @@ run() {
   if [[ $RELEASE_OLM_FILES == "true" ]]; then
     releaseOlmFiles
   fi
+  # Must be done after launching `addDigest.sh`
+  releaseDeploymentFiles
   releaseHelmPackage
 }
 


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
fix: Update RELATED_IMAGE in deployment files on release
