### PR TITLE
fix: Improve a way to check if DevWorkspace resources must be managed…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -583,6 +583,9 @@ bundle: generate manifests download-kustomize download-operator-sdk ## Generate 
 	yq -riY '.metadata.annotations.containerImage = "'$(IMG)'"' $${CSV_PATH}
 	yq -riY '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image = "'$(IMG)'"' $${CSV_PATH}
 
+	# Add No Opt DWO environment variable
+	yq -riY '.spec.install.spec.deployments[0].spec.template.spec.containers[0].env += [{"name": "NO_OPT_DWO", "value": "true"}]' "$${CSV_PATH}"
+
 	# Format file
 	yq -riY "." "$${BUNDLE_PATH}/manifests/org.eclipse.che_checlusters.yaml"
 

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.52.0-642.next
+  name: eclipse-che-preview-openshift.v7.52.0-643.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1392,7 +1392,7 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.52.0-642.next
+  version: 7.52.0-643.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -1138,6 +1138,8 @@ spec:
                         value: "1"
                       - name: ADD_COMPONENT_READINESS_INIT_CONTAINERS
                         value: "false"
+                      - name: NO_OPT_DWO
+                        value: 'true'
                     image: quay.io/eclipse/che-operator:next
                     imagePullPolicy: Always
                     livenessProbe:

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -82,6 +82,7 @@ const (
 	KubernetesManagedByLabelKey = "app.kubernetes.io/managed-by"
 	KubernetesInstanceLabelKey  = "app.kubernetes.io/instance"
 	KubernetesNameLabelKey      = "app.kubernetes.io/name"
+	OlmOwnerLabelKey            = "olm.owner"
 
 	// Annotations
 	CheEclipseOrgMountPath                = "che.eclipse.org/mount-path"
@@ -120,8 +121,9 @@ const (
 	GatewayAuthenticationContainerName = "oauth-proxy"
 	GatewayAuthorizationContainerName  = "kube-rbac-proxy"
 
-	//
+	// common
 	CheEclipseOrg         = "che.eclipse.org"
+	DevWorkspaceOperator  = "devworkspace-operator"
 	InstallOrUpdateFailed = "InstallOrUpdateFailed"
 )
 

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -82,7 +82,6 @@ const (
 	KubernetesManagedByLabelKey = "app.kubernetes.io/managed-by"
 	KubernetesInstanceLabelKey  = "app.kubernetes.io/instance"
 	KubernetesNameLabelKey      = "app.kubernetes.io/name"
-	OlmOwnerLabelKey            = "olm.owner"
 
 	// Annotations
 	CheEclipseOrgMountPath                = "che.eclipse.org/mount-path"

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -14,6 +14,8 @@ package utils
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
+	"github.com/eclipse-che/che-operator/pkg/common/test"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -268,4 +270,12 @@ func Whitelist(hostname string) (value string) {
 		return hostname[i:]
 	}
 	return hostname
+}
+
+func GetOperatorNamespace() (string, error) {
+	if test.IsTestMode() {
+		return "eclipse-che", nil
+	}
+
+	return infrastructure.GetOperatorNamespace()
 }

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -14,8 +14,6 @@ package utils
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
-	"github.com/eclipse-che/che-operator/pkg/common/test"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -23,6 +21,9 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
+	"github.com/eclipse-che/che-operator/pkg/common/test"
 
 	"k8s.io/apimachinery/pkg/labels"
 

--- a/pkg/deploy/dev-workspace/dev_workspace.go
+++ b/pkg/deploy/dev-workspace/dev_workspace.go
@@ -62,27 +62,19 @@ func NewDevWorkspaceReconciler() *DevWorkspaceReconciler {
 
 func (d *DevWorkspaceReconciler) Reconcile(ctx *chetypes.DeployContext) (reconcile.Result, bool, error) {
 	if infrastructure.IsOpenShift() {
-		// Do nothing if Eclipse Che operator installed by OLM
-		// In this case DevWorkspace operator should be managed by OLM as well
-		cheOperatorInstalledByOLM, err := isCheOperatorInstalledByOLM(ctx)
-		if cheOperatorInstalledByOLM {
+		// Do nothing if Che operator has owner.
+		// In this case DevWorkspace operator resources mustn't be managed by Che operator.
+		cheOperatorHasOwner, err := isCheOperatorHasOwner(ctx)
+		if cheOperatorHasOwner {
 			return reconcile.Result{}, true, nil
 		} else if err != nil {
 			return reconcile.Result{Requeue: true}, false, err
 		}
 
-		// Do nothing if Dev Workspace operator installed by OLM
-		devWorkspaceInstalledByOLM, err := isDevWorkspaceOperatorInstalledByOLM(ctx)
-		if devWorkspaceInstalledByOLM {
-			return reconcile.Result{}, true, nil
-		} else if err != nil {
-			return reconcile.Result{Requeue: true}, false, err
-		}
-
-		// Do nothing if WTO exists since it should bring or embeds DWO
-		// TODO check if it is needed
-		wtoInstalledByOlm, err := isWebTerminalInstalledByOlm(ctx)
-		if wtoInstalledByOlm {
+		// Do nothing if Dev Workspace operator has owner.
+		// In this case DevWorkspace operator resources mustn't be managed by Che operator.
+		devWorkspaceOperatorHasOwner, err := isDevWorkspaceOperatorHasOwner(ctx)
+		if devWorkspaceOperatorHasOwner {
 			return reconcile.Result{}, true, nil
 		} else if err != nil {
 			return reconcile.Result{Requeue: true}, false, err

--- a/pkg/deploy/dev-workspace/dev_workspace.go
+++ b/pkg/deploy/dev-workspace/dev_workspace.go
@@ -63,15 +63,6 @@ func (d *DevWorkspaceReconciler) Reconcile(ctx *chetypes.DeployContext) (reconci
 			return reconcile.Result{Requeue: true}, false, err
 		}
 
-		// Do nothing if Che operator has owner (installed via OLM).
-		// In this case Dev Workspace operator resources mustn't be managed by Che operator.
-		isCheOperatorHasOwner, err := isCheOperatorHasOwner(ctx)
-		if isCheOperatorHasOwner {
-			return reconcile.Result{}, true, nil
-		} else if err != nil {
-			return reconcile.Result{Requeue: true}, false, err
-		}
-
 		// Do nothing if Dev Workspace operator has owner (installed via OLM).
 		// In this case Dev Workspace operator resources mustn't be managed by Che operator.
 		isDevWorkspaceOperatorHasOwner, err := isDevWorkspaceOperatorHasOwner(ctx)

--- a/pkg/deploy/dev-workspace/dev_workspace_syncer_test.go
+++ b/pkg/deploy/dev-workspace/dev_workspace_syncer_test.go
@@ -77,49 +77,6 @@ func TestShouldSyncObjectIfItWasCreatedBySameOriginHashDifferent(t *testing.T) {
 	assert.Equal(t, "c", actual.Data["a"], "data mismatch")
 }
 
-func TestShouldNotSyncObjectIfThereIsAnotherCheCluster(t *testing.T) {
-	cheCluster := &chev2.CheCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "eclipse-che",
-			Namespace: "eclipse-che-1",
-		},
-	}
-	anotherCheCluster := &chev2.CheCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "eclipse-che",
-			Namespace: "eclipse-che-2",
-		},
-	}
-	deployContext := test.GetDeployContext(cheCluster, []runtime.Object{anotherCheCluster})
-
-	// creates initial object
-	initialObject := deploy.GetConfigMapSpec(deployContext, "test", map[string]string{"a": "b"}, "test")
-	initialObject.SetAnnotations(map[string]string{
-		constants.CheEclipseOrgHash256:   "hash-2",
-		constants.CheEclipseOrgNamespace: "eclipse-che-2",
-	})
-	isCreated, err := deploy.Create(deployContext, initialObject)
-	assert.NoError(t, err)
-	assert.True(t, isCreated)
-
-	// tries to sync object with a new hash but different origin
-	newObject := deploy.GetConfigMapSpec(deployContext, "test", map[string]string{"a": "c"}, "test")
-	newObject.GetAnnotations()[constants.CheEclipseOrgHash256] = "newHash"
-	isDone, err := syncObject(deployContext, newObject, "eclipse-che")
-	assert.NoError(t, err, "Failed to sync object")
-	assert.True(t, isDone, "Failed to sync object")
-
-	// reads object and check content, object isn't supposed to be updated
-	actual := &corev1.ConfigMap{}
-	exists, err := deploy.GetNamespacedObject(deployContext, "test", actual)
-	assert.NoError(t, err, "failed to get configmap")
-	assert.True(t, exists, "configmap is not found")
-
-	assert.Equal(t, "eclipse-che-2", actual.GetAnnotations()[constants.CheEclipseOrgNamespace], "hash annotation mismatch")
-	assert.Equal(t, "hash-2", actual.GetAnnotations()[constants.CheEclipseOrgHash256], "namespace annotation mismatch")
-	assert.Equal(t, "b", actual.Data["a"], "data mismatch")
-}
-
 func TestShouldNotSyncObjectIfHashIsEqual(t *testing.T) {
 	deployContext := test.GetDeployContext(nil, []runtime.Object{})
 

--- a/pkg/deploy/dev-workspace/dev_workspace_test.go
+++ b/pkg/deploy/dev-workspace/dev_workspace_test.go
@@ -13,9 +13,7 @@ package devworkspace
 
 import (
 	"context"
-	"os"
-
-	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"k8s.io/apimachinery/pkg/types"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,11 +36,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	DevWorkspaceCSVName = "devworkspace-operator.v0.11.0"
-)
-
 func TestReconcileDevWorkspace(t *testing.T) {
+	cheOperatorDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaults.GetCheFlavor() + "-operator",
+			Namespace: "eclipse-che",
+		},
+	}
+
 	type testCase struct {
 		name           string
 		infrastructure infrastructure.Type
@@ -82,12 +83,8 @@ func TestReconcileDevWorkspace(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			deployContext := test.GetDeployContext(testCase.cheCluster, []runtime.Object{})
-
+			deployContext := test.GetDeployContext(testCase.cheCluster, []runtime.Object{cheOperatorDeployment})
 			infrastructure.InitializeForTesting(testCase.infrastructure)
-
-			err := os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "true")
-			assert.NoError(t, err)
 
 			devWorkspaceReconciler := NewDevWorkspaceReconciler()
 			_, done, err := devWorkspaceReconciler.Reconcile(deployContext)
@@ -104,7 +101,12 @@ func TestShouldReconcileDevWorkspaceIfDevWorkspaceDeploymentExists(t *testing.T)
 			Name:      "eclipse-che",
 		},
 	}
-
+	cheOperatorDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaults.GetCheFlavor() + "-operator",
+			Namespace: "eclipse-che",
+		},
+	}
 	devworkspaceDeployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -113,14 +115,15 @@ func TestShouldReconcileDevWorkspaceIfDevWorkspaceDeploymentExists(t *testing.T)
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DevWorkspaceDeploymentName,
 			Namespace: DevWorkspaceNamespace,
