### PR TITLE
fix: Set default openVSXURL if Che updated from 7.52.0 version or ear…

### DIFF
--- a/pkg/deploy/pluginregistry/openvsxurl_reconciler.go
+++ b/pkg/deploy/pluginregistry/openvsxurl_reconciler.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	v7520             = "v7.52.0"
+	v7530             = "v7.53.0"
 	openVSXDefaultUrl = "https://open-vsx.org"
 )
 
@@ -61,8 +61,8 @@ func (r *OpenVSXUrlReconciler) syncOpenVSXUrl(ctx *chetypes.DeployContext) (bool
 			return true, nil
 		}
 
-		if semver.Compare(fmt.Sprintf("v%s", ctx.CheCluster.Status.CheVersion), v7520) == -1 {
-			// updating Eclipse Che, version is less than 7.52.0
+		if semver.Compare(fmt.Sprintf("v%s", ctx.CheCluster.Status.CheVersion), v7530) == -1 {
+			// updating Eclipse Che, version is less than 7.53.0
 			return setOpenVSXDefaultUrl(ctx)
 		}
 	}

--- a/pkg/deploy/pluginregistry/openvsxurl_reconciler_test.go
+++ b/pkg/deploy/pluginregistry/openvsxurl_reconciler_test.go
@@ -109,20 +109,20 @@ func TestOpenVSXUrlReconciler(t *testing.T) {
 			expectedOpenVSXUrl: "open-vsx-url",
 		},
 		{
-			name: "Should not update default openVSXURL if Eclipse Che version is greater or equal to 7.52.0 #1",
+			name: "Should not update default openVSXURL if Eclipse Che version is greater or equal to 7.53.0 #1",
 			cheCluster: &chev2.CheCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "eclipse-che",
 					Namespace: "eclipse-che",
 				},
 				Status: chev2.CheClusterStatus{
-					CheVersion: "7.52.0",
+					CheVersion: "7.53.0",
 				},
 			},
 			expectedOpenVSXUrl: "",
 		},
 		{
-			name: "Should not update default openVSXURL if Eclipse Che version is greater or equal to 7.52.0 #2",
+			name: "Should not update default openVSXURL if Eclipse Che version is greater or equal to 7.53.0 #2",
 			cheCluster: &chev2.CheCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "eclipse-che",
@@ -136,7 +136,7 @@ func TestOpenVSXUrlReconciler(t *testing.T) {
 					},
 				},
 				Status: chev2.CheClusterStatus{
-					CheVersion: "7.52.0",
+					CheVersion: "7.53.0",
 				},
 			},
 			expectedOpenVSXUrl: "open-vsx-url",

--- a/pkg/deploy/pluginregistry/openvsxurl_reconciler_test.go
+++ b/pkg/deploy/pluginregistry/openvsxurl_reconciler_test.go
@@ -76,20 +76,20 @@ func TestOpenVSXUrlReconciler(t *testing.T) {
 			expectedOpenVSXUrl: "open-vsx-url",
 		},
 		{
-			name: "Should set default openVSXURL if Eclipse Che version is less then 7.52.0",
+			name: "Should set default openVSXURL if Eclipse Che version is less then 7.53.0",
 			cheCluster: &chev2.CheCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "eclipse-che",
 					Namespace: "eclipse-che",
 				},
 				Status: chev2.CheClusterStatus{
-					CheVersion: "7.51.2",
+					CheVersion: "7.52.2",
 				},
 			},
 			expectedOpenVSXUrl: openVSXDefaultUrl,
 		},
 		{
-			name: "Should not update openVSXURL if Eclipse Che version is less then 7.52.0",
+			name: "Should not update openVSXURL if Eclipse Che version is less then 7.53.0",
 			cheCluster: &chev2.CheCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "eclipse-che",
@@ -103,7 +103,7 @@ func TestOpenVSXUrlReconciler(t *testing.T) {
 					},
 				},
 				Status: chev2.CheClusterStatus{
-					CheVersion: "7.51.2",
+					CheVersion: "7.52.2",
 				},
 			},
 			expectedOpenVSXUrl: "open-vsx-url",


### PR DESCRIPTION
…lier

Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
fix: Set default openVSXURL if Che updated from 7.52.0 version or earlier

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21637

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
