### PR TITLE
feat: Add ValidatingWebhookConfiguration to ensure only one CheCluste…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,9 @@ gen-chectl-tmpl: ## Generate Eclipse Che k8s deployment resources used by chectl
 			cp $${src}/$${TARGET_PLATFORM}/objects/che-operator.Role.yaml $${dst}/$${TARGET_PLATFORM}/role.yaml
 
 			cp $${src}/$${TARGET_PLATFORM}/objects/che-operator-service.Service.yaml $${dst}/$${TARGET_PLATFORM}/webhook-service.yaml
+			if [[ -f $${src}/org.eclipse.che.ValidatingWebhookConfiguration.yaml ]]; then
+			  cp $${src}/org.eclipse.che.ValidatingWebhookConfiguration.yaml $${dst}/org.eclipse.che.ValidatingWebhookConfiguration.yaml
+			fi
 
 			if [[ $${TARGET_PLATFORM} == "kubernetes" ]]; then
 				cp $${src}/$${TARGET_PLATFORM}/objects/che-operator-serving-cert.Certificate.yaml $${dst}/$${TARGET_PLATFORM}/serving-cert.yaml

--- a/PROJECT
+++ b/PROJECT
@@ -26,5 +26,6 @@ resources:
   version: v2
   webhooks:
     conversion: true
+    validation: true
     webhookVersion: v1
 version: "3"

--- a/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -1395,6 +1395,27 @@ spec:
   webhookdefinitions:
     - admissionReviewVersions:
         - v1
+        - v1beta1
+      containerPort: 443
+      deploymentName: che-operator
+      failurePolicy: Fail
+      generateName: vchecluster.kb.io
+      rules:
+        - apiGroups:
+            - org.eclipse.che
+          apiVersions:
+            - v2
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - checlusters
+      sideEffects: None
+      targetPort: 9443
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-org-eclipse-che-v2-checluster
+    - admissionReviewVersions:
+        - v1
         - v2
       containerPort: 443
       conversionCRDs:

--- a/config/kubernetes/kustomization.yaml
+++ b/config/kubernetes/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
 # Kubernetes platform specific patches
 patchesStrategicMerge:
   - patches/cainjection_in_checlusters.yaml
+  - patches/cainjection_in_webhook.yaml
   - patches/manager_pod_security_context.yaml
 
 vars:

--- a/config/kubernetes/patches/cainjection_in_checlusters.yaml
+++ b/config/kubernetes/patches/cainjection_in_checlusters.yaml
@@ -14,6 +14,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: checlusters.org.eclipse.che
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: checlusters.org.eclipse.che

--- a/config/kubernetes/patches/cainjection_in_webhook.yaml
+++ b/config/kubernetes/patches/cainjection_in_webhook.yaml
@@ -10,14 +10,9 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-resources:
-  - ../crd
-  - ../rbac
-  - ../manager
-  - ../namespace
-  - ../webhook
-
-patchesStrategicMerge:
-  - patches/cainjection_in_checlusters.yaml
-  - patches/cainjection_in_webhook.yaml
-  - patches/service_cert_patch.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: org.eclipse.che
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/openshift/patches/cainjection_in_webhook.yaml
+++ b/config/openshift/patches/cainjection_in_webhook.yaml
@@ -10,14 +10,9 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-resources:
-  - ../crd
-  - ../rbac
-  - ../manager
-  - ../namespace
-  - ../webhook
-
-patchesStrategicMerge:
-  - patches/cainjection_in_checlusters.yaml
-  - patches/cainjection_in_webhook.yaml
-  - patches/service_cert_patch.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: org.eclipse.che
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -11,6 +11,7 @@
 #
 
 resources:
+- webhooks.yaml
 - service.yaml
 
 configurations:

--- a/config/webhook/webhooks.yaml
+++ b/config/webhook/webhooks.yaml
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2019-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: org.eclipse.che
+  labels:
+    app.kubernetes.io/component: che-operator
+    app.kubernetes.io/instance: che
+    app.kubernetes.io/name: che
+    app.kubernetes.io/part-of: che.eclipse.org
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: che-operator-service
+        namespace: eclipse-che
+        path: /validate-org-eclipse-che-v2-checluster
+    failurePolicy: Fail
+    name: vchecluster.kb.io
+    rules:
+      - apiGroups:
+          - org.eclipse.che
+        apiVersions:
+          - v2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - checlusters
+    sideEffects: None

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -6200,3 +6200,37 @@ metadata:
   namespace: eclipse-che
 spec:
   selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: eclipse-che/che-operator-serving-cert
+  labels:
+    app.kubernetes.io/component: che-operator
+    app.kubernetes.io/instance: che
+    app.kubernetes.io/name: che
+    app.kubernetes.io/part-of: che.eclipse.org
+  name: org.eclipse.che
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: che-operator-service
+      namespace: eclipse-che
+      path: /validate-org-eclipse-che-v2-checluster
+  failurePolicy: Fail
+  name: vchecluster.kb.io
+  rules:
+  - apiGroups:
+    - org.eclipse.che
+    apiVersions:
+    - v2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - checlusters
+  sideEffects: None