+			Labels: map[string]string{
+				constants.KubernetesPartOfLabelKey: constants.DevWorkspaceOperator,
+				constants.KubernetesNameLabelKey:   constants.DevWorkspaceController,
+			},
 		},
 	}
 
-	deployContext := test.GetDeployContext(cheCluster, []runtime.Object{devworkspaceDeployment})
-
+	deployContext := test.GetDeployContext(cheCluster, []runtime.Object{devworkspaceDeployment, cheOperatorDeployment})
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
-	err := os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "false")
-	assert.NoError(t, err)
 
 	devWorkspaceReconciler := NewDevWorkspaceReconciler()
 	_, done, err := devWorkspaceReconciler.Reconcile(deployContext)
@@ -129,9 +132,15 @@ func TestShouldReconcileDevWorkspaceIfDevWorkspaceDeploymentExists(t *testing.T)
 	assert.True(t, done, "DevWorkspace should be reconciled.")
 }
 
-func TestReconcileWhenWebTerminalSubscriptionExists(t *testing.T) {
+func TestShouldNotReconcileDevWorkspaceWhenWebTerminalSubscriptionExists(t *testing.T) {
 	cheCluster := &chev2.CheCluster{
 		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "eclipse-che",
+		},
+	}
+	cheOperatorDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaults.GetCheFlavor() + "-operator",
 			Namespace: "eclipse-che",
 		},
 	}
