### PR TITLE
fix(utils): whitelist should not cut off second-level domain

### DIFF
--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -229,7 +229,10 @@ func FormatLabels(m map[string]string) string {
 func Whitelist(hostname string) (value string) {
 	i := strings.Index(hostname, ".")
 	if i > -1 {
-		return hostname[i:]
+		j := strings.LastIndex(hostname, ".")
+		if j > i {
+			return hostname[i:]
+		}
 	}
 	return hostname
 }

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -74,6 +74,7 @@ func TestWhitelist(t *testing.T) {
 		{"abraCadabra-KvakaZybra", "abraCadabra-KvakaZybra"},
 		{".", "."},
 		{"", ""},
+		{"test.com", "test.com"},
 	}
 	for _, test := range tests {
 		if actual := Whitelist(test.host); !reflect.DeepEqual(test.whitelistedHost, actual) {


### PR DESCRIPTION
### What does this PR do?
Fixes `Whitelist` function to not cut off second-level domain

### What issues does this PR fix or reference?
I noticed the `impaktapps.com` was whitelisted as `.com` when I helped with https://github.com/eclipse/che/issues/21886. As a quick workaround I [proposed to use three-level domain](https://github.com/eclipse/che/issues/21886#issuecomment-1356767907). Now it's time to fix the root cause.
