### PR TITLE
fix: conversion when only one resource (cpu or memory) is specified f…

### DIFF
--- a/api/checluster_conversion_to_test.go
+++ b/api/checluster_conversion_to_test.go
@@ -543,3 +543,29 @@ func TestConvertTo(t *testing.T) {
 	assert.Equal(t, checlusterv2.Spec.GitServices.BitBucket[0].SecretName, "bitbucket-secret-name")
 	assert.Equal(t, checlusterv2.Spec.GitServices.BitBucket[0].Endpoint, "bitbucket-endpoint")
 }
+
+func TestShouldConvertToWhenOnlyMemoryResourceSpecified(t *testing.T) {
+	infrastructure.InitializeForTesting(infrastructure.Kubernetes)
+
+	checlusterv1 := &chev1.CheCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eclipse-che",
+			Namespace: "eclipse-che",
+		},
+		Spec: chev1.CheClusterSpec{
+			Server: chev1.CheClusterSpecServer{
+				ServerMemoryLimit:   "10Gi",
+				ServerMemoryRequest: "5Gi",
+			},
+		},
+	}
+
+	checlusterv2 := &chev2.CheCluster{}
+	err := checlusterv1.ConvertTo(checlusterv2)
+	assert.Nil(t, err)
+
+	assert.True(t, checlusterv2.Spec.Components.CheServer.Deployment.Containers[0].Resources.Limits.Cpu.IsZero())
+	assert.Equal(t, checlusterv2.Spec.Components.CheServer.Deployment.Containers[0].Resources.Limits.Memory, resource.MustParse("10Gi"))
+	assert.True(t, checlusterv2.Spec.Components.CheServer.Deployment.Containers[0].Resources.Requests.Cpu.IsZero())
+	assert.Equal(t, checlusterv2.Spec.Components.CheServer.Deployment.Containers[0].Resources.Requests.Memory, resource.MustParse("5Gi"))
+}

--- a/api/v1/checluster_conversion_from.go
+++ b/api/v1/checluster_conversion_from.go
@@ -14,6 +14,7 @@ package v1
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"strconv"
 	"strings"
 
@@ -153,12 +154,12 @@ func (dst *CheCluster) convertFrom_Server(src *chev2.CheCluster) error {
 
 			if src.Spec.Components.CheServer.Deployment.Containers[0].Resources != nil {
 				if src.Spec.Components.CheServer.Deployment.Containers[0].Resources.Requests != nil {
-					dst.Spec.Server.ServerMemoryRequest = src.Spec.Components.CheServer.Deployment.Containers[0].Resources.Requests.Memory.String()
-					dst.Spec.Server.ServerCpuRequest = src.Spec.Components.CheServer.Deployment.Containers[0].Resources.Requests.Cpu.String()
+					dst.Spec.Server.ServerMemoryRequest = resource2String(src.Spec.Components.CheServer.Deployment.Containers[0].Resources.Requests.Memory)
+					dst.Spec.Server.ServerCpuRequest = resource2String(src.Spec.Components.CheServer.Deployment.Containers[0].Resources.Requests.Cpu)
 				}
 				if src.Spec.Components.CheServer.Deployment.Containers[0].Resources.Limits != nil {
-					dst.Spec.Server.ServerMemoryLimit = src.Spec.Components.CheServer.Deployment.Containers[0].Resources.Limits.Memory.String()
-					dst.Spec.Server.ServerCpuLimit = src.Spec.Components.CheServer.Deployment.Containers[0].Resources.Limits.Cpu.String()
+					dst.Spec.Server.ServerMemoryLimit = resource2String(src.Spec.Components.CheServer.Deployment.Containers[0].Resources.Limits.Memory)
+					dst.Spec.Server.ServerCpuLimit = resource2String(src.Spec.Components.CheServer.Deployment.Containers[0].Resources.Limits.Cpu)
 				}
 			}
 		}
