### PR TITLE
[pkg] add env var to dashboard deplyoment for kubernetes oidc auth

### DIFF
--- a/pkg/deploy/dashboard/deployment_dashboard.go
+++ b/pkg/deploy/dashboard/deployment_dashboard.go
@@ -75,6 +75,38 @@ func (d *DashboardReconciler) getDashboardDeploymentSpec(ctx *chetypes.DeployCon
 			Value: fmt.Sprintf("http://%s.%s.svc:8080/api", deploy.CheServiceName, ctx.CheCluster.Namespace)},
 	)
 
+	if ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_INFRA_KUBERNETES_PORT"]!="" {
+		envVars = append(envVars,
+			corev1.EnvVar{
+				Name: "CHE_INFRA_KUBERNETES_PORT",
+				Value: fmt.Sprintf("%s", ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_INFRA_KUBERNETES_PORT"])},
+		)
+	}
+
+	if ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_INFRA_KUBERNETES_PORT_443_TCP_ADDR"]!=""{
+		envVars = append(envVars,
+			corev1.EnvVar{
+				Name: "CHE_INFRA_KUBERNETES_PORT_443_TCP_ADDR",
+				Value: fmt.Sprintf("%s", ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_INFRA_KUBERNETES_PORT_443_TCP_ADDR"])},
+		)
+	}
+
+	if ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_INFRA_KUBERNETES_PORT_443_TCP"]!=""{
+		envVars = append(envVars,
+			corev1.EnvVar{
+				Name: "CHE_INFRA_KUBERNETES_PORT_443_TCP",
+				Value: fmt.Sprintf("%s", ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_INFRA_KUBERNETES_PORT_443_TCP"])},
+		)
+	}
+
+	if ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_INFRA_KUBERNETES_SERVICE_HOST"]!=""{
+		envVars = append(envVars,
+			corev1.EnvVar{
+				Name: "CHE_INFRA_KUBERNETES_SERVICE_HOST",
+				Value: fmt.Sprintf("%s", ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_INFRA_KUBERNETES_SERVICE_HOST"])},
+		)
+	}
+
 	if infrastructure.IsOpenShift() {
 		envVars = append(envVars,
 			corev1.EnvVar{


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?

Allow for non dex oidc auth providers in managed kubernetes deployments by setting env vars in che-dashboard deployment if present. Currently che-dashboard has no way to change these variables so no way to us non dex auth. With these changes it will be possible to set all of these env vars from CheCluster. Making it easier to use che with managed kubernetes. 

Add CHE_INFRA_KUBERNETES_PORT, CHE_INFRA_KUBERNETES_PORT_443_TCP_ADDR, CHE_INFRA_KUBERNETES_PORT_443_TCP, CHE_INFRA_KUBERNETES_SERVICE_HOST to the che-dashboard deployment for kubernetes if the variables are set.
```
spec:
  components:
    cheServer:
      extraProperties:
        CHE_INFRA_KUBERNETES_PORT:
        CHE_INFRA_KUBERNETES_PORT_443_TCP_ADDR:
        CHE_INFRA_KUBERNETES_PORT_443_TCP: 
        CHE_INFRA_KUBERNETES_SERVICE_HOST:
```

This way non dex oidc auth providers can be used ( ex: gke with external auth). This significantly simplifies deployment and can make auth consistent and easy to use with managed kubernetes clusters where the kube api cannot be set or changed. 

These are then used as env vars in the che-dashboard deployment for kubernetes. With changes to the dashboard in another pr (https://github.com/eclipse-che/che-dashboard/pull/596 ), if these env vars are present in the deployment the dashboard will use them to set KUBERNETES_PORT, KUBERNETES_PORT_443_TCP_ADDR, KUBERNETES_PORT_443_TCP, KUBERNETES_SERVICE_HOST. Allowing for the configuration of a non dex oidc auth provider. 

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->

https://github.com/eclipse/che/issues/21260

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
Test platform: managed kubernetes with non dex oidc auth. 

```bash
cat EOF << > /tmp/patch.yaml
spec:
  components:
    cheServer:
      extraProperties:
        # needed but not added in this pr
        CHE_INFRA_KUBERNETES_MASTER__URL=https://gke-oidc-envoy.anthos-identity-service
        # added in this pr
        CHE_INFRA_KUBERNETES_PORT:tcp://<gke-oidc-envoy LB IP>:443
        CHE_INFRA_KUBERNETES_PORT_443_TCP_ADDR:<gke-oidc-envoy LB IP>
        CHE_INFRA_KUBERNETES_PORT_443_TCP:tcp://<gke-oidc-envoy LB IP>:443
        CHE_INFRA_KUBERNETES_SERVICE_HOST:<gke-oidc-envoy LB IP>
EOF

chectl server:deploy \
     --installer operator \
     --platform k8s \
     --che-operator-image <CUSTOM_OPERATOR_IMAGE> \
     --che-operator-cr-patch-yaml /tmp/patch.yaml
```

Docs pr: https://github.com/eclipse-che/che-docs/pull/2413

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
