### PR TITLE
Add retry middleware to retry connecting to mainurl if connection failed

### DIFF
--- a/controllers/devworkspace/solver/che_routing_test.go
+++ b/controllers/devworkspace/solver/che_routing_test.go
@@ -402,7 +402,7 @@ func TestCreateRelocatedObjectsOpenshift(t *testing.T) {
 
 		workspaceMainConfig := gateway.TraefikConfig{}
 		assert.NoError(t, yaml.Unmarshal([]byte(traefikMainWorkspaceConfig), &workspaceMainConfig))
-		assert.Len(t, workspaceMainConfig.HTTP.Middlewares, 5)
+		assert.Len(t, workspaceMainConfig.HTTP.Middlewares, 6)
 
 		wsid = "wsid"
 		mwares := []string{
@@ -410,7 +410,8 @@ func TestCreateRelocatedObjectsOpenshift(t *testing.T) {
 			wsid + gateway.StripPrefixMiddlewareSuffix,
 			wsid + gateway.HeaderRewriteMiddlewareSuffix,
 			wsid + gateway.HeadersMiddlewareSuffix,
-			wsid + gateway.ErrorsMiddlewareSuffix}
+			wsid + gateway.ErrorsMiddlewareSuffix,
+			wsid + gateway.RetryMiddlewareSuffix}
 		for _, mware := range mwares {
 			assert.Contains(t, workspaceMainConfig.HTTP.Middlewares, mware)
 

--- a/pkg/deploy/gateway/traefik_config.go
+++ b/pkg/deploy/gateway/traefik_config.go
@@ -39,6 +39,7 @@ type TraefikConfigMiddleware struct {
 	ForwardAuth *TraefikConfigForwardAuth `json:"forwardAuth,omitempty"`
 	Errors      *TraefikConfigErrors      `json:"errors,omitempty"`
 	Headers     *TraefikConfigHeaders     `json:"headers,omitempty"`
+	Retry       *TraefikConfigRetry       `json:"retry,omitempty"`
 	Plugin      *TraefikPlugin            `json:"plugin,omitempty"`
 }
 
@@ -73,6 +74,12 @@ type TraefikConfigErrors struct {
 
 type TraefikConfigHeaders struct {
 	CustomResponseHeaders map[string]string `json:"customResponseHeaders,omitempty"`
+}
+
+type TraefikConfigRetry struct {
+	CustomResponseHeaders map[string]string `json:"customResponseHeaders,omitempty"`
+	Attempts              int               `json:"attempts,omitempty"`
+	InitialInterval       string            `json:"initialInterval,omitempty"`
 }
 
 type TraefikPlugin struct {

--- a/pkg/deploy/gateway/traefik_config_util.go
+++ b/pkg/deploy/gateway/traefik_config_util.go
@@ -17,6 +17,7 @@ const (
 	AuthMiddlewareSuffix          = "-auth"
 	ErrorsMiddlewareSuffix        = "-errors"
 	HeadersMiddlewareSuffix       = "-headers"
+	RetryMiddlewareSuffix         = "-retry"
 )
 
 func CreateEmptyTraefikConfig() *TraefikConfig {
@@ -123,6 +124,17 @@ func (cfg *TraefikConfig) AddResponseHeaders(componentName string, headers map[s
 	cfg.HTTP.Middlewares[middlewareName] = &TraefikConfigMiddleware{
 		Headers: &TraefikConfigHeaders{
 			CustomResponseHeaders: headers,
+		},
+	}
+}
+
+func (cfg *TraefikConfig) AddRetry(componentName string, attempts int, initialInterval string) {
+	middlewareName := componentName + RetryMiddlewareSuffix
+	cfg.HTTP.Routers[componentName].Middlewares = append(cfg.HTTP.Routers[componentName].Middlewares, middlewareName)
+	cfg.HTTP.Middlewares[middlewareName] = &TraefikConfigMiddleware{
+		Retry: &TraefikConfigRetry{
+			Attempts:        attempts,
+			InitialInterval: initialInterval,
 		},
 	}
 }

--- a/pkg/deploy/gateway/traefik_config_util_test.go
+++ b/pkg/deploy/gateway/traefik_config_util_test.go
@@ -124,6 +124,22 @@ func TestAddResponseHeaders(t *testing.T) {
 	}
 }
 
+func TestAddRetry(t *testing.T) {
+	attempts := 3
+	initialInterval := "100ms"
+
+	cfg := CreateCommonTraefikConfig(testComponentName, testRule, 1, "http://svc:8080", []string{})
+	cfg.AddRetry(testComponentName, attempts, initialInterval)
+
+	assert.Len(t, cfg.HTTP.Routers[testComponentName].Middlewares, 1, *cfg)
+	assert.Len(t, cfg.HTTP.Middlewares, 1, *cfg)
+	middlewareName := cfg.HTTP.Routers[testComponentName].Middlewares[0]
+	if assert.Contains(t, cfg.HTTP.Middlewares, middlewareName, *cfg) && assert.NotNil(t, cfg.HTTP.Middlewares[middlewareName].Retry) {
+		assert.Equal(t, attempts, cfg.HTTP.Middlewares[middlewareName].Retry.Attempts)
+		assert.Equal(t, initialInterval, cfg.HTTP.Middlewares[middlewareName].Retry.InitialInterval)
+	}
+}
+
 func TestMiddlewaresPreserveOrder(t *testing.T) {
 	t.Run("strip-header", func(t *testing.T) {
 		cfg := CreateCommonTraefikConfig(testComponentName, testRule, 1, "http://svc:8080", []string{})


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
On OpenShift, retries the connection to the workspace service if connection cannot be established. This was done with the [Retry middleware](https://doc.traefik.io/traefik/middlewares/http/retry/#:~:text=The%20Retry%20middleware%20reissues%20requests,to%20enable%20an%20exponential%20backoff.)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
Confirming that the workspace not running page still appears:

https://user-images.githubusercontent.com/83611742/207145593-e086f207-ae0c-446e-b198-cfa79d2bf86f.mov


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Aims to handle https://github.com/eclipse/che/issues/21796.

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
Unfortunately, https://github.com/eclipse/che/issues/21796 is quite hard to reproduce.

To test this PR does not break the routing on OpenShift:

1. Deploy using:
```bash
chectl server:deploy \
     --installer operator \
     --platform openshift \
     --che-operator-image quay.io/dkwon17/che-operator:addRetries \
```
2. Start a workspace
3. Wait until the workspace IDE url opens
4. Stop the workspace
5. Regresh the workspace IDE url
6. Confirm that the 'Workspace is not running' page is displayed from the dashboard:
![image](https://user-images.githubusercontent.com/83611742/207129592-be2d5874-b8f6-48fb-9355-a7edd203756b.png)
7. Confirm that the traefik config for the workspace in the `eclipse-che` namespace has the following changes:
```diff
data:
  workspace111e417fd82a4e5e.yml: |
    http:
      middlewares:
        workspace111e417fd82a4e5e-auth:
          forwardAuth:
            address: http://127.0.0.1:8089?namespace=che-kube-admin-che-yqqmbc
            trustForwardHeader: false
        workspace111e417fd82a4e5e-errors:
          errors:
            query: /
            service: che-dashboard
            status: 500-599
        workspace111e417fd82a4e5e-header-rewrite:
          plugin:
            header-rewrite:
              from: X-Forwarded-Access-Token
              prefix: 'Bearer '
              to: Authorization
        workspace111e417fd82a4e5e-headers:
          headers:
            customResponseHeaders:
              cache-control: no-store, max-age=0
+       workspace111e417fd82a4e5e-retry:
+         retry:
+           attempts: 2
+           initialInterval: 500ms
        workspace111e417fd82a4e5e-strip-prefix:
          stripPrefix:
            prefixes:
            - /workspace111e417fd82a4e5e
      routers:
        workspace111e417fd82a4e5e:
          middlewares:
          - workspace111e417fd82a4e5e-strip-prefix
          - workspace111e417fd82a4e5e-header-rewrite
          - workspace111e417fd82a4e5e-auth
          - workspace111e417fd82a4e5e-headers
          - workspace111e417fd82a4e5e-errors
+         - workspace111e417fd82a4e5e-retry
          priority: 100
          rule: PathPrefix(`/workspace111e417fd82a4e5e`)
          service: workspace111e417fd82a4e5e
        workspace111e417fd82a4e5e-3100-healthz:
          middlewares:
          - workspace111e417fd82a4e5e-strip-prefix
          - workspace111e417fd82a4e5e-header-rewrite
          priority: 101
          rule: Path(`/workspace111e417fd82a4e5e/tools/3100/healthz`)
          service: workspace111e417fd82a4e5e
      serversTransports:
        workspace111e417fd82a4e5e:
          forwardingTimeouts:
+           dialTimeout: 2500ms
-           dialTimeout: 4s
      services:
        workspace111e417fd82a4e5e:
          loadBalancer:
            servers:
            - url: http://workspace111e417fd82a4e5e-service.che-kube-admin-che-yqqmbc.svc:3030
            serversTransport: workspace111e417fd82a4e5e
```


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
