### PR TITLE
feat: Support ephemeral pvc strategy

### DIFF
--- a/api/v2/checluster_types.go
+++ b/api/v2/checluster_types.go
@@ -394,12 +394,13 @@ type WorkspaceStorage struct {
 	// +optional
 	PerWorkspaceStrategyPvcConfig *PVC `json:"perWorkspaceStrategyPvcConfig,omitempty"`
 	// Persistent volume claim strategy for the Che server.
-	// The supported strategies are: `per-user` (all workspaces PVCs in one volume)
-	// and 'per-workspace' (each workspace is given its own individual PVC).
-	// For details, see https://github.com/eclipse/che/issues/21185.
+	// The supported strategies are: `per-user` (all workspaces PVCs in one volume),
+	// `per-workspace` (each workspace is given its own individual PVC)
+	// and `ephemeral` (non-persistent storage where local changes will be lost when
+	// the workspace is stopped.)
 	// +optional
 	// +kubebuilder:default:="per-user"
-	// +kubebuilder:validation:Enum=common;per-user;per-workspace
+	// +kubebuilder:validation:Enum=common;per-user;per-workspace;ephemeral
 	PvcStrategy string `json:"pvcStrategy,omitempty"`
 }
 

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -77,7 +77,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che.v7.58.0-737.next
+  name: eclipse-che.v7.58.0-738.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1233,7 +1233,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Eclipse Foundation
-  version: 7.58.0-737.next
+  version: 7.58.0-738.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -77,7 +77,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che.v7.58.0-738.next
+  name: eclipse-che.v7.59.0-739.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1233,7 +1233,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Eclipse Foundation
-  version: 7.58.0-738.next
+  version: 7.59.0-739.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
@@ -7040,13 +7040,15 @@ spec:
                           default: per-user
                           description: 'Persistent volume claim strategy for the Che
                             server. The supported strategies are: `per-user` (all
-                            workspaces PVCs in one volume) and ''per-workspace'' (each
-                            workspace is given its own individual PVC). For details,
-                            see https://github.com/eclipse/che/issues/21185.'
+                            workspaces PVCs in one volume), `per-workspace` (each
+                            workspace is given its own individual PVC) and `ephemeral`
+                            (non-persistent storage where local changes will be lost
+                            when the workspace is stopped.)'
                           enum:
                             - common
                             - per-user
                             - per-workspace
+                            - ephemeral
                           type: string
                       type: object
                     tolerations:

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -6849,12 +6849,15 @@ spec:
                         default: per-user
                         description: 'Persistent volume claim strategy for the Che
                           server. The supported strategies are: `per-user` (all workspaces
-                          PVCs in one volume) and ''per-workspace'' (each workspace
-                          is given its own individual PVC). For details, see https://github.com/eclipse/che/issues/21185.'
+                          PVCs in one volume), `per-workspace` (each workspace is
+                          given its own individual PVC) and `ephemeral` (non-persistent
+                          storage where local changes will be lost when the workspace
+                          is stopped.)'
                         enum:
                         - common
                         - per-user
                         - per-workspace
+                        - ephemeral
                         type: string
                     type: object
                   tolerations:

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -4632,11 +4632,12 @@ spec:
                         type: object
                       pvcStrategy:
                         default: per-user
-                        description: 'Persistent volume claim strategy for the Che server. The supported strategies are: `per-user` (all workspaces PVCs in one volume) and ''per-workspace'' (each workspace is given its own individual PVC). For details, see https://github.com/eclipse/che/issues/21185.'
+                        description: 'Persistent volume claim strategy for the Che server. The supported strategies are: `per-user` (all workspaces PVCs in one volume), `per-workspace` (each workspace is given its own individual PVC) and `ephemeral` (non-persistent storage where local changes will be lost when the workspace is stopped.)'
                         enum:
                         - common
                         - per-user
                         - per-workspace
+                        - ephemeral
                         type: string
                     type: object
                   tolerations:

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -4627,11 +4627,12 @@ spec:
                         type: object
                       pvcStrategy:
                         default: per-user
-                        description: 'Persistent volume claim strategy for the Che server. The supported strategies are: `per-user` (all workspaces PVCs in one volume) and ''per-workspace'' (each workspace is given its own individual PVC). For details, see https://github.com/eclipse/che/issues/21185.'
+                        description: 'Persistent volume claim strategy for the Che server. The supported strategies are: `per-user` (all workspaces PVCs in one volume), `per-workspace` (each workspace is given its own individual PVC) and `ephemeral` (non-persistent storage where local changes will be lost when the workspace is stopped.)'
                         enum:
                         - common
                         - per-user
                         - per-workspace
+                        - ephemeral
                         type: string
                     type: object
                   tolerations:

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -4632,11 +4632,12 @@ spec:
                         type: object
                       pvcStrategy:
                         default: per-user
-                        description: 'Persistent volume claim strategy for the Che server. The supported strategies are: `per-user` (all workspaces PVCs in one volume) and ''per-workspace'' (each workspace is given its own individual PVC). For details, see https://github.com/eclipse/che/issues/21185.'
+                        description: 'Persistent volume claim strategy for the Che server. The supported strategies are: `per-user` (all workspaces PVCs in one volume), `per-workspace` (each workspace is given its own individual PVC) and `ephemeral` (non-persistent storage where local changes will be lost when the workspace is stopped.)'
                         enum:
                         - common
                         - per-user
                         - per-workspace
+                        - ephemeral
                         type: string
                     type: object
                   tolerations:

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -4627,11 +4627,12 @@ spec:
                         type: object
                       pvcStrategy:
                         default: per-user
