### PR TITLE
fix: Update `CHE_WORKSPACE_PLUGIN__REGISTRY__URL` based on `externalPluginRegistry` field

### DIFF
--- a/pkg/deploy/server/server_configmap.go
+++ b/pkg/deploy/server/server_configmap.go
@@ -156,6 +156,13 @@ func (s *CheServerReconciler) getCheConfigMapData(ctx *chetypes.DeployContext) (
 	devfileRegistryURL = strings.TrimSpace(devfileRegistryURL)
 
 	pluginRegistryURL := ctx.CheCluster.Status.PluginRegistryURL
+	for _, r := range ctx.CheCluster.Spec.Components.PluginRegistry.ExternalPluginRegistries {
+		if strings.Index(pluginRegistryURL, r.Url) == -1 {
+			pluginRegistryURL += " " + r.Url
+		}
+	}
+	pluginRegistryURL = strings.TrimSpace(pluginRegistryURL)
+
 	cheLogLevel := utils.GetValue(ctx.CheCluster.Spec.Components.CheServer.LogLevel, constants.DefaultServerLogLevel)
 	cheDebug := "false"
 	if ctx.CheCluster.Spec.Components.CheServer.Debug != nil {

--- a/pkg/deploy/server/server_configmap_test.go
+++ b/pkg/deploy/server/server_configmap_test.go
@@ -321,7 +321,7 @@ func TestShouldSetUpCorrectlyDevfileRegistryURL(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name: "Test devfile registry urls #1",
+			name: "Test #1",
 			cheCluster: &chev2.CheCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "eclipse-che",
@@ -331,19 +331,19 @@ func TestShouldSetUpCorrectlyDevfileRegistryURL(t *testing.T) {
 						DevfileRegistry: chev2.DevfileRegistry{
 							DisableInternalRegistry: true,
 							ExternalDevfileRegistries: []chev2.ExternalDevfileRegistry{
-								{Url: "http://devfile-registry.external.1"},
+								{Url: "external-plugin-registry"},
 							},
 						},
 					},
 				},
 			},
 			expectedData: map[string]string{
-				"CHE_WORKSPACE_DEVFILE__REGISTRY__URL":           "http://devfile-registry.external.1",
+				"CHE_WORKSPACE_DEVFILE__REGISTRY__URL":           "external-plugin-registry",
 				"CHE_WORKSPACE_DEVFILE__REGISTRY__INTERNAL__URL": "",
 			},
 		},
 		{
-			name: "Test devfile registry urls #2",
+			name: "Test #2",
 			cheCluster: &chev2.CheCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "eclipse-che",
@@ -352,17 +352,17 @@ func TestShouldSetUpCorrectlyDevfileRegistryURL(t *testing.T) {
 					Components: chev2.CheClusterComponents{
 						DevfileRegistry: chev2.DevfileRegistry{
 							ExternalDevfileRegistries: []chev2.ExternalDevfileRegistry{
-								{Url: "http://devfile-registry.external.2"},
+								{Url: "external-plugin-registry"},
 							},
 						},
 					},
 				},
 				Status: chev2.CheClusterStatus{
-					DevfileRegistryURL: "http://devfile-registry.internal.1",
+					DevfileRegistryURL: "internal-plugin-registry",
 				},
 			},
 			expectedData: map[string]string{
-				"CHE_WORKSPACE_DEVFILE__REGISTRY__URL":           "http://devfile-registry.internal.1 http://devfile-registry.external.2",
+				"CHE_WORKSPACE_DEVFILE__REGISTRY__URL":           "internal-plugin-registry external-plugin-registry",
 				"CHE_WORKSPACE_DEVFILE__REGISTRY__INTERNAL__URL": "http://devfile-registry.eclipse-che.svc:8080",
 			},
 		},
@@ -373,12 +373,12 @@ func TestShouldSetUpCorrectlyDevfileRegistryURL(t *testing.T) {
 					Namespace: "eclipse-che",
 				},
 				Status: chev2.CheClusterStatus{
-					DevfileRegistryURL: "http://devfile-registry.internal",
+					DevfileRegistryURL: "internal-plugin-registry",
 				},
 			},
 			expectedData: map[string]string{
 				"CHE_WORKSPACE_DEVFILE__REGISTRY__INTERNAL__URL": "http://devfile-registry.eclipse-che.svc:8080",
-				"CHE_WORKSPACE_DEVFILE__REGISTRY__URL":           "http://devfile-registry.internal",
+				"CHE_WORKSPACE_DEVFILE__REGISTRY__URL":           "internal-plugin-registry",
 			},
 		},
 	}
@@ -395,7 +395,7 @@ func TestShouldSetUpCorrectlyDevfileRegistryURL(t *testing.T) {
 	}
 }
 
-func TestShouldSetUpCorrectlyInternalPluginRegistryServiceURL(t *testing.T) {
+func TestShouldSetUpCorrectlyPluginRegistryURL(t *testing.T) {
 	type testCase struct {
 		name         string
 		initObjects  []runtime.Object
@@ -405,7 +405,7 @@ func TestShouldSetUpCorrectlyInternalPluginRegistryServiceURL(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name: "Test CHE_WORKSPACE_PLUGIN__REGISTRY__INTERNAL__URL #1",
+			name: "Test #1",
 			cheCluster: &chev2.CheCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "eclipse-che",
@@ -414,15 +414,16 @@ func TestShouldSetUpCorrectlyInternalPluginRegistryServiceURL(t *testing.T) {
 					Components: chev2.CheClusterComponents{
 						PluginRegistry: chev2.PluginRegistry{
 							DisableInternalRegistry: true,
+							ExternalPluginRegistries: []chev2.ExternalPluginRegistry{
+								{Url: "external-plugin-registry"},
+							},
 						},
 					},
-				},
-				Status: chev2.CheClusterStatus{
-					PluginRegistryURL: "http://external-plugin-registry",
 				},
 			},
 			expectedData: map[string]string{
 				"CHE_WORKSPACE_PLUGIN__REGISTRY__INTERNAL__URL": "",
+				"CHE_WORKSPACE_PLUGIN__REGISTRY__URL":           "external-plugin-registry",
 			},
 		},
 		{
@@ -432,11 +433,12 @@ func TestShouldSetUpCorrectlyInternalPluginRegistryServiceURL(t *testing.T) {
 					Namespace: "eclipse-che",
 				},
 				Status: chev2.CheClusterStatus{
-					PluginRegistryURL: "http://external-plugin-registry",
+					PluginRegistryURL: "internal-plugin-registry",
 				},
 			},
 			expectedData: map[string]string{
 				"CHE_WORKSPACE_PLUGIN__REGISTRY__INTERNAL__URL": "http://plugin-registry.eclipse-che.svc:8080/v3",
+				"CHE_WORKSPACE_PLUGIN__REGISTRY__URL":           "internal-plugin-registry",
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
https://github.com/eclipse/che/issues/21681

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Update `CHE_WORKSPACE_PLUGIN__REGISTRY__URL` based on `externalPluginRegistry` field

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
