### PR TITLE
fix: Limit che resources to run minikube tests

### DIFF
--- a/build/scripts/minikube-tests/minikube-checluster-patch.yaml
+++ b/build/scripts/minikube-tests/minikube-checluster-patch.yaml
@@ -1,0 +1,83 @@
+#
+# Copyright (c) 2019-2022 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+apiVersion: org.eclipse.che/v2
+spec:
+  components:
+    pluginRegistry:
+      openVSXURL: https://open-vsx.org
+      deployment:
+        containers:
+          - resources:
+              request:
+                cpu: '50m'
+              limits:
+                cpu: '50m'
+    devfileRegistry:
+      deployment:
+        containers:
+          - resources:
+              request:
+                cpu: '50m'
+              limits:
+                cpu: '50m'
+    cheServer:
+      deployment:
+        containers:
+          - resources:
+              limits:
+                cpu: '500m'
+    dashboard:
+      deployment:
+        containers:
+          - resources:
+              request:
+                cpu: '50m'
+              limits:
+                cpu: '50m'
+    database:
+      deployment:
+        containers:
+          - resources:
+              request:
+                cpu: '50m'
+              limits:
+                cpu: '50m'
+  networking:
+    auth:
+      gateway:
+        deployment:
+          containers:
+            - name: gateway
+              resources:
+                request:
+                  cpu: '50m'
+                limits:
+                  cpu: '50m'
+            - name: configbump
+              resources:
+                request:
+                  cpu: '50m'
+                limits:
+                  cpu: '50m'
+            - name: oauth-proxy
+              resources:
+                request:
+                  cpu: '50m'
+                limits:
+                  cpu: '50m'
+            - name: kube-rbac-proxy
+              resources:
+                request:
+                  cpu: '50m'
+                limits:
+                  cpu: '50m'

--- a/build/scripts/minikube-tests/test-operator.sh
+++ b/build/scripts/minikube-tests/test-operator.sh
@@ -29,7 +29,12 @@ runTest() {
   buildAndCopyCheOperatorImageToMinikube
   yq -riSY '.spec.template.spec.containers[0].image = "'${OPERATOR_IMAGE}'"' "${CURRENT_OPERATOR_VERSION_TEMPLATE_PATH}/che-operator/kubernetes/operator.yaml"
   yq -riSY '.spec.template.spec.containers[0].imagePullPolicy = "IfNotPresent"' "${CURRENT_OPERATOR_VERSION_TEMPLATE_PATH}/che-operator/kubernetes/operator.yaml"
-  chectl server:deploy --batch --platform minikube --templates "${CURRENT_OPERATOR_VERSION_TEMPLATE_PATH}"
+
+  chectl server:deploy \
+    --batch \
+    --platform minikube \
+    --templates "${CURRENT_OPERATOR_VERSION_TEMPLATE_PATH}" \
+    --che-operator-cr-patch-yaml "${OPERATOR_REPO}/build/scripts/minikube-tests/minikube-checluster-patch.yaml"
 
   pushd ${OPERATOR_REPO}
     make wait-eclipseche-version VERSION="next" NAMESPACE=${NAMESPACE}

--- a/build/scripts/minikube-tests/test-upgrade-from-stable-to-next.sh
+++ b/build/scripts/minikube-tests/test-upgrade-from-stable-to-next.sh
@@ -27,7 +27,11 @@ trap "catchFinish" EXIT SIGINT
 
 runTest() {
   # Deploy stable version
-  chectl server:deploy --platform minikube --batch --templates ${LAST_OPERATOR_VERSION_TEMPLATE_PATH}
+  chectl server:deploy \
+    --batch \
+    --platform minikube \
+    --templates ${LAST_OPERATOR_VERSION_TEMPLATE_PATH} \
+    --che-operator-cr-patch-yaml "${OPERATOR_REPO}/build/scripts/minikube-tests/minikube-checluster-patch.yaml"
 
   # Update to next version
   buildAndCopyCheOperatorImageToMinikube

--- a/build/scripts/minikube-tests/test-upgrade-from-stable-to-stable.sh
+++ b/build/scripts/minikube-tests/test-upgrade-from-stable-to-stable.sh
@@ -26,7 +26,12 @@ source "${OPERATOR_REPO}/build/scripts/minikube-tests/common.sh"
 trap "catchFinish" EXIT SIGINT
 
 runTest() {
-  chectl server:deploy --platform minikube --templates ${PREVIOUS_OPERATOR_VERSION_TEMPLATE_PATH} --batch
+  chectl server:deploy \
+    --batch \
+    --platform minikube  \
+    --templates ${PREVIOUS_OPERATOR_VERSION_TEMPLATE_PATH} \
+    --che-operator-cr-patch-yaml "${OPERATOR_REPO}/build/scripts/minikube-tests/minikube-checluster-patch.yaml"
+
   chectl server:update --templates ${LAST_OPERATOR_VERSION_TEMPLATE_PATH} --batch
 
   # Wait until Eclipse Che is deployed

--- a/pkg/deploy/pluginregistry/pluginregistry_deployment.go
+++ b/pkg/deploy/pluginregistry/pluginregistry_deployment.go
@@ -55,6 +55,11 @@ func (p *PluginRegistryReconciler) getPluginRegistryDeploymentSpec(ctx *chetypes
 		resources,
 		probePath)
 
+	if ctx.CheCluster.Spec.Components.PluginRegistry.OpenVSXURL == "" {
+		// Add time to start embedded VSX registry
+		deployment.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds = 300
+	}
+
 	deploy.EnsurePodSecurityStandards(deployment, constants.DefaultSecurityContextRunAsUser, constants.DefaultSecurityContextFsGroup)
 	deploy.CustomizeDeployment(deployment, ctx.CheCluster.Spec.Components.PluginRegistry.Deployment)
 	return deployment


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
fix: Limit che resources to run minikube tests

### Reference issue
https://github.com/eclipse/che/issues/21663