-                        description: 'Persistent volume claim strategy for the Che server. The supported strategies are: `per-user` (all workspaces PVCs in one volume) and ''per-workspace'' (each workspace is given its own individual PVC). For details, see https://github.com/eclipse/che/issues/21185.'
+                        description: 'Persistent volume claim strategy for the Che server. The supported strategies are: `per-user` (all workspaces PVCs in one volume), `per-workspace` (each workspace is given its own individual PVC) and `ephemeral` (non-persistent storage where local changes will be lost when the workspace is stopped.)'
                         enum:
                         - common
                         - per-user
                         - per-workspace
+                        - ephemeral
                         type: string
                     type: object
                   tolerations:

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -4627,11 +4627,12 @@ spec:
                         type: object
                       pvcStrategy:
                         default: per-user
-                        description: 'Persistent volume claim strategy for the Che server. The supported strategies are: `per-user` (all workspaces PVCs in one volume) and ''per-workspace'' (each workspace is given its own individual PVC). For details, see https://github.com/eclipse/che/issues/21185.'
+                        description: 'Persistent volume claim strategy for the Che server. The supported strategies are: `per-user` (all workspaces PVCs in one volume), `per-workspace` (each workspace is given its own individual PVC) and `ephemeral` (non-persistent storage where local changes will be lost when the workspace is stopped.)'
                         enum:
                         - common
                         - per-user
                         - per-workspace
+                        - ephemeral
                         type: string
                     type: object
                   tolerations:

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -99,6 +99,7 @@ const (
 	PerUserPVCStorageStrategy      = "per-user"
 	DefaultPvcStorageStrategy      = "per-user"
 	PerWorkspacePVCStorageStrategy = "per-workspace"
+	EphemeralPVCStorageStrategy    = "ephemeral"
 	CommonPVCStorageStrategy       = "common"
 	DefaultAutoProvision           = true
 	DefaultWorkspaceJavaOpts       = "-XX:MaxRAM=150m -XX:MaxRAMFraction=2 -XX:+UseParallelGC " +

--- a/pkg/deploy/dev-workspace-config/dev_workspace_config.go
+++ b/pkg/deploy/dev-workspace-config/dev_workspace_config.go
@@ -90,10 +90,11 @@ func updateWorkspaceConfig(devEnvironments *chev2.CheClusterDevEnvironments, ope
 func updateWorkspaceStorageConfig(devEnvironments *chev2.CheClusterDevEnvironments, workspaceConfig *controllerv1alpha1.WorkspaceConfig) error {
 	pvcStrategy := utils.GetValue(devEnvironments.Storage.PvcStrategy, constants.DefaultPvcStorageStrategy)
 	isPerWorkspacePVCStorageStrategy := pvcStrategy == constants.PerWorkspacePVCStorageStrategy
-	pvc := map[bool]*chev2.PVC{
-		true:  devEnvironments.Storage.PerWorkspaceStrategyPvcConfig,
-		false: devEnvironments.Storage.PerUserStrategyPvcConfig,
-	}[isPerWorkspacePVCStorageStrategy]
+	pvc := map[string]*chev2.PVC{
+		constants.PerUserPVCStorageStrategy:      devEnvironments.Storage.PerUserStrategyPvcConfig,
+		constants.CommonPVCStorageStrategy:       devEnvironments.Storage.PerUserStrategyPvcConfig,
+		constants.PerWorkspacePVCStorageStrategy: devEnvironments.Storage.PerWorkspaceStrategyPvcConfig,
+	}[pvcStrategy]
 
 	if pvc != nil {
 		if pvc.StorageClass != "" {

--- a/pkg/deploy/dev-workspace-config/dev_workspace_config_test.go
+++ b/pkg/deploy/dev-workspace-config/dev_workspace_config_test.go
@@ -91,6 +91,31 @@ func TestReconcileDevWorkspaceConfigPerUserStorage(t *testing.T) {
 			expectedOperatorConfig: &controllerv1alpha1.OperatorConfiguration{Workspace: &controllerv1alpha1.WorkspaceConfig{}},
 		},
 		{
+			name: "Create DevWorkspaceOperatorConfig with ephemeral strategy",
+			cheCluster: &chev2.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "eclipse-che",
+					Name:      "eclipse-che",
+				},
+				Spec: chev2.CheClusterSpec{
+					DevEnvironments: chev2.CheClusterDevEnvironments{
+						Storage: chev2.WorkspaceStorage{
+							PvcStrategy: constants.EphemeralPVCStorageStrategy,
+							PerUserStrategyPvcConfig: &chev2.PVC{
+								StorageClass: "test-storage",
+								ClaimSize:    "10Gi",
+							},
+							PerWorkspaceStrategyPvcConfig: &chev2.PVC{
+								StorageClass: "test-storage",
+								ClaimSize:    "10Gi",
+							},
+						},
+					},
+				},
+			},
+			expectedOperatorConfig: &controllerv1alpha1.OperatorConfiguration{Workspace: &controllerv1alpha1.WorkspaceConfig{}},
+		},
+		{
 			name: "Create DevWorkspaceOperatorConfig with StorageClassName only",
 			cheCluster: &chev2.CheCluster{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
feat: Support ephemeral pvc strategy

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21885

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
1. `make gen-chectl-tmpl TEMPLATES=/tmp/operator-resources`
2. `chectl server:deploy -p <PLATFORM> --templates /tmp/operator-resources --che-operator-image=quay.io/abazko/operator:2188`
3. Update CheCluster CR to set `ephemeral` pvcStrategy
4. Start a workspace, devfile attributes:
```yaml
attributes:
  controller.devfile.io/devworkspace-config:
    name: devworkspace-config
    namespace: eclipse-che
  controller.devfile.io/storage-type: ephemeral
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
