### PR TITLE
Updated oc-test-happy-path.sh according to new test scripts in "Che" project

### DIFF
--- a/build/scripts/oc-tests/oc-test-happy-path.sh
+++ b/build/scripts/oc-tests/oc-test-happy-path.sh
@@ -23,7 +23,8 @@ trap "catchFinish" EXIT SIGINT
 runTests() {
   . ${OPERATOR_REPO}/build/scripts/olm/test-catalog-from-sources.sh --verbose
 
-  export HAPPY_PATH_SUITE=test-empty-workspace-devworkspace-happy-path-code
+  export HAPPY_PATH_USERSTORY=EmptyWorkspace && export HAPPY_PATH_SUITE=test-all-devfiles
+
   bash <(curl -s ${DEVWORKSPACE_HAPPY_PATH}/remote-launch.sh)
 }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
According to task  #[22043](https://github.com/eclipse/che/pull/22043) test scripts were updated, necessary changes added to this repository.
PR: [#22052](https://github.com/eclipse/che/pull/22052)

The old npm script "test-empty-workspace-devworkspace-happy-path-code" runs one test spec file - "EmptyWorkspace.spec.ts" from the test [directory](https://github.com/eclipse/che/tree/main/tests/e2e/tests/devfiles/che-code) and uses hard-coded mocha config.
It was replaced with "test-all-devfiles" which uses new dynamic mocha config and will run the same file if variable "USERSTORY=EmptyWorkspace" or all test specs in the test directory if variable not set. 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
Run happy-pass PR check.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
