### PR TITLE
chore: set che-incubator/che-code/latest as a default editor

### DIFF
--- a/api/v1/checluster_types.go
+++ b/api/v1/checluster_types.go
@@ -368,7 +368,7 @@ type CheClusterSpecServer struct {
 	// The plugin ID must have `publisher/plugin/version`.
 	// The URI must start from `http`.
 	// +optional
-	// +kubebuilder:default:=che-incubator/che-code/insiders
+	// +kubebuilder:default:=che-incubator/che-code/latest
 	WorkspaceDefaultEditor string `json:"workspaceDefaultEditor,omitempty"`
 	// Default components applied to DevWorkspaces.
 	// These default components are meant to be used when a Devfile does not contain any components.

--- a/api/v2/checluster_types.go
+++ b/api/v2/checluster_types.go
@@ -37,7 +37,7 @@ type CheClusterSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Development environments"
-	// +kubebuilder:default:={disableContainerBuildCapabilities: true, defaultComponents: {{name: universal-developer-image, container: {image: "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}}, defaultEditor: che-incubator/che-code/insiders, storage: {pvcStrategy: per-user}, defaultNamespace: {template: <username>-che, autoProvision: true}, secondsOfInactivityBeforeIdling:1800, secondsOfRunBeforeIdling:-1, startTimeoutSeconds:300, maxNumberOfWorkspacesPerUser:-1}
+	// +kubebuilder:default:={disableContainerBuildCapabilities: true, defaultComponents: {{name: universal-developer-image, container: {image: "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}}, defaultEditor: che-incubator/che-code/latest, storage: {pvcStrategy: per-user}, defaultNamespace: {template: <username>-che, autoProvision: true}, secondsOfInactivityBeforeIdling:1800, secondsOfRunBeforeIdling:-1, startTimeoutSeconds:300, maxNumberOfWorkspacesPerUser:-1}
 	DevEnvironments CheClusterDevEnvironments `json:"devEnvironments"`
 	// Che components configuration.
 	// +optional
@@ -90,7 +90,7 @@ type CheClusterDevEnvironments struct {
 	// The plugin ID must have `publisher/plugin/version` format.
 	// The URI must start from `http://` or `https://`.
 	// +optional
-	// +kubebuilder:default:=che-incubator/che-code/insiders
+	// +kubebuilder:default:=che-incubator/che-code/latest
 	DefaultEditor string `json:"defaultEditor,omitempty"`
 	// Default components applied to DevWorkspaces.
 	// These default components are meant to be used when a Devfile, that does not contain any components.

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -77,7 +77,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che.v7.61.0-760.next
+  name: eclipse-che.v7.61.0-761.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1221,7 +1221,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Eclipse Foundation
-  version: 7.61.0-760.next
+  version: 7.61.0-761.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
@@ -3778,7 +3778,7 @@ spec:
                         type: object
                       type: array
                     workspaceDefaultEditor:
-                      default: che-incubator/che-code/insiders
+                      default: che-incubator/che-code/latest
                       description: The default editor to workspace create with. It
                         could be a plugin ID or a URI. The plugin ID must have `publisher/plugin/version`.
                         The URI must start from `http`.
@@ -5397,7 +5397,7 @@ spec:
                       - container:
                           image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
                         name: universal-developer-image
-                    defaultEditor: che-incubator/che-code/insiders
+                    defaultEditor: che-incubator/che-code/latest
                     defaultNamespace:
                       autoProvision: true
                       template: <username>-che
@@ -6925,7 +6925,7 @@ spec:
                         type: object
                       type: array
                     defaultEditor:
-                      default: che-incubator/che-code/insiders
+                      default: che-incubator/che-code/latest
                       description: The default editor to workspace create with. It
                         could be a plugin ID or a URI. The plugin ID must have `publisher/plugin/version`
                         format. The URI must start from `http://` or `https://`.

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -3664,7 +3664,7 @@ spec:
                       type: object
                     type: array
                   workspaceDefaultEditor:
-                    default: che-incubator/che-code/insiders
+                    default: che-incubator/che-code/latest
                     description: The default editor to workspace create with. It could
                       be a plugin ID or a URI. The plugin ID must have `publisher/plugin/version`.
                       The URI must start from `http`.
@@ -5258,7 +5258,7 @@ spec:
                   - container:
                       image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
                     name: universal-developer-image
-                  defaultEditor: che-incubator/che-code/insiders
+                  defaultEditor: che-incubator/che-code/latest
                   defaultNamespace:
                     autoProvision: true
                     template: <username>-che
@@ -6736,7 +6736,7 @@ spec:
                       type: object
                     type: array
                   defaultEditor:
-                    default: che-incubator/che-code/insiders
+                    default: che-incubator/che-code/latest
                     description: The default editor to workspace create with. It could
                       be a plugin ID or a URI. The plugin ID must have `publisher/plugin/version`
                       format. The URI must start from `http://` or `https://`.

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -3683,7 +3683,7 @@ spec:
                       type: object
                     type: array
                   workspaceDefaultEditor:
-                    default: che-incubator/che-code/insiders
+                    default: che-incubator/che-code/latest
                     description: The default editor to workspace create with. It could
                       be a plugin ID or a URI. The plugin ID must have `publisher/plugin/version`.
                       The URI must start from `http`.
@@ -5277,7 +5277,7 @@ spec:
                   - container:
                       image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
                     name: universal-developer-image
-                  defaultEditor: che-incubator/che-code/insiders
+                  defaultEditor: che-incubator/che-code/latest
                   defaultNamespace:
                     autoProvision: true
                     template: <username>-che
@@ -6755,7 +6755,7 @@ spec:
                       type: object
                     type: array
                   defaultEditor:
-                    default: che-incubator/che-code/insiders
+                    default: che-incubator/che-code/latest
                     description: The default editor to workspace create with. It could
                       be a plugin ID or a URI. The plugin ID must have `publisher/plugin/version`
                       format. The URI must start from `http://` or `https://`.

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -3678,7 +3678,7 @@ spec:
                       type: object
                     type: array
                   workspaceDefaultEditor:
-                    default: che-incubator/che-code/insiders
+                    default: che-incubator/che-code/latest
                     description: The default editor to workspace create with. It could
                       be a plugin ID or a URI. The plugin ID must have `publisher/plugin/version`.
                       The URI must start from `http`.
@@ -5272,7 +5272,7 @@ spec:
                   - container:
                       image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
                     name: universal-developer-image
-                  defaultEditor: che-incubator/che-code/insiders
+                  defaultEditor: che-incubator/che-code/latest
                   defaultNamespace:
                     autoProvision: true
                     template: <username>-che
@@ -6750,7 +6750,7 @@ spec:
                       type: object
                     type: array
                   defaultEditor:
-                    default: che-incubator/che-code/insiders
+                    default: che-incubator/che-code/latest
                     description: The default editor to workspace create with. It could
                       be a plugin ID or a URI. The plugin ID must have `publisher/plugin/version`
                       format. The URI must start from `http://` or `https://`.

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -3683,7 +3683,7 @@ spec:
                       type: object
                     type: array
                   workspaceDefaultEditor:
-                    default: che-incubator/che-code/insiders
+                    default: che-incubator/che-code/latest
                     description: The default editor to workspace create with. It could
                       be a plugin ID or a URI. The plugin ID must have `publisher/plugin/version`.
                       The URI must start from `http`.
@@ -5277,7 +5277,7 @@ spec:
                   - container:
                       image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
                     name: universal-developer-image
-                  defaultEditor: che-incubator/che-code/insiders
+                  defaultEditor: che-incubator/che-code/latest
                   defaultNamespace:
                     autoProvision: true
                     template: <username>-che
@@ -6755,7 +6755,7 @@ spec:
                       type: object
                     type: array
                   defaultEditor:
-                    default: che-incubator/che-code/insiders
+                    default: che-incubator/che-code/latest
                     description: The default editor to workspace create with. It could
                       be a plugin ID or a URI. The plugin ID must have `publisher/plugin/version`
                       format. The URI must start from `http://` or `https://`.

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -3678,7 +3678,7 @@ spec:
                       type: object
                     type: array
                   workspaceDefaultEditor:
-                    default: che-incubator/che-code/insiders
+                    default: che-incubator/che-code/latest
                     description: The default editor to workspace create with. It could
                       be a plugin ID or a URI. The plugin ID must have `publisher/plugin/version`.
                       The URI must start from `http`.
@@ -5272,7 +5272,7 @@ spec:
                   - container:
                       image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
                     name: universal-developer-image
-                  defaultEditor: che-incubator/che-code/insiders
+                  defaultEditor: che-incubator/che-code/latest
                   defaultNamespace:
                     autoProvision: true
                     template: <username>-che
@@ -6750,7 +6750,7 @@ spec:
                       type: object
                     type: array
                   defaultEditor:
-                    default: che-incubator/che-code/insiders
+                    default: che-incubator/che-code/latest
                     description: The default editor to workspace create with. It could
                       be a plugin ID or a URI. The plugin ID must have `publisher/plugin/version`
                       format. The URI must start from `http://` or `https://`.

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -3678,7 +3678,7 @@ spec:
                       type: object
                     type: array
                   workspaceDefaultEditor:
-                    default: che-incubator/che-code/insiders
+                    default: che-incubator/che-code/latest
                     description: The default editor to workspace create with. It could
                       be a plugin ID or a URI. The plugin ID must have `publisher/plugin/version`.
                       The URI must start from `http`.
@@ -5272,7 +5272,7 @@ spec:
                   - container:
                       image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
                     name: universal-developer-image
-                  defaultEditor: che-incubator/che-code/insiders
+                  defaultEditor: che-incubator/che-code/latest
                   defaultNamespace:
                     autoProvision: true
                     template: <username>-che
@@ -6750,7 +6750,7 @@ spec:
                       type: object
                     type: array
                   defaultEditor:
-                    default: che-incubator/che-code/insiders
+                    default: che-incubator/che-code/latest
                     description: The default editor to workspace create with. It could
                       be a plugin ID or a URI. The plugin ID must have `publisher/plugin/version`
                       format. The URI must start from `http://` or `https://`.


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Sets **che-incubator/che-code/latest** as a default editor

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-3568
https://issues.redhat.com/browse/CRW-3932

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

```bash
chectl server:deploy \
     --installer operator \
     --platform <PLATFORM_TO_DEPLOY> \
     --che-operator-image <CUSTOM_OPERATOR_IMAGE> 
```

Check the value of **defaultEditor** it should be **che-incubator/che-code/latest**
```
  devEnvironments:
      defaultEditor: che-incubator/che-code/latest
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
