### PR TITLE
fix: prepare-community-operators-update.sh

### DIFF
--- a/build/scripts/release/prepare-community-operators-update.sh
+++ b/build/scripts/release/prepare-community-operators-update.sh
@@ -20,7 +20,7 @@ set -u
 
 STABLE_CHANNELS=("stable")
 OPERATOR_REPO=$(dirname "$(dirname "$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")")")
-source "${OPERATOR_REPO}/build/scripts/oc-tests/oc-common.sh"
+source "${OPERATOR_REPO}/build/scripts/minikube-tests/common.sh"
 
 base_branch="main"
 GITHUB_USER="che-bot"


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
fix: prepare-community-operators-update.sh