--- a/deploy/deployment/kubernetes/objects/org.eclipse.che.ValidatingWebhookConfiguration.yaml
+++ b/deploy/deployment/kubernetes/objects/org.eclipse.che.ValidatingWebhookConfiguration.yaml
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2019-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: eclipse-che/che-operator-serving-cert
+  labels:
+    app.kubernetes.io/component: che-operator
+    app.kubernetes.io/instance: che
+    app.kubernetes.io/name: che
+    app.kubernetes.io/part-of: che.eclipse.org
+  name: org.eclipse.che
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: che-operator-service
+      namespace: eclipse-che
+      path: /validate-org-eclipse-che-v2-checluster
+  failurePolicy: Fail
+  name: vchecluster.kb.io
+  rules:
+  - apiGroups:
+    - org.eclipse.che
+    apiVersions:
+    - v2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - checlusters
+  sideEffects: None

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -6167,3 +6167,37 @@ spec:
         secret:
           defaultMode: 420
           secretName: che-operator-webhook-server-cert
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    app.kubernetes.io/component: che-operator
+    app.kubernetes.io/instance: che
+    app.kubernetes.io/name: che
+    app.kubernetes.io/part-of: che.eclipse.org
+  name: org.eclipse.che
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: che-operator-service
+      namespace: eclipse-che
+      path: /validate-org-eclipse-che-v2-checluster
+  failurePolicy: Fail
+  name: vchecluster.kb.io
+  rules:
+  - apiGroups:
+    - org.eclipse.che
+    apiVersions:
+    - v2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - checlusters
+  sideEffects: None

--- a/deploy/deployment/openshift/objects/org.eclipse.che.ValidatingWebhookConfiguration.yaml
+++ b/deploy/deployment/openshift/objects/org.eclipse.che.ValidatingWebhookConfiguration.yaml
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2019-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    app.kubernetes.io/component: che-operator
+    app.kubernetes.io/instance: che
+    app.kubernetes.io/name: che
+    app.kubernetes.io/part-of: che.eclipse.org
+  name: org.eclipse.che
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: che-operator-service
+      namespace: eclipse-che
+      path: /validate-org-eclipse-che-v2-checluster
+  failurePolicy: Fail
+  name: vchecluster.kb.io
+  rules:
+  - apiGroups:
+    - org.eclipse.che
+    apiVersions:
+    - v2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - checlusters
+  sideEffects: None

--- a/helmcharts/next/templates/org.eclipse.che.ValidatingWebhookConfiguration.yaml
+++ b/helmcharts/next/templates/org.eclipse.che.ValidatingWebhookConfiguration.yaml
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2019-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: eclipse-che/che-operator-serving-cert
+  labels:
+    app.kubernetes.io/component: che-operator
+    app.kubernetes.io/instance: che
+    app.kubernetes.io/name: che
+    app.kubernetes.io/part-of: che.eclipse.org
+  name: org.eclipse.che
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: che-operator-service
+      namespace: eclipse-che
+      path: /validate-org-eclipse-che-v2-checluster
+  failurePolicy: Fail
+  name: vchecluster.kb.io
+  rules:
+  - apiGroups:
+    - org.eclipse.che
+    apiVersions:
+    - v2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - checlusters
+  sideEffects: None

--- a/main.go
+++ b/main.go
@@ -318,9 +318,11 @@ func main() {
 		})
 	}
 
-	if err = (&chev2.CheCluster{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "CheCluster")
-		os.Exit(1)
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err = (&chev2.CheCluster{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "CheCluster")
+			os.Exit(1)
+		}
 	}
 
 	// +kubebuilder:scaffold:builder

--- a/pkg/common/k8s-helper/k8s_helper.go
+++ b/pkg/common/k8s-helper/k8s_helper.go
@@ -18,6 +18,9 @@ import (
 	"io"
 	"os"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/sirupsen/logrus"
@@ -27,10 +30,12 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 type K8sHelper struct {
 	clientset kubernetes.Interface
+	client    client.Client
 }
 
 var (
@@ -51,6 +56,10 @@ func New() *K8sHelper {
 
 func (cl *K8sHelper) GetClientset() kubernetes.Interface {
 	return cl.clientset
+}
+
+func (cl *K8sHelper) GetClient() client.Client {
+	return cl.client
 }
 
 func (cl *K8sHelper) ExecIntoPod(
@@ -159,6 +168,7 @@ func (cl *K8sHelper) RunExec(command []string, podName, namespace string, stdin 
 func initializeForTesting() *K8sHelper {
 	k8sHelper = &K8sHelper{
 		clientset: fake.NewSimpleClientset(),
+		client:    fakeclient.NewClientBuilder().Build(),
 	}
 
 	return k8sHelper
@@ -175,8 +185,14 @@ func initialize() *K8sHelper {
 		logrus.Fatalf("Failed to initialized Kubernetes client: %v", err)
 	}
 
+	client, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
+	if err != nil {
+		logrus.Fatalf("Failed to initialized Kubernetes client: %v", err)
+	}
+
 	k8sHelper = &K8sHelper{
 		clientset: clientSet,
+		client:    client,
 	}
 
 	return k8sHelper


### PR DESCRIPTION
…r is created

Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Add ValidatingWebhookConfiguration to ensure only one CheCluster is created

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![screenshot-console-openshift-console apps ci-ln-isdrrfb-76ef8 origin-ci-int-aws dev rhcloud com-2022 09 16-13_22_25](https://user-images.githubusercontent.com/1640675/190618497-7aa74409-5b9c-4286-81be-859fc0f6e65a.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-3328

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
1. Deloy Eclipse Che from CatalogSource `docker.io/abazko/catalog:crw-3328`.
2. Try to create Eclipse Che CR

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
