### PR TITLE
chore: Deprecate CheCluster API v1

### DIFF
--- a/api/v1/checluster_types.go
+++ b/api/v1/checluster_types.go
@@ -876,7 +876,7 @@ type CheClusterStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:deprecatedversion:warning="org.eclipse.che/v1 CheCluster API is deprecated"
+// +kubebuilder:deprecatedversion:warning="org.eclipse.che/v1 CheCluster is deprecated and will be removed in future releases"
 // +k8s:openapi-gen=true
 // +operator-sdk:csv:customresourcedefinitions:displayName="Eclipse Che instance Specification"
 // +operator-sdk:csv:customresourcedefinitions:order=1

--- a/api/v1/checluster_types.go
+++ b/api/v1/checluster_types.go
@@ -876,6 +876,7 @@ type CheClusterStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:deprecatedversion:warning="org.eclipse.che/v1 CheCluster API is deprecated"
 // +k8s:openapi-gen=true
 // +operator-sdk:csv:customresourcedefinitions:displayName="Eclipse Che instance Specification"
 // +operator-sdk:csv:customresourcedefinitions:order=1

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.52.0-626.next
+  name: eclipse-che-preview-openshift.v7.52.0-627.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1390,7 +1390,7 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.52.0-626.next
+  version: 7.52.0-627.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
@@ -42,7 +42,9 @@ spec:
     singular: checluster
   scope: Namespaced
   versions:
-    - name: v1
+    - deprecated: true
+      deprecationWarning: org.eclipse.che/v1 CheCluster API is deprecated
+      name: v1
       schema:
         openAPIV3Schema:
           description: The `CheCluster` custom resource allows defining and managing

--- a/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
@@ -43,7 +43,8 @@ spec:
   scope: Namespaced
   versions:
     - deprecated: true
-      deprecationWarning: org.eclipse.che/v1 CheCluster API is deprecated
+      deprecationWarning: org.eclipse.che/v1 CheCluster is deprecated and will be
+        removed in future releases
       name: v1
       schema:
         openAPIV3Schema:

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -28,7 +28,8 @@ spec:
   scope: Namespaced
   versions:
   - deprecated: true
-    deprecationWarning: org.eclipse.che/v1 CheCluster API is deprecated
+    deprecationWarning: org.eclipse.che/v1 CheCluster is deprecated and will be removed
+      in future releases
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -27,7 +27,9 @@ spec:
     singular: checluster
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: org.eclipse.che/v1 CheCluster API is deprecated
+    name: v1
     schema:
       openAPIV3Schema:
         description: The `CheCluster` custom resource allows defining and managing

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -47,7 +47,7 @@ spec:
   scope: Namespaced
   versions:
   - deprecated: true
-    deprecationWarning: org.eclipse.che/v1 CheCluster API is deprecated
+    deprecationWarning: org.eclipse.che/v1 CheCluster is deprecated and will be removed in future releases
     name: v1
     schema:
       openAPIV3Schema:

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -46,7 +46,9 @@ spec:
     singular: checluster
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: org.eclipse.che/v1 CheCluster API is deprecated
+    name: v1
     schema:
       openAPIV3Schema:
         description: The `CheCluster` custom resource allows defining and managing a Che server installation

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -42,7 +42,7 @@ spec:
   scope: Namespaced
   versions:
   - deprecated: true
-    deprecationWarning: org.eclipse.che/v1 CheCluster API is deprecated
+    deprecationWarning: org.eclipse.che/v1 CheCluster is deprecated and will be removed in future releases
     name: v1
     schema:
       openAPIV3Schema:

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -41,7 +41,9 @@ spec:
     singular: checluster
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: org.eclipse.che/v1 CheCluster API is deprecated
+    name: v1
     schema:
       openAPIV3Schema:
         description: The `CheCluster` custom resource allows defining and managing a Che server installation

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -47,7 +47,7 @@ spec:
   scope: Namespaced
   versions:
   - deprecated: true
-    deprecationWarning: org.eclipse.che/v1 CheCluster API is deprecated
+    deprecationWarning: org.eclipse.che/v1 CheCluster is deprecated and will be removed in future releases
     name: v1
     schema:
       openAPIV3Schema:

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -46,7 +46,9 @@ spec:
     singular: checluster
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: org.eclipse.che/v1 CheCluster API is deprecated
+    name: v1
     schema:
       openAPIV3Schema:
         description: The `CheCluster` custom resource allows defining and managing a Che server installation

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -42,7 +42,7 @@ spec:
   scope: Namespaced
   versions:
   - deprecated: true
-    deprecationWarning: org.eclipse.che/v1 CheCluster API is deprecated
+    deprecationWarning: org.eclipse.che/v1 CheCluster is deprecated and will be removed in future releases
     name: v1
     schema:
       openAPIV3Schema:

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -41,7 +41,9 @@ spec:
     singular: checluster
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: org.eclipse.che/v1 CheCluster API is deprecated
+    name: v1
     schema:
       openAPIV3Schema:
         description: The `CheCluster` custom resource allows defining and managing a Che server installation

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -42,7 +42,7 @@ spec:
   scope: Namespaced
   versions:
   - deprecated: true
-    deprecationWarning: org.eclipse.che/v1 CheCluster API is deprecated
+    deprecationWarning: org.eclipse.che/v1 CheCluster is deprecated and will be removed in future releases
     name: v1
     schema:
       openAPIV3Schema:

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -41,7 +41,9 @@ spec:
     singular: checluster
   scope: Namespaced
   versions:
-  - name: v1
+  - deprecated: true
+    deprecationWarning: org.eclipse.che/v1 CheCluster API is deprecated
+    name: v1
     schema:
       openAPIV3Schema:
         description: The `CheCluster` custom resource allows defining and managing a Che server installation


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
 Deprecate CheCluster API v1

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
```bash
kubectl apply -f config/samples/org_v1_checluster.yaml                                                                                                    
Warning: org.eclipse.che/v1 CheCluster is deprecated and will be removed in future releases
```

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21579

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
