### PR TITLE
fix: update path to buildCatalog.sh script

### DIFF
--- a/.github/workflows/build-catalog-and-bundle-images.yaml
+++ b/.github/workflows/build-catalog-and-bundle-images.yaml
@@ -38,6 +38,6 @@ jobs:
         password: ${{ secrets.QUAY_PASSWORD }}
     - name: Build and push images to quay.io
       run: |
-        ${GITHUB_WORKSPACE}/olm/buildCatalog.sh \
+        ${GITHUB_WORKSPACE}/build/scripts/olm/buildCatalog.sh \
           --channel 'next' \
           --catalog-image quay.io/eclipse/eclipse-che-openshift-opm-catalog:next


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
fix: update path to buildCatalog.sh script


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse-che/che-operator/runs/7867269103?check_suite_focus=true