@@ -234,12 +235,12 @@ func (dst *CheCluster) convertFrom_Server_PluginRegistry(src *chev2.CheCluster) 
 
 			if src.Spec.Components.PluginRegistry.Deployment.Containers[0].Resources != nil {
 				if src.Spec.Components.PluginRegistry.Deployment.Containers[0].Resources.Requests != nil {
-					dst.Spec.Server.PluginRegistryMemoryRequest = src.Spec.Components.PluginRegistry.Deployment.Containers[0].Resources.Requests.Memory.String()
-					dst.Spec.Server.PluginRegistryCpuRequest = src.Spec.Components.PluginRegistry.Deployment.Containers[0].Resources.Requests.Cpu.String()
+					dst.Spec.Server.PluginRegistryMemoryRequest = resource2String(src.Spec.Components.PluginRegistry.Deployment.Containers[0].Resources.Requests.Memory)
+					dst.Spec.Server.PluginRegistryCpuRequest = resource2String(src.Spec.Components.PluginRegistry.Deployment.Containers[0].Resources.Requests.Cpu)
 				}
 				if src.Spec.Components.PluginRegistry.Deployment.Containers[0].Resources.Limits != nil {
-					dst.Spec.Server.PluginRegistryMemoryLimit = src.Spec.Components.PluginRegistry.Deployment.Containers[0].Resources.Limits.Memory.String()
-					dst.Spec.Server.PluginRegistryCpuLimit = src.Spec.Components.PluginRegistry.Deployment.Containers[0].Resources.Limits.Cpu.String()
+					dst.Spec.Server.PluginRegistryMemoryLimit = resource2String(src.Spec.Components.PluginRegistry.Deployment.Containers[0].Resources.Limits.Memory)
+					dst.Spec.Server.PluginRegistryCpuLimit = resource2String(src.Spec.Components.PluginRegistry.Deployment.Containers[0].Resources.Limits.Cpu)
 				}
 			}
 		}
@@ -266,12 +267,12 @@ func (dst *CheCluster) convertFrom_Server_DevfileRegistry(src *chev2.CheCluster)
 
 			if src.Spec.Components.DevfileRegistry.Deployment.Containers[0].Resources != nil {
 				if src.Spec.Components.DevfileRegistry.Deployment.Containers[0].Resources.Requests != nil {
-					dst.Spec.Server.DevfileRegistryMemoryRequest = src.Spec.Components.DevfileRegistry.Deployment.Containers[0].Resources.Requests.Memory.String()
-					dst.Spec.Server.DevfileRegistryCpuRequest = src.Spec.Components.DevfileRegistry.Deployment.Containers[0].Resources.Requests.Cpu.String()
+					dst.Spec.Server.DevfileRegistryMemoryRequest = resource2String(src.Spec.Components.DevfileRegistry.Deployment.Containers[0].Resources.Requests.Memory)
+					dst.Spec.Server.DevfileRegistryCpuRequest = resource2String(src.Spec.Components.DevfileRegistry.Deployment.Containers[0].Resources.Requests.Cpu)
 				}
 				if src.Spec.Components.DevfileRegistry.Deployment.Containers[0].Resources.Limits != nil {
-					dst.Spec.Server.DevfileRegistryMemoryLimit = src.Spec.Components.DevfileRegistry.Deployment.Containers[0].Resources.Limits.Memory.String()
-					dst.Spec.Server.DevfileRegistryCpuLimit = src.Spec.Components.DevfileRegistry.Deployment.Containers[0].Resources.Limits.Cpu.String()
+					dst.Spec.Server.DevfileRegistryMemoryLimit = resource2String(src.Spec.Components.DevfileRegistry.Deployment.Containers[0].Resources.Limits.Memory)
+					dst.Spec.Server.DevfileRegistryCpuLimit = resource2String(src.Spec.Components.DevfileRegistry.Deployment.Containers[0].Resources.Limits.Cpu)
 				}
 			}
 		}
@@ -288,12 +289,12 @@ func (dst *CheCluster) convertFrom_Server_Dashboard(src *chev2.CheCluster) error
 			dst.Spec.Server.DashboardImagePullPolicy = string(src.Spec.Components.Dashboard.Deployment.Containers[0].ImagePullPolicy)
 			if src.Spec.Components.Dashboard.Deployment.Containers[0].Resources != nil {
 				if src.Spec.Components.Dashboard.Deployment.Containers[0].Resources.Requests != nil {
-					dst.Spec.Server.DashboardMemoryRequest = src.Spec.Components.Dashboard.Deployment.Containers[0].Resources.Requests.Memory.String()
-					dst.Spec.Server.DashboardCpuRequest = src.Spec.Components.Dashboard.Deployment.Containers[0].Resources.Requests.Cpu.String()
+					dst.Spec.Server.DashboardMemoryRequest = resource2String(src.Spec.Components.Dashboard.Deployment.Containers[0].Resources.Requests.Memory)
+					dst.Spec.Server.DashboardCpuRequest = resource2String(src.Spec.Components.Dashboard.Deployment.Containers[0].Resources.Requests.Cpu)
 				}
 				if src.Spec.Components.Dashboard.Deployment.Containers[0].Resources.Limits != nil {
-					dst.Spec.Server.DashboardMemoryLimit = src.Spec.Components.Dashboard.Deployment.Containers[0].Resources.Limits.Memory.String()
-					dst.Spec.Server.DashboardCpuLimit = src.Spec.Components.Dashboard.Deployment.Containers[0].Resources.Limits.Cpu.String()
+					dst.Spec.Server.DashboardMemoryLimit = resource2String(src.Spec.Components.Dashboard.Deployment.Containers[0].Resources.Limits.Memory)
+					dst.Spec.Server.DashboardCpuLimit = resource2String(src.Spec.Components.Dashboard.Deployment.Containers[0].Resources.Limits.Cpu)
 				}
 			}
 		}