@@ -143,7 +152,7 @@ func TestReconcileWhenWebTerminalSubscriptionExists(t *testing.T) {
 		Spec: &operatorsv1alpha1.SubscriptionSpec{},
 	}
 
-	deployContext := test.GetDeployContext(cheCluster, []runtime.Object{subscription})
+	deployContext := test.GetDeployContext(cheCluster, []runtime.Object{subscription, cheOperatorDeployment})
 	deployContext.ClusterAPI.Scheme.AddKnownTypes(operatorsv1alpha1.SchemeGroupVersion, &operatorsv1alpha1.Subscription{})
 	deployContext.ClusterAPI.Scheme.AddKnownTypes(admissionregistrationv1.SchemeGroupVersion, &admissionregistrationv1.MutatingWebhookConfiguration{})
 	deployContext.ClusterAPI.DiscoveryClient.(*fakeDiscovery.FakeDiscovery).Fake.Resources = []*metav1.APIResourceList{
@@ -155,8 +164,6 @@ func TestReconcileWhenWebTerminalSubscriptionExists(t *testing.T) {
 	}
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
-	err := os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "true")
-	assert.NoError(t, err)
 
 	devWorkspaceReconciler := NewDevWorkspaceReconciler()
 	_, done, err := devWorkspaceReconciler.Reconcile(deployContext)
