### PR TITLE
fix: release-nex-catalog.yaml

### DIFF
--- a/.github/workflows/release-next-catalog.yaml
+++ b/.github/workflows/release-next-catalog.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install yq
       run: sudo pip install yq
     - name: Docker login


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
fix: release-nex-catalog.yaml