### PR TITLE
fix: Avoid mounting bitbucket id if OAuth 1 is used

### DIFF
--- a/pkg/deploy/server/server_deployment.go
+++ b/pkg/deploy/server/server_deployment.go
@@ -318,10 +318,10 @@ func MountBitBucketOAuthConfig(ctx *chetypes.DeployContext, deployment *appsv1.D
 	mountEnv(deployment, "CHE_OAUTH1_BITBUCKET_CONSUMERKEYPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigConsumerKeyFileName)
 	mountEnv(deployment, "CHE_OAUTH1_BITBUCKET_PRIVATEKEYPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigPrivateKeyFileName)
 
-	if secret.Data["id"] != "" {
+	if secret.Data["id"] != nil {
 		mountEnv(deployment, "CHE_OAUTH2_BITBUCKET_CLIENTID__FILEPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigClientIdFileName)
 	}
-	if secret.Data["secret"] != "" {
+	if secret.Data["secret"] != nil {
 		mountEnv(deployment, "CHE_OAUTH2_BITBUCKET_CLIENTSECRET__FILEPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigClientSecretFileName)
 	}
 

--- a/pkg/deploy/server/server_deployment.go
+++ b/pkg/deploy/server/server_deployment.go
@@ -318,7 +318,9 @@ func MountBitBucketOAuthConfig(ctx *chetypes.DeployContext, deployment *appsv1.D
 	mountEnv(deployment, "CHE_OAUTH1_BITBUCKET_CONSUMERKEYPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigConsumerKeyFileName)
 	mountEnv(deployment, "CHE_OAUTH1_BITBUCKET_PRIVATEKEYPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigPrivateKeyFileName)
 
-	mountEnv(deployment, "CHE_OAUTH2_BITBUCKET_CLIENTID__FILEPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigClientIdFileName)
+	if secret.Data["id"] != nil {
+		mountEnv(deployment, "CHE_OAUTH2_BITBUCKET_CLIENTID__FILEPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigClientIdFileName)
+	}
 	mountEnv(deployment, "CHE_OAUTH2_BITBUCKET_CLIENTSECRET__FILEPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigClientSecretFileName)
 
 	oauthEndpoint := secret.Annotations[constants.CheEclipseOrgScmServerEndpoint]

--- a/pkg/deploy/server/server_deployment.go
+++ b/pkg/deploy/server/server_deployment.go
@@ -321,7 +321,7 @@ func MountBitBucketOAuthConfig(ctx *chetypes.DeployContext, deployment *appsv1.D
 	if secret.Data["id"] != "" {
 		mountEnv(deployment, "CHE_OAUTH2_BITBUCKET_CLIENTID__FILEPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigClientIdFileName)
 	}
-	if secret.Data["secret"] != nil {
+	if secret.Data["secret"] != "" {
 		mountEnv(deployment, "CHE_OAUTH2_BITBUCKET_CLIENTSECRET__FILEPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigClientSecretFileName)
 	}
 

--- a/pkg/deploy/server/server_deployment.go
+++ b/pkg/deploy/server/server_deployment.go
@@ -321,7 +321,9 @@ func MountBitBucketOAuthConfig(ctx *chetypes.DeployContext, deployment *appsv1.D
 	if secret.Data["id"] != nil {
 		mountEnv(deployment, "CHE_OAUTH2_BITBUCKET_CLIENTID__FILEPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigClientIdFileName)
 	}
-	mountEnv(deployment, "CHE_OAUTH2_BITBUCKET_CLIENTSECRET__FILEPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigClientSecretFileName)
+	if secret.Data["secret"] != nil {
+		mountEnv(deployment, "CHE_OAUTH2_BITBUCKET_CLIENTSECRET__FILEPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigClientSecretFileName)
+	}
 
 	oauthEndpoint := secret.Annotations[constants.CheEclipseOrgScmServerEndpoint]
 	if oauthEndpoint != "" {

--- a/pkg/deploy/server/server_deployment.go
+++ b/pkg/deploy/server/server_deployment.go
@@ -318,7 +318,7 @@ func MountBitBucketOAuthConfig(ctx *chetypes.DeployContext, deployment *appsv1.D
 	mountEnv(deployment, "CHE_OAUTH1_BITBUCKET_CONSUMERKEYPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigConsumerKeyFileName)
 	mountEnv(deployment, "CHE_OAUTH1_BITBUCKET_PRIVATEKEYPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigPrivateKeyFileName)
 
-	if secret.Data["id"] != nil {
+	if secret.Data["id"] != "" {
 		mountEnv(deployment, "CHE_OAUTH2_BITBUCKET_CLIENTID__FILEPATH", constants.BitBucketOAuthConfigMountPath+"/"+constants.BitBucketOAuthConfigClientIdFileName)
 	}
 	if secret.Data["secret"] != nil {

--- a/pkg/deploy/server/server_deployment_test.go
+++ b/pkg/deploy/server/server_deployment_test.go
@@ -131,7 +131,7 @@ func TestDeployment(t *testing.T) {
 	}
 }
 
-func TestMountBitBucketOAuthEnvVar(t *testing.T) {
+func TestMountBitBucketServerOAuthEnvVar(t *testing.T) {
 	type testCase struct {
 		name                    string
 		initObjects             []runtime.Object
@@ -152,7 +152,7 @@ func TestMountBitBucketOAuthEnvVar(t *testing.T) {
 						APIVersion: "v1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "github-oauth-config",
+						Name:      "bitbucket-oauth-config",
 						Namespace: "eclipse-che",
 						Labels: map[string]string{
 							"app.kubernetes.io/part-of":   "che.eclipse.org",
@@ -173,15 +173,15 @@ func TestMountBitBucketOAuthEnvVar(t *testing.T) {
 			expectedPrivateKeyPath:  "/che-conf/oauth/bitbucket/private.key",
 			expectedOAuthEndpoint:   "endpoint_1",
 			expectedVolume: corev1.Volume{
-				Name: "github-oauth-config",
+				Name: "bitbucket-oauth-config",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "github-oauth-config",
+						SecretName: "bitbucket-oauth-config",
 					},
 				},
 			},
 			expectedVolumeMount: corev1.VolumeMount{
-				Name:      "github-oauth-config",
+				Name:      "bitbucket-oauth-config",
 				MountPath: "/che-conf/oauth/bitbucket",
 			},
 		},
@@ -206,11 +206,93 @@ func TestMountBitBucketOAuthEnvVar(t *testing.T) {
 			value = utils.GetEnvByName("CHE_OAUTH1_BITBUCKET_ENDPOINT", container.Env)
 			assert.Equal(t, testCase.expectedOAuthEndpoint, value)
 
-			volume := test.FindVolume(deployment.Spec.Template.Spec.Volumes, "github-oauth-config")
+			volume := test.FindVolume(deployment.Spec.Template.Spec.Volumes, "bitbucket-oauth-config")
 			assert.NotNil(t, volume)
 			assert.Equal(t, testCase.expectedVolume, volume)
 
-			volumeMount := test.FindVolumeMount(container.VolumeMounts, "github-oauth-config")
+			volumeMount := test.FindVolumeMount(container.VolumeMounts, "bitbucket-oauth-config")
+			assert.NotNil(t, volumeMount)
+			assert.Equal(t, testCase.expectedVolumeMount, volumeMount)
+		})
+	}
+}
+
+func TestMountBitbucketOAuthEnvVar(t *testing.T) {
+	type testCase struct {
+		name                  string
+		initObjects           []runtime.Object
+		expectedIdKeyPath     string
+		expectedSecretKeyPath string
+		expectedOAuthEndpoint string
+		expectedVolume        corev1.Volume
+		expectedVolumeMount   corev1.VolumeMount
+	}
+
+	testCases := []testCase{
+		{
+			name: "Test",
+			initObjects: []runtime.Object{
+				&corev1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bitbucket-oauth-config",
+						Namespace: "eclipse-che",
+						Labels: map[string]string{
+							"app.kubernetes.io/part-of":   "che.eclipse.org",
+							"app.kubernetes.io/component": "oauth-scm-configuration",
+						},
+						Annotations: map[string]string{
+							"che.eclipse.org/oauth-scm-server":    "bitbucket",
+							"che.eclipse.org/scm-server-endpoint": "endpoint_1",
+						},
+					},
+					Data: map[string][]byte{
+						"id":     []byte("some_id"),
+						"secret": []byte("some_secret"),
+					},
+				},
+			},
+			expectedIdKeyPath:     "/che-conf/oauth/bitbucket/id",
+			expectedSecretKeyPath: "/che-conf/oauth/bitbucket/secret",
+			expectedVolume: corev1.Volume{
+				Name: "bitbucket-oauth-config",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "bitbucket-oauth-config",
+					},
+				},
+			},
+			expectedVolumeMount: corev1.VolumeMount{
+				Name:      "bitbucket-oauth-config",
+				MountPath: "/che-conf/oauth/bitbucket",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := test.GetDeployContext(nil, testCase.initObjects)
+
+			server := NewCheServerReconciler()
+			deployment, err := server.getDeploymentSpec(ctx)
+			assert.Nil(t, err, "Unexpected error %v", err)
+
+			container := &deployment.Spec.Template.Spec.Containers[0]
+
+			value := utils.GetEnvByName("CHE_OAUTH2_BITBUCKET_CLIENTID__FILEPATH", container.Env)
+			assert.Equal(t, testCase.expectedIdKeyPath, value)
+
+			value = utils.GetEnvByName("CHE_OAUTH2_BITBUCKET_CLIENTSECRET__FILEPATH", container.Env)
+			assert.Equal(t, testCase.expectedSecretKeyPath, value)
+
+			volume := test.FindVolume(deployment.Spec.Template.Spec.Volumes, "bitbucket-oauth-config")
+			assert.NotNil(t, volume)
+			assert.Equal(t, testCase.expectedVolume, volume)
+
+			volumeMount := test.FindVolumeMount(container.VolumeMounts, "bitbucket-oauth-config")
 			assert.NotNil(t, volumeMount)
 			assert.Equal(t, testCase.expectedVolumeMount, volumeMount)
 		})


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Check the bitbucket OAuth secret for the `id` data key. Do not mount it if it is not present. The bitbucket OAuth 1 configuration doesn't  use the `id` property, but Che fails to initialise, because it tries to read the file which is not mounted from the secret.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-3341

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
Configure Bitbucket Server OAuth https://www.eclipse.org/che/docs/next/administration-guide/configuring-oauth-1-for-a-bitbucket-server/

```bash
cat > /tmp/patch.yaml <<EOF
<PATCH_CONTENT>
EOF

chectl server:deploy \
     --installer operator \
     --platform <PLATFORM_TO_DEPLOY> \
     --che-operator-image <CUSTOM_OPERATOR_IMAGE> \
     --che-operator-cr-patch-yaml /tmp/patch.yaml
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#updating-custom-resource-definition-file)
- [ ] [OLM bundles are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