@@ -165,75 +172,114 @@ func TestReconcileWhenWebTerminalSubscriptionExists(t *testing.T) {
 	assert.True(t, done)
 
 	// verify that DWO is not provisioned
-	namespace := &corev1.Namespace{}
-	err = deployContext.ClusterAPI.NonCachingClient.Get(context.TODO(), types.NamespacedName{Name: DevWorkspaceNamespace}, namespace)
+	err = deployContext.ClusterAPI.NonCachingClient.Get(context.TODO(), types.NamespacedName{Name: DevWorkspaceNamespace}, &corev1.Namespace{})
 	assert.True(t, k8sErrors.IsNotFound(err))
 }
 
-func TestReconcileDevWorkspaceCheckIfCSVExists(t *testing.T) {
+func TestShouldNotReconcileDevWorkspaceIfDevWorkspaceDeploymentManagedByOLM(t *testing.T) {
+	cheOperatorDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaults.GetCheFlavor() + "-operator",
+			Namespace: "eclipse-che",
+		},
+	}
+	devworkspaceDeployment := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DevWorkspaceDeploymentName,
+			Namespace: DevWorkspaceNamespace,
+			Labels: map[string]string{
+				constants.KubernetesPartOfLabelKey: constants.DevWorkspaceOperator,
+				constants.KubernetesNameLabelKey:   constants.DevWorkspaceController,
+				constants.OlmOwnerLabelKey:         "olm",
+			},
+		},
+	}
 	cheCluster := &chev2.CheCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "eclipse-che",
 		},
 	}
-	devWorkspaceCSV := &operatorsv1alpha1.ClusterServiceVersion{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      DevWorkspaceCSVName,
-			Namespace: "openshift-operators",
-		},
-		Spec: operatorsv1alpha1.ClusterServiceVersionSpec{},
-	}
 
-	deployContext := test.GetDeployContext(cheCluster, []runtime.Object{})
-	deployContext.ClusterAPI.Scheme.AddKnownTypes(operatorsv1alpha1.SchemeGroupVersion, &operatorsv1alpha1.ClusterServiceVersion{})
-	deployContext.ClusterAPI.Scheme.AddKnownTypes(operatorsv1alpha1.SchemeGroupVersion, &operatorsv1alpha1.ClusterServiceVersionList{})
-	err := deployContext.ClusterAPI.Client.Create(context.TODO(), devWorkspaceCSV)
-	assert.NoError(t, err)
-	deployContext.ClusterAPI.DiscoveryClient.(*fakeDiscovery.FakeDiscovery).Fake.Resources = []*metav1.APIResourceList{
-		{
-			APIResources: []metav1.APIResource{
-				{
-					Name: ClusterServiceVersionResourceName,
-				},
-			},
-		},
-	}
-
+	deployContext := test.GetDeployContext(cheCluster, []runtime.Object{cheOperatorDeployment, devworkspaceDeployment})
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
-	err = os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "true")
-	assert.NoError(t, err)
 
 	devWorkspaceReconciler := NewDevWorkspaceReconciler()
 	_, done, err := devWorkspaceReconciler.Reconcile(deployContext)
 
-	assert.True(t, done, "Reconcile is not triggered")
+	assert.True(t, done)
 
-	// Get Devworkspace namespace. If error is thrown means devworkspace is not anymore installed if CSV is detected
-	err = deployContext.ClusterAPI.Client.Get(context.TODO(), client.ObjectKey{Name: DevWorkspaceNamespace}, &corev1.Namespace{})
-	assert.True(t, k8sErrors.IsNotFound(err), "DevWorkspace namespace is created when instead DWO CSV is expected to be created")
+	// verify that DWO is not provisioned
+	err = deployContext.ClusterAPI.NonCachingClient.Get(context.TODO(), types.NamespacedName{Name: DevWorkspaceNamespace}, &corev1.Namespace{})
+	assert.True(t, k8sErrors.IsNotFound(err))
 }
 
-func TestReconcileDevWorkspaceIfUnmanagedDWONamespaceExists(t *testing.T) {
+func TestShouldNotReconcileDevWorkspaceIfCheOperatorDeploymentManagedByOLM(t *testing.T) {
+	cheOperatorDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaults.GetCheFlavor() + "-operator",
+			Namespace: "eclipse-che",
+			Labels: map[string]string{
+				constants.OlmOwnerLabelKey: "olm",
+			},
+		},
+	}
+	devworkspaceDeployment := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DevWorkspaceDeploymentName,
+			Namespace: DevWorkspaceNamespace,
+			Labels: map[string]string{
+				constants.KubernetesPartOfLabelKey: constants.DevWorkspaceOperator,
+				constants.KubernetesNameLabelKey:   constants.DevWorkspaceController,
+			},
+		},
+	}
 	cheCluster := &chev2.CheCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "eclipse-che",
 		},
 	}
 
