### PR TITLE
Add 'use' permission for DWO SA when container build is enabled

### DIFF
--- a/pkg/deploy/container-build/container_build.go
+++ b/pkg/deploy/container-build/container_build.go
@@ -170,7 +170,7 @@ func (cb *ContainerBuildReconciler) getDevWorkspaceSccPolicyRules(ctx *chetypes.
 		{
 			APIGroups:     []string{"security.openshift.io"},
 			Resources:     []string{"securitycontextconstraints"},
-			Verbs:         []string{"get", "update"},
+			Verbs:         []string{"get", "update", "use"},
 			ResourceNames: []string{ctx.CheCluster.Spec.DevEnvironments.ContainerBuildConfiguration.OpenShiftSecurityContextConstraint},
 		},
 	}


### PR DESCRIPTION
### What does this PR do?
Add 'use' permissions in addition to 'get' and 'update' to be added to the DevWorkspace Operator ServiceAccount when container build functionality is enabled. This is required due to changes in the DevWorkspace Operator in https://github.com/devfile/devworkspace-operator/pull/954

I merged PR https://github.com/devfile/devworkspace-operator/pull/954 forgetting that it would impact Che nightlies -- apologies. Revert PR in DWO here: https://github.com/devfile/devworkspace-operator/pull/972

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A, required sync for changes in DWO

### How to test this PR?
Verify that automatic container-build provisioning works as expected (workspaces start and can perform podman builds).

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