@@ -368,12 +369,12 @@ func (dst *CheCluster) convertFrom_Database(src *chev2.CheCluster) error {
 			dst.Spec.Database.PostgresImagePullPolicy = src.Spec.Components.Database.Deployment.Containers[0].ImagePullPolicy
 			if src.Spec.Components.Database.Deployment.Containers[0].Resources != nil {
 				if src.Spec.Components.Database.Deployment.Containers[0].Resources.Requests != nil {
-					dst.Spec.Database.ChePostgresContainerResources.Requests.Memory = src.Spec.Components.Database.Deployment.Containers[0].Resources.Requests.Memory.String()
-					dst.Spec.Database.ChePostgresContainerResources.Requests.Cpu = src.Spec.Components.Database.Deployment.Containers[0].Resources.Requests.Cpu.String()
+					dst.Spec.Database.ChePostgresContainerResources.Requests.Memory = resource2String(src.Spec.Components.Database.Deployment.Containers[0].Resources.Requests.Memory)
+					dst.Spec.Database.ChePostgresContainerResources.Requests.Cpu = resource2String(src.Spec.Components.Database.Deployment.Containers[0].Resources.Requests.Cpu)
 				}
 				if src.Spec.Components.Database.Deployment.Containers[0].Resources.Limits != nil {
-					dst.Spec.Database.ChePostgresContainerResources.Limits.Memory = src.Spec.Components.Database.Deployment.Containers[0].Resources.Limits.Memory.String()
-					dst.Spec.Database.ChePostgresContainerResources.Limits.Cpu = src.Spec.Components.Database.Deployment.Containers[0].Resources.Limits.Cpu.String()
+					dst.Spec.Database.ChePostgresContainerResources.Limits.Memory = resource2String(src.Spec.Components.Database.Deployment.Containers[0].Resources.Limits.Memory)
+					dst.Spec.Database.ChePostgresContainerResources.Limits.Cpu = resource2String(src.Spec.Components.Database.Deployment.Containers[0].Resources.Limits.Cpu)
 				}
 			}
 		}
@@ -478,4 +479,11 @@ func findTrustStoreConfigMap(namespace string) (string, error) {
 	}
 
 	return "", nil
+}
+
+func resource2String(resource resource.Quantity) string {
+	if resource.IsZero() {
+		return ""
+	}
+	return resource.String()
 }

--- a/api/v1/checluster_conversion_from.go
+++ b/api/v1/checluster_conversion_from.go
@@ -14,9 +14,10 @@ package v1
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"strconv"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/eclipse-che/che-operator/pkg/common/utils"
 

--- a/api/v1/checluster_conversion_to.go
+++ b/api/v1/checluster_conversion_to.go
@@ -669,11 +669,16 @@ func toCheV2Deployment(
 	}
 
 	if memoryRequest != "" || cpuRequest != "" {
-		resources = &chev2.ResourceRequirements{
-			Requests: &chev2.ResourceList{
-				Memory: resource.MustParse(memoryRequest),
-				Cpu:    resource.MustParse(cpuRequest),
-			},
+		if resources == nil {
+			resources = &chev2.ResourceRequirements{}
+		}
+		resources.Requests = &chev2.ResourceList{}
+
+		if memoryRequest != "" {
+			resources.Requests.Memory = resource.MustParse(memoryRequest)
+		}
+		if cpuRequest != "" {
+			resources.Requests.Cpu = resource.MustParse(cpuRequest)
 		}
 	}
 
@@ -681,10 +686,13 @@ func toCheV2Deployment(
 		if resources == nil {
 			resources = &chev2.ResourceRequirements{}
 		}
+		resources.Limits = &chev2.ResourceList{}
 
-		resources.Limits = &chev2.ResourceList{
-			Memory: resource.MustParse(memoryLimit),
-			Cpu:    resource.MustParse(cpuLimit),
+		if memoryLimit != "" {
+			resources.Limits.Memory = resource.MustParse(memoryLimit)
+		}
+		if cpuLimit != "" {
+			resources.Limits.Cpu = resource.MustParse(cpuLimit)
 		}
 	}
 


### PR DESCRIPTION
…or component

Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
fix: conversion when only one resource (cpu or memory) is specified for a component

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-3315

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