+	deployContext := test.GetDeployContext(cheCluster, []runtime.Object{cheOperatorDeployment, devworkspaceDeployment})
+	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
+
+	devWorkspaceReconciler := NewDevWorkspaceReconciler()
+	_, done, err := devWorkspaceReconciler.Reconcile(deployContext)
+
+	assert.True(t, done)
+
+	// verify that DWO is not provisioned
+	err = deployContext.ClusterAPI.NonCachingClient.Get(context.TODO(), types.NamespacedName{Name: DevWorkspaceNamespace}, &corev1.Namespace{})
+	assert.True(t, k8sErrors.IsNotFound(err))
+}
+
+func TestShouldNotReconcileDevWorkspaceIfUnmanagedDWONamespaceExists(t *testing.T) {
+	cheCluster := &chev2.CheCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "eclipse-che",
+		},
+	}
+	cheOperatorDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaults.GetCheFlavor() + "-operator",
+			Namespace: "eclipse-che",
+		},
+	}
 	dwoNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: DevWorkspaceNamespace,
 			// no che annotations are there
 		},
 	}
-	deployContext := test.GetDeployContext(cheCluster, []runtime.Object{})
-	err := deployContext.ClusterAPI.Client.Create(context.TODO(), dwoNamespace)
-	assert.NoError(t, err)
-
+	deployContext := test.GetDeployContext(cheCluster, []runtime.Object{cheOperatorDeployment, dwoNamespace})
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
-
-	err = os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "true")
-	assert.NoError(t, err)
 
 	devWorkspaceReconciler := NewDevWorkspaceReconciler()
 	_, done, err := devWorkspaceReconciler.Reconcile(deployContext)
@@ -251,7 +297,12 @@ func TestReconcileDevWorkspaceIfManagedDWONamespaceExists(t *testing.T) {
 			Namespace: "eclipse-che",
 		},
 	}
-
+	cheOperatorDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaults.GetCheFlavor() + "-operator",
+			Namespace: "eclipse-che",
+		},
+	}
 	dwoNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: DevWorkspaceNamespace,
@@ -261,18 +312,8 @@ func TestReconcileDevWorkspaceIfManagedDWONamespaceExists(t *testing.T) {
 			// no che annotations are there
 		},
 	}
-	deployContext := test.GetDeployContext(cheCluster, []runtime.Object{})
-	err := deployContext.ClusterAPI.NonCachingClient.Create(context.TODO(), dwoNamespace)
-	assert.NoError(t, err)
-
-	exists, err := deploy.Get(deployContext,
-		types.NamespacedName{Name: DevWorkspaceNamespace, Namespace: DevWorkspaceNamespace},
-		&corev1.Namespace{})
-
+	deployContext := test.GetDeployContext(cheCluster, []runtime.Object{cheOperatorDeployment, dwoNamespace})
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
-
-	err = os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "true")
-	assert.NoError(t, err)
 
 	devWorkspaceReconciler := NewDevWorkspaceReconciler()
 	_, done, err := devWorkspaceReconciler.Reconcile(deployContext)
