### PR TITLE
feat: configure DWOC from che-operator CR

### DIFF
--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.53.0-664.next
+  name: eclipse-che-preview-openshift.v7.53.0-666.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1389,7 +1389,7 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.53.0-664.next
+  version: 7.53.0-666.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/controllers/che/checluster_controller.go
+++ b/controllers/che/checluster_controller.go
@@ -15,6 +15,7 @@ package che
 import (
 	"context"
 
+	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 	"github.com/eclipse-che/che-operator/pkg/common/chetypes"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
@@ -23,6 +24,7 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/deploy/consolelink"
 	"github.com/eclipse-che/che-operator/pkg/deploy/dashboard"
 	devworkspace "github.com/eclipse-che/che-operator/pkg/deploy/dev-workspace"
+	devworkspaceConfig "github.com/eclipse-che/che-operator/pkg/deploy/dev-workspace-config"
 	"github.com/eclipse-che/che-operator/pkg/deploy/devfileregistry"
 	"github.com/eclipse-che/che-operator/pkg/deploy/gateway"
 	identityprovider "github.com/eclipse-che/che-operator/pkg/deploy/identity-provider"
@@ -41,6 +43,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -48,6 +51,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	chev2 "github.com/eclipse-che/che-operator/api/v2"
@@ -97,6 +101,7 @@ func NewReconciler(
 	reconcileManager.RegisterReconciler(tls.NewCertificatesReconciler())
 	reconcileManager.RegisterReconciler(tls.NewTlsSecretReconciler())
 	reconcileManager.RegisterReconciler(devworkspace.NewDevWorkspaceReconciler())
+	reconcileManager.RegisterReconciler(devworkspaceConfig.NewDevWorkspaceConfigReconciler())
 	reconcileManager.RegisterReconciler(rbac.NewCheServerPermissionsReconciler())
 	reconcileManager.RegisterReconciler(rbac.NewGatewayPermissionsReconciler())
 	reconcileManager.RegisterReconciler(rbac.NewWorkspacePermissionsReconciler())
@@ -164,6 +169,40 @@ func (r *CheClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return []ctrl.Request{}
 	}
 
+	// TODO: Just added the part-of label and use toEclipseCheRelatedObjRequestMapper?
+	var dwocRequestMapper = func(obj client.Object) []reconcile.Request {
+
+		if obj.GetName() != devworkspaceConfig.DwocName {
+			// We're looking for a DWOC created by the Che-Operator
+			return []ctrl.Request{}
+		}
+
+		if obj.GetNamespace() == "" {
+			// ignore cluster scope objects
+			return []ctrl.Request{}
+		}
+
+		checluster, num, _ := deploy.FindCheClusterCRInNamespace(r.nonCachedClient, r.namespace)
+		if num != 1 {
+			if num > 1 {
+				logrus.Warn("More than one checluster Custom Resource found.")
+			}
+			return []ctrl.Request{}
+		}
+
+		if checluster.Namespace != obj.GetNamespace() {
+			// ignore object in another namespace
+			return []ctrl.Request{}
+		}
+
+		// TODO: Should we make a request for the che cluster object or DWOC object?
+		return []ctrl.Request{{NamespacedName: types.NamespacedName{
+			Namespace: checluster.Namespace,
+			Name:      checluster.Name,
+		}}}
+
+	}
+
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		// Watch for changes to primary resource CheCluster
 		Watches(&source.Kind{Type: &chev2.CheCluster{}}, &handler.EnqueueRequestForObject{}).
@@ -200,6 +239,8 @@ func (r *CheClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			IsController: true,
 			OwnerType:    &chev2.CheCluster{},
 		}).
+		//TODO: Not sure if handler is correct
+		Watches(&source.Kind{Type: &controllerv1alpha1.DevWorkspaceOperatorConfig{}}, handler.EnqueueRequestsFromMapFunc(dwocRequestMapper)).
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}},
 			handler.EnqueueRequestsFromMapFunc(toTrustedBundleConfigMapRequestMapper),
 			builder.WithPredicates(onAllExceptGenericEventsPredicate),

