### PR TITLE
chore: Remove explicitly declared runAsNonRoot: true

### DIFF
--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.52.0-643.next
+  name: eclipse-che-preview-openshift.v7.52.0-644.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1181,7 +1181,6 @@ spec:
                           - ALL
                       privileged: false
                       readOnlyRootFilesystem: false
-                      runAsNonRoot: true
                     volumeMounts:
                       - mountPath: /tmp/k8s-webhook-server/serving-certs
                         name: webhook-tls-certs
@@ -1392,7 +1391,7 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.52.0-643.next
+  version: 7.52.0-644.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -125,7 +125,6 @@ spec:
             timeoutSeconds: 5
           securityContext:
             privileged: false
-            runAsNonRoot: true
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
             capabilities:

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -6023,7 +6023,6 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsNonRoot: true
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-tls-certs

--- a/deploy/deployment/kubernetes/objects/che-operator.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/che-operator.Deployment.yaml
@@ -140,7 +140,6 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsNonRoot: true
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-tls-certs

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -6025,7 +6025,6 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsNonRoot: true
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-tls-certs

--- a/deploy/deployment/openshift/objects/che-operator.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/che-operator.Deployment.yaml
@@ -140,7 +140,6 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsNonRoot: true
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-tls-certs

--- a/helmcharts/next/templates/che-operator.Deployment.yaml
+++ b/helmcharts/next/templates/che-operator.Deployment.yaml
@@ -140,7 +140,6 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: false
-          runAsNonRoot: true
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-tls-certs


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
`Remove explicitly declared runAsNonRoot: true` since it causes issues with starting che operator in OpenShift namespace labeled with `openshift.io/run-level=1` because of  https://docs.openshift.com/container-platform/4.10/authentication/managing-security-context-constraints.html

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21622

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