@@ -281,120 +322,9 @@ func TestReconcileDevWorkspaceIfManagedDWONamespaceExists(t *testing.T) {
 	assert.NoError(t, err, "Reconcile failed")
 
 	// check is reconcile created deployment if existing namespace is not annotated in che specific way
-	exists, err = deploy.Get(deployContext,
+	exists, err := deploy.Get(deployContext,
 		types.NamespacedName{Name: DevWorkspaceDeploymentName, Namespace: DevWorkspaceNamespace},
 		&appsv1.Deployment{})
 	assert.True(t, exists, "DevWorkspace deployment is not created in Che managed DWO namespace")
-	assert.NoError(t, err, "Failed to get devworkspace deployment")
-}
-
-func TestReconcileDevWorkspaceIfManagedDWOShouldBeTakenUnderControl(t *testing.T) {
-	cheCluster := &chev2.CheCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "eclipse-che",
-		},
-	}
-
-	dwoNamespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: DevWorkspaceNamespace,
-			Annotations: map[string]string{
-				constants.CheEclipseOrgNamespace: "eclipse-che-removed",
-			},
-			// no che annotations are there
-		},
-	}
-	deployContext := test.GetDeployContext(cheCluster, []runtime.Object{})
-	deployContext.ClusterAPI.Scheme.AddKnownTypes(crdv1.SchemeGroupVersion, &crdv1.CustomResourceDefinition{})
-	err := deployContext.ClusterAPI.NonCachingClient.Create(context.TODO(), dwoNamespace)
-	assert.NoError(t, err)
-
-	exists, err := deploy.Get(deployContext,
-		types.NamespacedName{Name: DevWorkspaceNamespace, Namespace: DevWorkspaceNamespace},
-		&corev1.Namespace{})
-
-	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
-
-	err = os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "true")
-	assert.NoError(t, err)
-
-	devWorkspaceReconciler := NewDevWorkspaceReconciler()
-	_, done, err := devWorkspaceReconciler.Reconcile(deployContext)
-
-	assert.True(t, done, "Reconcile is not triggered")
-	assert.NoError(t, err, "Reconcile failed")
-
-	// check is reconcile updated namespace with according way
-	exists, err = deploy.Get(deployContext,
-		types.NamespacedName{Name: DevWorkspaceNamespace},
-		dwoNamespace)
-	assert.True(t, exists, "DevWorkspace Namespace does not exist")
-	assert.Equal(t, "eclipse-che", dwoNamespace.GetAnnotations()[constants.CheEclipseOrgNamespace])
-
-	// check that objects are sync
-	exists, err = deploy.Get(deployContext,
-		types.NamespacedName{Name: DevWorkspaceDeploymentName, Namespace: DevWorkspaceNamespace},
-		&appsv1.Deployment{})
-	assert.True(t, exists, "DevWorkspace deployment is not created in Che managed DWO namespace")
-	assert.NoError(t, err, "Failed to get devworkspace deployment")
-}
-
-func TestReconcileDevWorkspaceIfManagedDWOShouldNotBeTakenUnderControl(t *testing.T) {
-	cheCluster := &chev2.CheCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "eclipse-che",
-			Name:      "che-cluster",
-		},
-	}
-	cheCluster2 := &chev2.CheCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "eclipse-che2",
-			Name:      "che-cluster2",
-		},
-	}
-
-	dwoNamespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: DevWorkspaceNamespace,
-			Annotations: map[string]string{
-				constants.CheEclipseOrgNamespace: "eclipse-che2",
-			},
-			// no che annotations are there
-		},
-	}
-	deployContext := test.GetDeployContext(cheCluster, []runtime.Object{})
-	deployContext.ClusterAPI.Scheme.AddKnownTypes(crdv1.SchemeGroupVersion, &crdv1.CustomResourceDefinition{})
-	err := deployContext.ClusterAPI.NonCachingClient.Create(context.TODO(), dwoNamespace)
-	assert.NoError(t, err)
-	err = deployContext.ClusterAPI.NonCachingClient.Create(context.TODO(), cheCluster2)
-	assert.NoError(t, err)
-
-	exists, err := deploy.Get(deployContext,
-		types.NamespacedName{Name: DevWorkspaceNamespace, Namespace: DevWorkspaceNamespace},
-		&corev1.Namespace{})
-
-	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
-
-	err = os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "true")
-	assert.NoError(t, err)
-
-	devWorkspaceReconciler := NewDevWorkspaceReconciler()
-	_, done, err := devWorkspaceReconciler.Reconcile(deployContext)
-
-	assert.True(t, done, "Reconcile is not triggered")
-	assert.NoError(t, err, "Reconcile failed")
-
-	// check is reconcile updated namespace with according way
-	exists, err = deploy.Get(deployContext,
-		types.NamespacedName{Name: DevWorkspaceNamespace},
-		dwoNamespace)
-	assert.True(t, exists, "DevWorkspace Namespace does not exist")
-	assert.Equal(t, "eclipse-che2", dwoNamespace.GetAnnotations()[constants.CheEclipseOrgNamespace])
-
-	// check that objects are sync
-	exists, err = deploy.Get(deployContext,
-		types.NamespacedName{Name: DevWorkspaceDeploymentName, Namespace: DevWorkspaceNamespace},
-		&appsv1.Deployment{})
-	assert.False(t, exists, "DevWorkspace deployment is not created in Che managed DWO namespace")
 	assert.NoError(t, err, "Failed to get devworkspace deployment")
 }