--- a/controllers/che/checluster_controller.go
+++ b/controllers/che/checluster_controller.go
@@ -14,6 +14,7 @@ package che
 
 import (
 	"context"
+
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 	"github.com/eclipse-che/che-operator/pkg/common/chetypes"
 	"github.com/eclipse-che/che-operator/pkg/common/test"

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -96,10 +96,12 @@ const (
 	CheEclipseOrgHash256                  = "che.eclipse.org/hash256"
 	CheEclipseOrgManagedAnnotationsDigest = "che.eclipse.org/managed-annotations-digest"
 
-	// Workspaces
-	DefaultPvcStrategy       = "common"
-	DefaultPvcClaimSize      = "10Gi"
-	DefaultWorkspaceJavaOpts = "-XX:MaxRAM=150m -XX:MaxRAMFraction=2 -XX:+UseParallelGC " +
+	// DevEnvironments
+	PerUserPVCStorageStrategy      = "per-user"
+	DefaultPvcStorageStrategy      = "per-user"
+	PerWorkspacePVCStorageStrategy = "per-workspace"
+	CommonPVCStorageStrategy       = "common"
+	DefaultWorkspaceJavaOpts       = "-XX:MaxRAM=150m -XX:MaxRAMFraction=2 -XX:+UseParallelGC " +
 		"-XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 " +
 		"-Dsun.zip.disableMemoryMapping=true " +
 		"-Xms20m -Djava.security.egd=file:/dev/./urandom"

--- a/pkg/common/test/utils.go
+++ b/pkg/common/test/utils.go
@@ -13,6 +13,8 @@ package test
 
 import (
 	"context"
+	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	routev1 "github.com/openshift/api/route/v1"
 	"os"
 	"strings"
 	"testing"
@@ -24,7 +26,6 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/chetypes"
 	console "github.com/openshift/api/console/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
-	routev1 "github.com/openshift/api/route/v1"
 	userv1 "github.com/openshift/api/user/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -169,6 +170,7 @@ func GetDeployContext(cheCluster *chev2.CheCluster, initObjs []runtime.Object) *
 	scheme := scheme.Scheme
 	chev2.SchemeBuilder.AddToScheme(scheme)
 	scheme.AddKnownTypes(operatorsv1alpha1.SchemeGroupVersion, &operatorsv1alpha1.Subscription{})
+	scheme.AddKnownTypes(controllerv1alpha1.SchemeBuilder.GroupVersion, &controllerv1alpha1.DevWorkspaceOperatorConfig{})
 	scheme.AddKnownTypes(crdv1.SchemeGroupVersion, &crdv1.CustomResourceDefinition{})
 	scheme.AddKnownTypes(operatorsv1alpha1.SchemeGroupVersion, &operatorsv1alpha1.Subscription{})
 	scheme.AddKnownTypes(oauthv1.GroupVersion, &oauthv1.OAuthClient{})

--- a/pkg/common/test/utils.go
+++ b/pkg/common/test/utils.go
@@ -13,11 +13,12 @@ package test
 
 import (
 	"context"
-	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
-	routev1 "github.com/openshift/api/route/v1"
 	"os"
 	"strings"
 	"testing"
+
+	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	routev1 "github.com/openshift/api/route/v1"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/pointer"

--- a/pkg/deploy/dev-workspace-config/dev_workspace_config.go
+++ b/pkg/deploy/dev-workspace-config/dev_workspace_config.go
@@ -1,0 +1,212 @@
+//
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package devworkspaceConfig
+
+import (
+	"context"
+
+	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/eclipse-che/che-operator/pkg/common/chetypes"
+	"github.com/eclipse-che/che-operator/pkg/deploy"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const DwocName string = "devworkspace-config"
+const perUserStorageStrategy string = "per-user"
+const commonStorageStrategy string = "common"
+const perWorkspaceStorageStrategy string = "per-workspace"
+
+type DevWorkspaceConfigReconciler struct {
+	deploy.Reconcilable
+}
+
+func NewDevWorkspaceConfigReconciler() *DevWorkspaceConfigReconciler {
+	return &DevWorkspaceConfigReconciler{}
+}
+
+func (d *DevWorkspaceConfigReconciler) Reconcile(ctx *chetypes.DeployContext) (reconcile.Result, bool, error) {
+	// Get the che-operator-owned DWOC, if it exists. Otherwise, create it.
+	namespace := ctx.CheCluster.Namespace
+	dwoc := &controllerv1alpha1.DevWorkspaceOperatorConfig{}
+	namespacedName := types.NamespacedName{Name: DwocName, Namespace: namespace}
+	err := ctx.ClusterAPI.Client.Get(context.TODO(), namespacedName, dwoc)
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return reconcile.Result{}, false, createDWOC(dwoc, ctx, namespace)
+		}
+		return reconcile.Result{}, false, err
+	}
+
+	// Now that we have the DWOC, modify it accordingly
+	updatedConfig, err := updateDWOC(ctx, dwoc)
+
+	if err != nil {
+		return reconcile.Result{}, false, err
+	}
+
+	if updatedConfig {
+		// Now sync the updated config with the cluster
+		didSync, err := deploy.Sync(ctx, dwoc)
+		if err != nil {
+			return reconcile.Result{}, false, err
+		}
+
+		if !didSync {
+			return reconcile.Result{Requeue: true}, false, nil
+		}
+	}
+
+	return reconcile.Result{}, true, nil
+}
+
+func (d *DevWorkspaceConfigReconciler) Finalize(ctx *chetypes.DeployContext) bool {
+	return true
+}
+
+func updateDWOC(ctx *chetypes.DeployContext, dwoc *controllerv1alpha1.DevWorkspaceOperatorConfig) (bool, error) {
+	updatedConfig := false
+
+	if dwoc.Config == nil {
+		dwoc.Config = &controllerv1alpha1.OperatorConfiguration{}
+		updatedConfig = true
+	}
+
+	if dwoc.Config.Workspace == nil {
+		dwoc.Config.Workspace = &controllerv1alpha1.WorkspaceConfig{}
+		updatedConfig = true
+	}
+
+	// Setting the storage class name requires that a PVC strategy be selected
+	if ctx.CheCluster.Spec.DevEnvironments.Storage.PvcStrategy != "" {
+
+		switch ctx.CheCluster.Spec.DevEnvironments.Storage.PvcStrategy {
+		case commonStorageStrategy:
+			fallthrough
+		case perUserStorageStrategy:
+
+			if ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig != nil &&
+				ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.StorageClass != "" {
+
+				if dwoc.Config.Workspace.StorageClassName == nil ||
+					ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.StorageClass != *dwoc.Config.Workspace.StorageClassName {
+					dwoc.Config.Workspace.StorageClassName = &ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.StorageClass
+					updatedConfig = true
+				}
+			}
+		case perWorkspaceStorageStrategy:
+			if ctx.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig != nil &&
+				ctx.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.StorageClass != "" {
+
+				if dwoc.Config.Workspace.StorageClassName == nil ||
+					ctx.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.StorageClass != *dwoc.Config.Workspace.StorageClassName {
+					dwoc.Config.Workspace.StorageClassName = &ctx.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.StorageClass
+					updatedConfig = true
+				}
+
+			}
+		}
+	}
+
+	if ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig != nil &&
+		ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.ClaimSize != "" {
+
+		if dwoc.Config.Workspace.DefaultStorageSize == nil {
+			dwoc.Config.Workspace.DefaultStorageSize = &controllerv1alpha1.StorageSizes{}
+			updatedConfig = true
+		}
+
+		if dwoc.Config.Workspace.DefaultStorageSize.Common == nil ||
+			dwoc.Config.Workspace.DefaultStorageSize.Common.String() != ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.ClaimSize {
+
+			pvcSize, err := resource.ParseQuantity(ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.ClaimSize)
+			if err != nil {
+				return updatedConfig, err
+			}
+			dwoc.Config.Workspace.DefaultStorageSize.Common = &pvcSize
+			updatedConfig = true
+		}
+
+	}
+
+	if ctx.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig != nil &&
+		ctx.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.ClaimSize != "" {
+
+		if dwoc.Config.Workspace.DefaultStorageSize == nil {
+			dwoc.Config.Workspace.DefaultStorageSize = &controllerv1alpha1.StorageSizes{}
+			updatedConfig = true
+		}
+
+		if dwoc.Config.Workspace.DefaultStorageSize.PerWorkspace == nil ||
+			dwoc.Config.Workspace.DefaultStorageSize.PerWorkspace.String() != ctx.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.ClaimSize {
+
+			pvcSize, err := resource.ParseQuantity(ctx.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.ClaimSize)
+			if err != nil {
+				return updatedConfig, err
+			}
+			dwoc.Config.Workspace.DefaultStorageSize.PerWorkspace = &pvcSize
+			updatedConfig = true
+		}
+
+	}
+
+	return updatedConfig, nil
+}
+
+func createDWOC(dwoc *controllerv1alpha1.DevWorkspaceOperatorConfig, ctx *chetypes.DeployContext, namespace string) error {
+	dwoc.ObjectMeta.Namespace = namespace
+	dwoc.ObjectMeta.Name = DwocName
+	dwoc.Config = &controllerv1alpha1.OperatorConfiguration{}
+	dwoc.Config.Workspace = &controllerv1alpha1.WorkspaceConfig{}
+
+	// Setting the storage class name requires that a PVC strategy be selected
+	if ctx.CheCluster.Spec.DevEnvironments.Storage.PvcStrategy != "" {
+		switch ctx.CheCluster.Spec.DevEnvironments.Storage.PvcStrategy {
+		case commonStorageStrategy:
+			fallthrough
+		case perUserStorageStrategy:
+			if ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig != nil && ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.StorageClass != "" {
+				dwoc.Config.Workspace.StorageClassName = &ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.StorageClass
+			}
+		case perWorkspaceStorageStrategy:
+			if ctx.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig != nil && ctx.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.StorageClass != "" {
+				dwoc.Config.Workspace.StorageClassName = &ctx.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.StorageClass
+			}
+		}
+	}
+
+	if ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig != nil && ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.ClaimSize != "" {
+		pvcSize, err := resource.ParseQuantity(ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.ClaimSize)
+		if err != nil {
+			return err
+		}
+
+		dwoc.Config.Workspace.DefaultStorageSize = &controllerv1alpha1.StorageSizes{}
+		dwoc.Config.Workspace.DefaultStorageSize.Common = &pvcSize
+	}
+
+	if ctx.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig != nil && ctx.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.ClaimSize != "" {
+		pvcSize, err := resource.ParseQuantity(ctx.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.ClaimSize)
+		if err != nil {
+			return err
+		}
+
+		if dwoc.Config.Workspace.DefaultStorageSize == nil {
+			dwoc.Config.Workspace.DefaultStorageSize = &controllerv1alpha1.StorageSizes{}
+		}
+		dwoc.Config.Workspace.DefaultStorageSize.PerWorkspace = &pvcSize
+	}
+
+	return ctx.ClusterAPI.Client.Create(context.TODO(), dwoc)
+}

--- a/pkg/deploy/dev-workspace-config/dev_workspace_config_test.go
+++ b/pkg/deploy/dev-workspace-config/dev_workspace_config_test.go
@@ -13,10 +13,11 @@ package devworkspaceconfig
 
 import (
 	"regexp"
+	"testing"
+
 	"github.com/eclipse-che/che-operator/pkg/common/constants"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
-	"testing"
 
 	"context"
 

--- a/pkg/deploy/dev-workspace-config/dev_workspace_config_test.go
+++ b/pkg/deploy/dev-workspace-config/dev_workspace_config_test.go
@@ -1,0 +1,313 @@
+//
+// Copyright (c) 2019-2022 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package devworkspaceConfig
+
+import (
+	"os"
+	"testing"
+
+	"context"
+
+	controllerv1alpha1 "github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
+	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
+	chev2 "github.com/eclipse-che/che-operator/api/v2"
+	"github.com/eclipse-che/che-operator/pkg/common/test"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type testCase struct {
+	name           string
+	infrastructure infrastructure.Type
+	cheCluster     *chev2.CheCluster
+}
+
+var testCases = []testCase{
+	{
+		name: "Reconcile DevWorkspace Configuration on OpenShift",
+		cheCluster: &chev2.CheCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "eclipse-che",
+			},
+		},
+		infrastructure: infrastructure.OpenShiftv4,
+	},
+	{
+		name: "Reconcile DevWorkspace Configuration on K8S",
+		cheCluster: &chev2.CheCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "eclipse-che",
+			},
+			Spec: chev2.CheClusterSpec{
+				Components: chev2.CheClusterComponents{
+					CheServer: chev2.CheServer{
+						ExtraProperties: map[string]string{"CHE_INFRA_KUBERNETES_ENABLE__UNSUPPORTED__K8S": "true"},
+					},
+				},
+				Networking: chev2.CheClusterSpecNetworking{
+					Domain: "che.domain",
+				},
+			},
+		},
+		infrastructure: infrastructure.Kubernetes,
+	},
+}
+
+func TestReconcileDevWorkspaceConfigPerUserStorage(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			deployContext := test.GetDeployContext(testCase.cheCluster.DeepCopy(), []runtime.Object{})
+			deployContext.ClusterAPI.Scheme.AddKnownTypes(controllerv1alpha1.SchemeBuilder.GroupVersion, &controllerv1alpha1.DevWorkspaceOperatorConfig{})
+
+			dwoc := controllerv1alpha1.DevWorkspaceOperatorConfig{}
+			namespace := deployContext.CheCluster.Namespace
+
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PvcStrategy = perUserStorageStrategy
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig = &chev2.PVC{}
+
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.StorageClass = "testStorageClass"
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.ClaimSize = "15Gi"
+
+			infrastructure.InitializeForTesting(testCase.infrastructure)
+
+			err := os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "true")
+			assert.NoError(t, err)
+
+			devWorkspaceConfigReconciler := NewDevWorkspaceConfigReconciler()
+			_, _, err = devWorkspaceConfigReconciler.Reconcile(deployContext)
+			assert.NoError(t, err, "Reconcile failed")
+			_, done, err := devWorkspaceConfigReconciler.Reconcile(deployContext)
+			assert.NoError(t, err, "Reconcile failed")
+			assert.True(t, done, "Dev Workspace configuration has not been provisioned")
+
+			// A DWOC should have now been created
+			namespacedName := types.NamespacedName{Name: DwocName, Namespace: namespace}
+			deployContext.ClusterAPI.Client.Get(context.TODO(), namespacedName, &dwoc)
+			assert.Equal(t, deployContext.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.StorageClass, *dwoc.Config.Workspace.StorageClassName)
+			assert.Equal(t, deployContext.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.ClaimSize, dwoc.Config.Workspace.DefaultStorageSize.Common.String())
+		})
+	}
+}
+
+func TestReconcileDevWorkspaceConfigPerWorkspaceStorage(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			deployContext := test.GetDeployContext(testCase.cheCluster.DeepCopy(), []runtime.Object{})
+			deployContext.ClusterAPI.Scheme.AddKnownTypes(controllerv1alpha1.SchemeBuilder.GroupVersion, &controllerv1alpha1.DevWorkspaceOperatorConfig{})
+
+			dwoc := controllerv1alpha1.DevWorkspaceOperatorConfig{}
+			namespace := deployContext.CheCluster.Namespace
+
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PvcStrategy = perWorkspaceStorageStrategy
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig = &chev2.PVC{}
+
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.StorageClass = "testStorageClass"
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.ClaimSize = "15Gi"
+
+			infrastructure.InitializeForTesting(testCase.infrastructure)
+
+			err := os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "true")
+			assert.NoError(t, err)
+
+			devWorkspaceConfigReconciler := NewDevWorkspaceConfigReconciler()
+			_, _, err = devWorkspaceConfigReconciler.Reconcile(deployContext)
+			assert.NoError(t, err, "Reconcile failed")
+			_, done, err := devWorkspaceConfigReconciler.Reconcile(deployContext)
+			assert.NoError(t, err, "Reconcile failed")
+			assert.True(t, done, "Dev Workspace configuration has not been provisioned")
+
+			// A DWOC should have now been created
+			namespacedName := types.NamespacedName{Name: DwocName, Namespace: namespace}
+			deployContext.ClusterAPI.Client.Get(context.TODO(), namespacedName, &dwoc)
+			assert.Equal(t, deployContext.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.StorageClass, *dwoc.Config.Workspace.StorageClassName)
+			assert.Equal(t, deployContext.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.ClaimSize, dwoc.Config.Workspace.DefaultStorageSize.PerWorkspace.String())
+		})
+	}
+}
+
+func TestUpdateExistingEmptyDevWorkspaceConfigPerWorkspaceStorage(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			deployContext := test.GetDeployContext(testCase.cheCluster.DeepCopy(), []runtime.Object{})
+			deployContext.ClusterAPI.Scheme.AddKnownTypes(controllerv1alpha1.SchemeBuilder.GroupVersion, &controllerv1alpha1.DevWorkspaceOperatorConfig{})
+
+			// Create DWOC which will be updated during reconcile
+			dwoc := controllerv1alpha1.DevWorkspaceOperatorConfig{}
+			namespace := deployContext.CheCluster.Namespace
+
+			dwoc.ObjectMeta.Name = DwocName
+			dwoc.ObjectMeta.Namespace = namespace
+			deployContext.ClusterAPI.Client.Create(context.TODO(), &dwoc)
+
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PvcStrategy = perWorkspaceStorageStrategy
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig = &chev2.PVC{}
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.StorageClass = "testStorageClass"
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.ClaimSize = "15Gi"
+
+			infrastructure.InitializeForTesting(testCase.infrastructure)
+
+			err := os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "true")
+			assert.NoError(t, err)
+
+			devWorkspaceConfigReconciler := NewDevWorkspaceConfigReconciler()
+			_, _, err = devWorkspaceConfigReconciler.Reconcile(deployContext)
+			assert.NoError(t, err, "Reconcile failed")
+			_, done, err := devWorkspaceConfigReconciler.Reconcile(deployContext)
+			assert.NoError(t, err, "Reconcile failed")
+			assert.True(t, done, "Dev Workspace configuration has not been provisioned")
+
+			namespacedName := types.NamespacedName{Name: DwocName, Namespace: namespace}
+			deployContext.ClusterAPI.Client.Get(context.TODO(), namespacedName, &dwoc)
+			assert.Equal(t, deployContext.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.StorageClass, *dwoc.Config.Workspace.StorageClassName)
+			assert.Equal(t, deployContext.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.ClaimSize, dwoc.Config.Workspace.DefaultStorageSize.PerWorkspace.String())
+		})
+	}
+}
+
+func TestUpdateExistingEmptyDevWorkspaceConfigPerUserStorage(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			deployContext := test.GetDeployContext(testCase.cheCluster.DeepCopy(), []runtime.Object{})
+			deployContext.ClusterAPI.Scheme.AddKnownTypes(controllerv1alpha1.SchemeBuilder.GroupVersion, &controllerv1alpha1.DevWorkspaceOperatorConfig{})
+
+			// Create DWOC which will be updated during reconcile
+			dwoc := controllerv1alpha1.DevWorkspaceOperatorConfig{}
+			namespace := deployContext.CheCluster.Namespace
+
+			dwoc.ObjectMeta.Name = DwocName
+			dwoc.ObjectMeta.Namespace = namespace
+			deployContext.ClusterAPI.Client.Create(context.TODO(), &dwoc)
+
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PvcStrategy = perUserStorageStrategy
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig = &chev2.PVC{}
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.StorageClass = "testStorageClass"
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.ClaimSize = "15Gi"
+
+			infrastructure.InitializeForTesting(testCase.infrastructure)
+
+			err := os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "true")
+			assert.NoError(t, err)
+
+			devWorkspaceConfigReconciler := NewDevWorkspaceConfigReconciler()
+			_, _, err = devWorkspaceConfigReconciler.Reconcile(deployContext)
+			assert.NoError(t, err, "Reconcile failed")
+			_, done, err := devWorkspaceConfigReconciler.Reconcile(deployContext)
+			assert.NoError(t, err, "Reconcile failed")
+			assert.True(t, done, "Dev Workspace configuration has not been provisioned")
+
+			namespacedName := types.NamespacedName{Name: DwocName, Namespace: namespace}
+			deployContext.ClusterAPI.Client.Get(context.TODO(), namespacedName, &dwoc)
+			assert.Equal(t, deployContext.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.StorageClass, *dwoc.Config.Workspace.StorageClassName)
+			assert.Equal(t, deployContext.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.ClaimSize, dwoc.Config.Workspace.DefaultStorageSize.Common.String())
+		})
+	}
+}
+
+func TestUpdateExistingPopulatedDevWorkspaceConfig(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			deployContext := test.GetDeployContext(testCase.cheCluster.DeepCopy(), []runtime.Object{})
+			deployContext.ClusterAPI.Scheme.AddKnownTypes(controllerv1alpha1.SchemeBuilder.GroupVersion, &controllerv1alpha1.DevWorkspaceOperatorConfig{})
+
+			// Create DWOC which will be updated during reconcile
+			dwoc := controllerv1alpha1.DevWorkspaceOperatorConfig{}
+			namespace := deployContext.CheCluster.Namespace
+
+			dwoc.ObjectMeta.Name = DwocName
+			dwoc.ObjectMeta.Namespace = namespace
+			dwoc.Config = &controllerv1alpha1.OperatorConfiguration{}
+			dwoc.Config.Workspace = &controllerv1alpha1.WorkspaceConfig{}
+
+			storageClass := "oldStorageClass"
+			dwoc.Config.Workspace.StorageClassName = &storageClass
+
+			commonStorageSize := resource.MustParse("12Gi")
+			perWorkspaceStorageSize := resource.MustParse("13Gi")
+			dwoc.Config.Workspace.DefaultStorageSize = &controllerv1alpha1.StorageSizes{
+				Common:       &commonStorageSize,
+				PerWorkspace: &perWorkspaceStorageSize,
+			}
+
+			deployContext.ClusterAPI.Client.Create(context.TODO(), &dwoc)
+
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PvcStrategy = commonStorageStrategy
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig = &chev2.PVC{
+				ClaimSize:    "15Gi",
+				StorageClass: "testStorageClass",
+			}
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig = &chev2.PVC{
+				ClaimSize: "15Gi",
+			}
+			infrastructure.InitializeForTesting(testCase.infrastructure)
+
+			err := os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "true")
+			assert.NoError(t, err)
+
+			devWorkspaceConfigReconciler := NewDevWorkspaceConfigReconciler()
+			_, _, err = devWorkspaceConfigReconciler.Reconcile(deployContext)
+			assert.NoError(t, err, "Reconcile failed")
+			_, done, err := devWorkspaceConfigReconciler.Reconcile(deployContext)
+			assert.NoError(t, err, "Reconcile failed")
+			assert.True(t, done, "Dev Workspace configuration has not been provisioned")
+
+			namespacedName := types.NamespacedName{Name: DwocName, Namespace: namespace}
+			deployContext.ClusterAPI.Client.Get(context.TODO(), namespacedName, &dwoc)
+			assert.Equal(t, deployContext.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.StorageClass, *dwoc.Config.Workspace.StorageClassName)
+			assert.Equal(t, deployContext.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.ClaimSize, dwoc.Config.Workspace.DefaultStorageSize.Common.String())
+			assert.Equal(t, deployContext.CheCluster.Spec.DevEnvironments.Storage.PerWorkspaceStrategyPvcConfig.ClaimSize, dwoc.Config.Workspace.DefaultStorageSize.PerWorkspace.String())
+		})
+	}
+}
+
+func TestNoDevWorkspaceConfigUpdateNecessary(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			deployContext := test.GetDeployContext(testCase.cheCluster.DeepCopy(), []runtime.Object{})
+			deployContext.ClusterAPI.Scheme.AddKnownTypes(controllerv1alpha1.SchemeBuilder.GroupVersion, &controllerv1alpha1.DevWorkspaceOperatorConfig{})
+
+			// Create DWOC that will already be up to date on the cluster
+			dwoc := controllerv1alpha1.DevWorkspaceOperatorConfig{}
+			namespace := deployContext.CheCluster.Namespace
+
+			dwoc.ObjectMeta.Name = DwocName
+			dwoc.ObjectMeta.Namespace = namespace
+			dwoc.Config = &controllerv1alpha1.OperatorConfiguration{}
+			dwoc.Config.Workspace = &controllerv1alpha1.WorkspaceConfig{}
+			storageClass := "testStorageClass"
+			storageSize := resource.MustParse("9Gi")
+			dwoc.Config.Workspace.StorageClassName = &storageClass
+			dwoc.Config.Workspace.DefaultStorageSize = &controllerv1alpha1.StorageSizes{
+				Common: &storageSize,
+			}
+			deployContext.ClusterAPI.Client.Create(context.TODO(), &dwoc)
+
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PvcStrategy = perUserStorageStrategy
+			deployContext.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig = &chev2.PVC{
+				ClaimSize:    storageSize.String(),
+				StorageClass: "testStorageClass",
+			}
+
+			infrastructure.InitializeForTesting(testCase.infrastructure)
+
+			err := os.Setenv("ALLOW_DEVWORKSPACE_ENGINE", "true")
+			assert.NoError(t, err)
+
+			devWorkspaceConfigReconciler := NewDevWorkspaceConfigReconciler()
+			_, done, err := devWorkspaceConfigReconciler.Reconcile(deployContext)
+			assert.NoError(t, err, "Reconcile failed")
+			assert.True(t, done, "Dev Workspace configuration has not been provisioned")
+		})
+	}
+}

