### PR TITLE
fix: typo in oc-test-operator.sh

### DIFF
--- a/build/scripts/oc-tests/oc-test-operator.sh
+++ b/build/scripts/oc-tests/oc-test-operator.sh
@@ -22,7 +22,7 @@ trap "catchFinish" EXIT SIGINT
 [[ -z "${CI_CHE_OPERATOR_IMAGE}" ]] && { echo [ERROR] CI_CHE_OPERATOR_IMAGE not defined; exit 1; }
 
 runTests() {
-  . ${OPERATOR_REPO}/build/scripts/olm/testCatalogFromSources -o ${CI_CHE_OPERATOR_IMAGE}
+  . ${OPERATOR_REPO}/build/scripts/olm/testCatalogFromSources.sh -o ${CI_CHE_OPERATOR_IMAGE}
 }
 
 runTests


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
fix: typo in oc-test-operator.sh