### PR TITLE
fix: Display workspace idle page on k8s

### DIFF
--- a/controllers/devworkspace/solver/che_routing.go
+++ b/controllers/devworkspace/solver/che_routing.go
@@ -519,19 +519,17 @@ func add5XXErrorHandling(cfg *gateway.TraefikConfig, dwId string) {
 	dashboardServiceName := defaults.GetCheFlavor() + "-dashboard"
 	cfg.AddErrors(dwId, "500-599", dashboardServiceName, "/")
 
-	if infrastructure.IsOpenShift() {
-		// If a connection cannot be established with the workspace service within the `DialTimeout`, traefik
-		// will retry the connection with an exponential backoff
-		cfg.HTTP.ServersTransports = map[string]*gateway.TraefikConfigServersTransport{}
+	// If a connection cannot be established with the workspace service within the `DialTimeout`, traefik
+	// will retry the connection with an exponential backoff
+	cfg.HTTP.ServersTransports = map[string]*gateway.TraefikConfigServersTransport{}
 
-		cfg.HTTP.ServersTransports[dwId] = &gateway.TraefikConfigServersTransport{
-			ForwardingTimeouts: &gateway.TraefikConfigForwardingTimeouts{
-				DialTimeout: "2500ms",
-			},
-		}
-		cfg.AddRetry(dwId, 2, "500ms")
-		cfg.HTTP.Services[dwId].LoadBalancer.ServersTransport = dwId
+	cfg.HTTP.ServersTransports[dwId] = &gateway.TraefikConfigServersTransport{
+		ForwardingTimeouts: &gateway.TraefikConfigForwardingTimeouts{
+			DialTimeout: "2500ms",
+		},
 	}
+	cfg.AddRetry(dwId, 2, "500ms")
+	cfg.HTTP.Services[dwId].LoadBalancer.ServersTransport = dwId
 }
 
 // makes '/healthz' path of main endpoints reachable from the outside

--- a/controllers/devworkspace/solver/che_routing_test.go
+++ b/controllers/devworkspace/solver/che_routing_test.go
@@ -302,14 +302,15 @@ func TestCreateRelocatedObjectsK8S(t *testing.T) {
 
 		workspaceMainConfig := gateway.TraefikConfig{}
 		assert.NoError(t, yaml.Unmarshal([]byte(traefikMainWorkspaceConfig), &workspaceMainConfig))
-		assert.Len(t, workspaceMainConfig.HTTP.Middlewares, 4)
+		assert.Len(t, workspaceMainConfig.HTTP.Middlewares, 5)
 
 		wsid = "wsid"
 		mwares = []string{
 			wsid + gateway.AuthMiddlewareSuffix,
 			wsid + gateway.StripPrefixMiddlewareSuffix,
 			wsid + gateway.HeadersMiddlewareSuffix,
-			wsid + gateway.ErrorsMiddlewareSuffix}
+			wsid + gateway.ErrorsMiddlewareSuffix,
+			wsid + gateway.RetryMiddlewareSuffix}
 		for _, mware := range mwares {
 			assert.Contains(t, workspaceMainConfig.HTTP.Middlewares, mware)
 
@@ -322,12 +323,15 @@ func TestCreateRelocatedObjectsK8S(t *testing.T) {
 			assert.Truef(t, found, "traefik config route doesn't set middleware '%s'", mware)
 		}
 
-		t.Run("testServerTransportIsEmpty", func(t *testing.T) {
-			assert.Empty(t, workspaceMainConfig.HTTP.ServersTransports)
+		t.Run("testServerTransportInMainWorkspaceRoute", func(t *testing.T) {
+			serverTransportName := wsid
+
+			assert.Len(t, workspaceMainConfig.HTTP.ServersTransports, 1)
+			assert.Contains(t, workspaceMainConfig.HTTP.ServersTransports, serverTransportName)
 
 			assert.Len(t, workspaceMainConfig.HTTP.Services, 1)
 			assert.Contains(t, workspaceMainConfig.HTTP.Services, wsid)
-			assert.Empty(t, workspaceMainConfig.HTTP.Services[wsid].LoadBalancer.ServersTransport)
+			assert.Equal(t, workspaceMainConfig.HTTP.Services[wsid].LoadBalancer.ServersTransport, serverTransportName)
 		})
 
 		t.Run("testHealthzEndpointInMainWorkspaceRoute", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
fix: Display workspace idle page on k8s

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21882

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
See the description of the issue

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
