### PR TITLE
feat: Increase default memory limit for plug-in registry

### DIFF
--- a/api/v1/checluster_types.go
+++ b/api/v1/checluster_types.go
@@ -251,7 +251,7 @@ type CheClusterSpecServer struct {
 	// Default value is `Always` for `nightly`, `next` or `latest` images, and `IfNotPresent` in other cases.
 	// +optional
 	PluginRegistryPullPolicy corev1.PullPolicy `json:"pluginRegistryPullPolicy,omitempty"`
-	// Overrides the memory limit used in the plugin registry deployment. Defaults to 256Mi.
+	// Overrides the memory limit used in the plugin registry deployment. Defaults to 512Mi.
 	// +optional
 	PluginRegistryMemoryLimit string `json:"pluginRegistryMemoryLimit,omitempty"`
 	// Overrides the memory request used in the plugin registry deployment. Defaults to 16Mi.

--- a/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
@@ -921,7 +921,7 @@ spec:
                       type: object
                     pluginRegistryMemoryLimit:
                       description: Overrides the memory limit used in the plugin registry
-                        deployment. Defaults to 256Mi.
+                        deployment. Defaults to 512Mi.
                       type: string
                     pluginRegistryMemoryRequest:
                       description: Overrides the memory request used in the plugin

--- a/bundle/stable/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/stable/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml
@@ -918,7 +918,7 @@ spec:
                       type: object
                     pluginRegistryMemoryLimit:
                       description: Overrides the memory limit used in the plugin registry
-                        deployment. Defaults to 256Mi.
+                        deployment. Defaults to 512Mi.
                       type: string
                     pluginRegistryMemoryRequest:
                       description: Overrides the memory request used in the plugin

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -889,7 +889,7 @@ spec:
                     type: object
                   pluginRegistryMemoryLimit:
                     description: Overrides the memory limit used in the plugin registry
-                      deployment. Defaults to 256Mi.
+                      deployment. Defaults to 512Mi.
                     type: string
                   pluginRegistryMemoryRequest:
                     description: Overrides the memory request used in the plugin registry

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -566,7 +566,7 @@ spec:
                         type: string
                     type: object
                   pluginRegistryMemoryLimit:
-                    description: Overrides the memory limit used in the plugin registry deployment. Defaults to 256Mi.
+                    description: Overrides the memory limit used in the plugin registry deployment. Defaults to 512Mi.
                     type: string
                   pluginRegistryMemoryRequest:
                     description: Overrides the memory request used in the plugin registry deployment. Defaults to 16Mi.

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -561,7 +561,7 @@ spec:
                         type: string
                     type: object
                   pluginRegistryMemoryLimit:
-                    description: Overrides the memory limit used in the plugin registry deployment. Defaults to 256Mi.
+                    description: Overrides the memory limit used in the plugin registry deployment. Defaults to 512Mi.
                     type: string
                   pluginRegistryMemoryRequest:
                     description: Overrides the memory request used in the plugin registry deployment. Defaults to 16Mi.

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -566,7 +566,7 @@ spec:
                         type: string
                     type: object
                   pluginRegistryMemoryLimit:
-                    description: Overrides the memory limit used in the plugin registry deployment. Defaults to 256Mi.
+                    description: Overrides the memory limit used in the plugin registry deployment. Defaults to 512Mi.
                     type: string
                   pluginRegistryMemoryRequest:
                     description: Overrides the memory request used in the plugin registry deployment. Defaults to 16Mi.

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -561,7 +561,7 @@ spec:
                         type: string
                     type: object
                   pluginRegistryMemoryLimit:
-                    description: Overrides the memory limit used in the plugin registry deployment. Defaults to 256Mi.
+                    description: Overrides the memory limit used in the plugin registry deployment. Defaults to 512Mi.
                     type: string
                   pluginRegistryMemoryRequest:
                     description: Overrides the memory request used in the plugin registry deployment. Defaults to 16Mi.

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -561,7 +561,7 @@ spec:
                         type: string
                     type: object
                   pluginRegistryMemoryLimit:
-                    description: Overrides the memory limit used in the plugin registry deployment. Defaults to 256Mi.
+                    description: Overrides the memory limit used in the plugin registry deployment. Defaults to 512Mi.
                     type: string
                   pluginRegistryMemoryRequest:
                     description: Overrides the memory request used in the plugin registry deployment. Defaults to 16Mi.

--- a/helmcharts/stable/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/stable/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -559,7 +559,7 @@ spec:
                         type: string
                     type: object
                   pluginRegistryMemoryLimit:
-                    description: Overrides the memory limit used in the plugin registry deployment. Defaults to 256Mi.
+                    description: Overrides the memory limit used in the plugin registry deployment. Defaults to 512Mi.
                     type: string
                   pluginRegistryMemoryRequest:
                     description: Overrides the memory request used in the plugin registry deployment. Defaults to 16Mi.

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -33,7 +33,7 @@ const (
 	DefaultDashboardCpuRequest    = "100m"
 
 	// PluginRegistry
-	DefaultPluginRegistryMemoryLimit   = "256Mi"
+	DefaultPluginRegistryMemoryLimit   = "512Mi"
 	DefaultPluginRegistryMemoryRequest = "32Mi"
 	DefaultPluginRegistryCpuLimit      = "500m"
 	DefaultPluginRegistryCpuRequest    = "100m"


### PR DESCRIPTION
### What does this PR do?
When OpenVSX will be included in the plug-in registry
It'll require more memory to start.
With 256Mi, container is killed with OOM error

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20549

### How to test this PR?
Deploy che and check more memory is assigned for plug-in registry container

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: I2ae148f858550f92d64c41d6fa81af826624b377
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