--- a/pkg/deploy/server/server_configmap.go
+++ b/pkg/deploy/server/server_configmap.go
@@ -132,14 +132,6 @@ func (s *CheServerReconciler) getCheConfigMapData(ctx *chetypes.DeployContext) (
 		}
 	}
 
-	pvcStrategy := utils.GetValue(ctx.CheCluster.Spec.DevEnvironments.Storage.PvcStrategy, constants.DefaultPvcStrategy)
-	workspacePvcStorageClassName := ""
-	pvcClaimSize := constants.DefaultPvcClaimSize
-	if ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig != nil {
-		pvcClaimSize = ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.ClaimSize
-		workspacePvcStorageClassName = ctx.CheCluster.Spec.DevEnvironments.Storage.PerUserStrategyPvcConfig.StorageClass
-	}
-
 	chePostgresHostName := utils.GetValue(ctx.CheCluster.Spec.Components.Database.PostgresHostName, constants.DefaultPostgresHostName)
 	chePostgresPort := utils.GetValue(ctx.CheCluster.Spec.Components.Database.PostgresPort, constants.DefaultPostgresPort)
 	chePostgresDb := utils.GetValue(ctx.CheCluster.Spec.Components.Database.PostgresDb, constants.DefaultPostgresDb)
@@ -204,9 +196,6 @@ func (s *CheServerReconciler) getCheConfigMapData(ctx *chetypes.DeployContext) (
 		CheInfraKubernetesServiceAccountName:   cheWorkspaceServiceAccount,
 		CheInfraKubernetesUserClusterRoles:     cheUserClusterRoleNames,
 		DefaultTargetNamespace:                 workspaceNamespaceDefault,
-		PvcStrategy:                            pvcStrategy,
-		PvcClaimSize:                           pvcClaimSize,
-		WorkspacePvcStorageClassName:           workspacePvcStorageClassName,
 		TlsSupport:                             "true",
 		K8STrustCerts:                          "true",
 		CheLogLevel:                            cheLogLevel,


### PR DESCRIPTION
### What does this PR do?
This PR adds a new reconciler which is in charge of creating and updating a DevWorkspace-Operator configuration (DWOC) in the che cluster namespace. 
The intention is to propagate relevant fields from the che cluster custom resource to the DWOC.

Currently, only the following (storage related) fields are propagated from the che cluster custom resource to the DWOC:
- `checluster.spec.devEnvironments.Storage.pvcStrategy`
- `checluster.spec.devEnvironments.Storage.perUserStrategyPvcConfig.ClaimSize`
- `checluster.spec.devEnvironments.Storage.perUserStrategyPvcConfig.StorageClass`
- `checluster.spec.devEnvironments.Storage.perWorkspaceStrategyPvcConfig.ClaimSize`
- `checluster.spec.devEnvironments.Storage.perWorkspaceStrategyPvcConfig.StorageClass`

The DWOC fields which can receive values from the che cluster are:
- `workspace.storageClassName`
- `workspace.defaultStorageSize.common` 
- `workspace.defaultStorageSize.perWorkspace` 


### Screenshot/screencast of this PR
n/a


### What issues does this PR fix or reference?
Part of eclipse/che/issues/21405


### How to test this PR?
There are a few automated tests that were added.

For manual testing (on minikube):
1. [Build and push the che-operator image to quay](https://github.com/eclipse-che/che-operator#build-and-push-custom-che-operator-image)
2. Deploy che using the custom che-operator image: `chectl server:deploy --installer operator -p minikube --che-operator-image=${IMAGE_REGISTRY_HOST}/${IMAGE_REGISTRY_USER_NAME}/che-operator:next`
3. Once deployed, check to ensure the che-owned DWOC has been created:
```YAML
[aobuchow@fedora ~]$ kubectl describe devworkspaceoperatorconfigs.controller.devfile.io -n eclipse-che
Name:         devworkspace-config
Namespace:    eclipse-che
Labels:       <none>
Annotations:  <none>
API Version:  controller.devfile.io/v1alpha1
Config:
Kind:                    DevWorkspaceOperatorConfig
Metadata:
...
```
4. Edit the che cluster's storage-related fields so that they can be propagated to the DWOC: `kubectl edit checluster eclipse-che -n eclipse-che`
```diff
...
  devEnvironments:
    defaultComponents:
    - container:
        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
        sourceMapping: /projects
      name: universal-developer-image
    defaultEditor: eclipse/che-theia/latest
    defaultNamespace:
      template: <username>-che
    secondsOfInactivityBeforeIdling: 1800
    secondsOfRunBeforeIdling: -1
    storage:
+     perUserStrategyPvcConfig:
+       claimSize: 15Gi
+       storageClass: testName
      pvcStrategy: per-user
```
5. Ensure the appropriate changes have been made to the DWOC. In this example, the common storage size should be set to `15Gi` and the storage class name should be set to `testName`.
```diff
[aobuchow@fedora ~]$ kubectl describe devworkspaceoperatorconfigs.controller.devfile.io -n eclipse-che
Name:         devworkspace-config
Namespace:    eclipse-che
Labels:       <none>
Annotations:  <none>
API Version:  controller.devfile.io/v1alpha1
Config:
  Workspace:
+   Default Storage Size:
+     Common:            15Gi
+   Storage Class Name:  testName
Kind:                    DevWorkspaceOperatorConfig
Metadata:
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [x] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
