### PR TITLE
fix: path to run prepare-community-operators-update.sh script

### DIFF
--- a/build/scripts/release/make-release.sh
+++ b/build/scripts/release/make-release.sh
@@ -273,7 +273,7 @@ createPRToMainBranch() {
 }
 
 prepareCommunityOperatorsUpdate() {
-  . "${OPERATOR_REPO}/build/script/release/prepare-community-operators-update.sh" $FORCE_UPDATE
+  . "${OPERATOR_REPO}/build/scripts/release/prepare-community-operators-update.sh" $FORCE_UPDATE
 }
 
 run() {


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
fix: path to run prepare-community-operators-update.sh script