### PR TITLE
chore: increase the number of failure threshold for embedded plugin registries

### DIFF
--- a/pkg/deploy/pluginregistry/pluginregistry_deployment.go
+++ b/pkg/deploy/pluginregistry/pluginregistry_deployment.go
@@ -58,6 +58,7 @@ func (p *PluginRegistryReconciler) getPluginRegistryDeploymentSpec(ctx *chetypes
 	if ctx.CheCluster.IsOpenVSXURLEmpty() {
 		// Add time to start embedded VSX registry
 		deployment.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds = 300
+		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.FailureThreshold = 90
 	}
 
 	deploy.EnsurePodSecurityStandards(deployment, constants.DefaultSecurityContextRunAsUser, constants.DefaultSecurityContextFsGroup)


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
In case when embedded plugin registry is initializing we have to wait for the pod to be ready a bit longer. To increase time when registry pod will be ready, the number of  FailureThreshold was increased from 10 to 90.

Max value for waiting when the pod is ready is calculated:
```
InitialDelaySeconds + TimeoutSeconds + PeriodSeconds * (FailureThreshold - 1) ---> 3 + 3 + 10*(90 - 1) --> 896 seconds
```

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-4047

### How to test?

Deploy che with the next command:

`chectl server:deploy -p openshift --che-operator-image=vsvydenko/che-operator:fix --che-operator-cr-patch-yaml=/tmp/patch.yaml`

patch.yaml
```yaml
kind: CheCluster
apiVersion: org.eclipse.che/v2
spec:
  components:
    pluginRegistry:
      openVSXURL: ""

```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