--- a/pkg/deploy/dev-workspace/dev_workspace_test.go
+++ b/pkg/deploy/dev-workspace/dev_workspace_test.go
@@ -13,6 +13,7 @@ package devworkspace
 
 import (
 	"context"
+
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"k8s.io/apimachinery/pkg/types"
 

--- a/pkg/deploy/dev-workspace/dev_workspace_test.go
+++ b/pkg/deploy/dev-workspace/dev_workspace_test.go
@@ -186,42 +186,6 @@ func TestShouldNotReconcileDevWorkspaceIfNoOptExists(t *testing.T) {
 	os.Unsetenv("NO_OPT_DWO")
 }
 
-func TestShouldNotReconcileDevWorkspaceIfCheOperatorDeploymentManagedByOLM(t *testing.T) {
-	cheOperatorDeployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            defaults.GetCheFlavor() + "-operator",
-			Namespace:       "eclipse-che",
-			OwnerReferences: []metav1.OwnerReference{{}},
-		},
-	}
-	devworkspaceDeployment := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Deployment",
-			APIVersion: "apps/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      DevWorkspaceDeploymentName,
-			Namespace: DevWorkspaceNamespace,
-			Labels: map[string]string{
-				constants.KubernetesPartOfLabelKey: constants.DevWorkspaceOperator,
-				constants.KubernetesNameLabelKey:   constants.DevWorkspaceController,
-			},
-		},
-	}
-
-	deployContext := test.GetDeployContext(nil, []runtime.Object{cheOperatorDeployment, devworkspaceDeployment})
-	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
-
-	devWorkspaceReconciler := NewDevWorkspaceReconciler()
-	_, done, err := devWorkspaceReconciler.Reconcile(deployContext)
-
-	assert.True(t, done)
-
-	// verify that DWO is not provisioned
-	err = deployContext.ClusterAPI.NonCachingClient.Get(context.TODO(), types.NamespacedName{Name: DevWorkspaceNamespace}, &corev1.Namespace{})
-	assert.True(t, k8sErrors.IsNotFound(err))
-}
-
 func TestShouldNotReconcileDevWorkspaceIfUnmanagedDWONamespaceExists(t *testing.T) {
 	cheOperatorDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/deploy/dev-workspace/dev_workspace_utils.go
+++ b/pkg/deploy/dev-workspace/dev_workspace_utils.go
@@ -76,9 +76,13 @@ func isDevWorkspaceOperatorHasOwner(ctx *chetypes.DeployContext) (bool, error) {
 		return false, err
 	}
 
-	if len(deployments.Items) != 1 {
-		return false, nil
+	if len(deployments.Items) > 0 {
+		for _, deployment := range deployments.Items {
+			if len(deployment.OwnerReferences) != 0 {
+				return true, nil
+			}
+		}
 	}
 
-	return len(deployments.Items[0].OwnerReferences) != 0, nil
+	return false, nil
 }

--- a/pkg/deploy/dev-workspace/dev_workspace_utils.go
+++ b/pkg/deploy/dev-workspace/dev_workspace_utils.go
@@ -19,14 +19,11 @@ import (
 
 	"github.com/eclipse-che/che-operator/pkg/common/chetypes"
 	"github.com/eclipse-che/che-operator/pkg/common/constants"
-	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
-	"github.com/eclipse-che/che-operator/pkg/common/utils"
 	"github.com/eclipse-che/che-operator/pkg/deploy"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -51,26 +48,6 @@ func isNoOptDWO() (bool, error) {
 	}
 
 	return strconv.ParseBool(value)
-}
-
-func isCheOperatorHasOwner(ctx *chetypes.DeployContext) (bool, error) {
-	operatorNamespace, err := utils.GetOperatorNamespace()
-	if err != nil {
-		return false, err
-	}
-
-	deployment := &appsv1.Deployment{}
-	if err := ctx.ClusterAPI.NonCachingClient.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Namespace: operatorNamespace,
-			Name:      defaults.GetCheFlavor() + "-operator",
-		},
-		deployment); err != nil {
-		return false, err
-	}
-
-	return len(deployment.OwnerReferences) != 0, nil
 }
 
 func isDevWorkspaceOperatorHasOwner(ctx *chetypes.DeployContext) (bool, error) {

--- a/pkg/deploy/dev-workspace/dev_workspace_utils.go
+++ b/pkg/deploy/dev-workspace/dev_workspace_utils.go
@@ -19,58 +19,13 @@ import (
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/utils"
 	"github.com/eclipse-che/che-operator/pkg/deploy"
-	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// Indicates if Web Terminal installed on the cluster by checking
-// its subscription in both `openshift-operators` and current namespaces
-func isWebTerminalInstalledByOlm(deployContext *chetypes.DeployContext) (bool, error) {
-	cheOperatorNamespace, err := utils.GetOperatorNamespace()
-	if err != nil {
-		return false, err
-	}
-
-	namespace2check := []string{cheOperatorNamespace, OperatorNamespace}
-	for _, namespace := range namespace2check {
-		isWebTerminalSubscriptionExist, err := isSubscriptionExist(WebTerminalOperatorSubscriptionName, namespace, deployContext)
-		if isWebTerminalSubscriptionExist {
-			return true, nil
-		} else if err != nil {
-			return false, err
-		}
-	}
-
-	return false, nil
-}
-
-func isSubscriptionExist(name string, namespace string, ctx *chetypes.DeployContext) (bool, error) {
-	if !utils.IsK8SResourceServed(ctx.ClusterAPI.DiscoveryClient, SubscriptionResourceName) {
-		return false, nil
-	}
-
-	if err := ctx.ClusterAPI.NonCachingClient.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Name:      name,
-			Namespace: namespace,
-		},
-		&operatorsv1alpha1.Subscription{}); err != nil {
-
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return true, nil
-}
 
 func createDwNamespace(deployContext *chetypes.DeployContext) (bool, error) {
 	namespace := &corev1.Namespace{
@@ -86,8 +41,7 @@ func createDwNamespace(deployContext *chetypes.DeployContext) (bool, error) {
 	return deploy.CreateIfNotExists(deployContext, namespace)
 }
 
-// Indicates if Eclipse Che operator installed by OLM by checking existence `olm.owner` label.
-func isCheOperatorInstalledByOLM(ctx *chetypes.DeployContext) (bool, error) {
+func isCheOperatorHasOwner(ctx *chetypes.DeployContext) (bool, error) {
 	operatorNamespace, err := utils.GetOperatorNamespace()
 	if err != nil {
 		return false, err
@@ -96,15 +50,18 @@ func isCheOperatorInstalledByOLM(ctx *chetypes.DeployContext) (bool, error) {
 	deployment := &appsv1.Deployment{}
 	if err := ctx.ClusterAPI.NonCachingClient.Get(
 		context.TODO(),
-		types.NamespacedName{Namespace: operatorNamespace, Name: defaults.GetCheFlavor() + "-operator"},
+		types.NamespacedName{
+			Namespace: operatorNamespace,
+			Name:      defaults.GetCheFlavor() + "-operator",
+		},
 		deployment); err != nil {
 		return false, err
 	}
 
-	return deployment.Labels[constants.OlmOwnerLabelKey] != "", nil
+	return len(deployment.OwnerReferences) != 0, nil
 }
 
-func isDevWorkspaceOperatorInstalledByOLM(ctx *chetypes.DeployContext) (bool, error) {
+func isDevWorkspaceOperatorHasOwner(ctx *chetypes.DeployContext) (bool, error) {
 	deployments := &appsv1.DeploymentList{}
 	if err := ctx.ClusterAPI.NonCachingClient.List(
 		context.TODO(),
@@ -122,5 +79,5 @@ func isDevWorkspaceOperatorInstalledByOLM(ctx *chetypes.DeployContext) (bool, er
 		return false, nil
 	}
 
-	return deployments.Items[0].Labels[constants.OlmOwnerLabelKey] != "", nil
+	return len(deployments.Items[0].OwnerReferences) != 0, nil
 }

--- a/pkg/deploy/dev-workspace/dev_workspace_utils.go
+++ b/pkg/deploy/dev-workspace/dev_workspace_utils.go
@@ -14,6 +14,8 @@ package devworkspace
 
 import (
 	"context"
+	"os"
+	"strconv"
 
 	"github.com/eclipse-che/che-operator/pkg/common/chetypes"
 	"github.com/eclipse-che/che-operator/pkg/common/constants"
@@ -40,6 +42,15 @@ func createDwNamespace(deployContext *chetypes.DeployContext) (bool, error) {
 	}
 
 	return deploy.CreateIfNotExists(deployContext, namespace)
+}
+
+func isNoOptDWO() (bool, error) {
+	value, exists := os.LookupEnv("NO_OPT_DWO")
+	if !exists {
+		return false, nil
+	}
+
+	return strconv.ParseBool(value)
 }
 
 func isCheOperatorHasOwner(ctx *chetypes.DeployContext) (bool, error) {

--- a/pkg/deploy/dev-workspace/dev_workspace_utils.go
+++ b/pkg/deploy/dev-workspace/dev_workspace_utils.go
@@ -14,6 +14,7 @@ package devworkspace
 
 import (
 	"context"
+
 	"github.com/eclipse-che/che-operator/pkg/common/chetypes"
 	"github.com/eclipse-che/che-operator/pkg/common/constants"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"

--- a/pkg/deploy/dev-workspace/dev_workspace_utils.go
+++ b/pkg/deploy/dev-workspace/dev_workspace_utils.go
@@ -76,11 +76,9 @@ func isDevWorkspaceOperatorHasOwner(ctx *chetypes.DeployContext) (bool, error) {
 		return false, err
 	}
 
-	if len(deployments.Items) > 0 {
-		for _, deployment := range deployments.Items {
-			if len(deployment.OwnerReferences) != 0 {
-				return true, nil
-			}
+	for _, deployment := range deployments.Items {
+		if len(deployment.OwnerReferences) != 0 {
+			return true, nil
 		}
 	}
 


### PR DESCRIPTION
… by Che Operator

Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Checks if Che Operator or Dev Workspace operator deployment has an owner.
It means these resources are managed by someone else (OLM). 
So, Dev Workspace resources mustn't be managed by Che Operator as well.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21603

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

Catalog source image to test: `docker.io/abazko/catalog:21603`


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
