### PR TITLE
chore:use UDI with ubi8-latest tag in the default component

### DIFF
--- a/api/v1/checluster_types.go
+++ b/api/v1/checluster_types.go
@@ -373,7 +373,7 @@ type CheClusterSpecServer struct {
 	// Default components applied to DevWorkspaces.
 	// These default components are meant to be used when a Devfile does not contain any components.
 	// +optional
-	// +kubebuilder:default:={{name: universal-developer-image, container: {image: "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}}
+	// +kubebuilder:default:={{name: universal-developer-image, container: {image: "quay.io/devfile/universal-developer-image:ubi8-latest"}}}
 	WorkspaceDefaultComponents []devfile.Component `json:"workspaceDefaultComponents,omitempty"`
 	// List of environment variables to set in the Che server container.
 	// +optional

--- a/api/v2/checluster_types.go
+++ b/api/v2/checluster_types.go
@@ -37,7 +37,7 @@ type CheClusterSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Development environments"
-	// +kubebuilder:default:={disableContainerBuildCapabilities: true, defaultComponents: {{name: universal-developer-image, container: {image: "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}}, defaultEditor: che-incubator/che-code/latest, storage: {pvcStrategy: per-user}, defaultNamespace: {template: <username>-che, autoProvision: true}, secondsOfInactivityBeforeIdling:1800, secondsOfRunBeforeIdling:-1, startTimeoutSeconds:300, maxNumberOfWorkspacesPerUser:-1}
+	// +kubebuilder:default:={disableContainerBuildCapabilities: true, defaultComponents: {{name: universal-developer-image, container: {image: "quay.io/devfile/universal-developer-image:ubi8-latest"}}}, defaultEditor: che-incubator/che-code/latest, storage: {pvcStrategy: per-user}, defaultNamespace: {template: <username>-che, autoProvision: true}, secondsOfInactivityBeforeIdling:1800, secondsOfRunBeforeIdling:-1, startTimeoutSeconds:300, maxNumberOfWorkspacesPerUser:-1}
 	DevEnvironments CheClusterDevEnvironments `json:"devEnvironments"`
 	// Che components configuration.
 	// +optional
@@ -95,7 +95,7 @@ type CheClusterDevEnvironments struct {
 	// Default components applied to DevWorkspaces.
 	// These default components are meant to be used when a Devfile, that does not contain any components.
 	// +optional
-	// +kubebuilder:default:={{name: universal-developer-image, container: {image: "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}}
+	// +kubebuilder:default:={{name: universal-developer-image, container: {image: "quay.io/devfile/universal-developer-image:ubi8-latest"}}}
 	DefaultComponents []devfile.Component `json:"defaultComponents,omitempty"`
 	// Idle timeout for workspaces in seconds.
 	// This timeout is the duration after which a workspace will be idled if there is no activity.

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -77,7 +77,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che.v7.62.0-766.next
+  name: eclipse-che.v7.63.0-767.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1233,7 +1233,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Eclipse Foundation
-  version: 7.62.0-766.next
+  version: 7.63.0-767.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
@@ -2275,7 +2275,7 @@ spec:
                     workspaceDefaultComponents:
                       default:
                         - container:
-                            image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                            image: quay.io/devfile/universal-developer-image:ubi8-latest
                           name: universal-developer-image
                       description: Default components applied to DevWorkspaces. These
                         default components are meant to be used when a Devfile does
@@ -5373,7 +5373,7 @@ spec:
                   default:
                     defaultComponents:
                       - container:
-                          image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                          image: quay.io/devfile/universal-developer-image:ubi8-latest
                         name: universal-developer-image
                     defaultEditor: che-incubator/che-code/latest
                     defaultNamespace:
@@ -5400,7 +5400,7 @@ spec:
                     defaultComponents:
                       default:
                         - container:
-                            image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                            image: quay.io/devfile/universal-developer-image:ubi8-latest
                           name: universal-developer-image
                       description: Default components applied to DevWorkspaces. These
                         default components are meant to be used when a Devfile, that

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -2211,7 +2211,7 @@ spec:
                   workspaceDefaultComponents:
                     default:
                     - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                        image: quay.io/devfile/universal-developer-image:ubi8-latest
                       name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile does
@@ -5234,7 +5234,7 @@ spec:
                 default:
                   defaultComponents:
                   - container:
-                      image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                      image: quay.io/devfile/universal-developer-image:ubi8-latest
                     name: universal-developer-image
                   defaultEditor: che-incubator/che-code/latest
                   defaultNamespace:
@@ -5261,7 +5261,7 @@ spec:
                   defaultComponents:
                     default:
                     - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                        image: quay.io/devfile/universal-developer-image:ubi8-latest
                       name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile, that

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -2230,7 +2230,7 @@ spec:
                   workspaceDefaultComponents:
                     default:
                     - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                        image: quay.io/devfile/universal-developer-image:ubi8-latest
                       name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile does
@@ -5253,7 +5253,7 @@ spec:
                 default:
                   defaultComponents:
                   - container:
-                      image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                      image: quay.io/devfile/universal-developer-image:ubi8-latest
                     name: universal-developer-image
                   defaultEditor: che-incubator/che-code/latest
                   defaultNamespace:
@@ -5280,7 +5280,7 @@ spec:
                   defaultComponents:
                     default:
                     - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                        image: quay.io/devfile/universal-developer-image:ubi8-latest
                       name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile, that

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -2225,7 +2225,7 @@ spec:
                   workspaceDefaultComponents:
                     default:
                     - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                        image: quay.io/devfile/universal-developer-image:ubi8-latest
                       name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile does
@@ -5248,7 +5248,7 @@ spec:
                 default:
                   defaultComponents:
                   - container:
-                      image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                      image: quay.io/devfile/universal-developer-image:ubi8-latest
                     name: universal-developer-image
                   defaultEditor: che-incubator/che-code/latest
                   defaultNamespace:
@@ -5275,7 +5275,7 @@ spec:
                   defaultComponents:
                     default:
                     - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                        image: quay.io/devfile/universal-developer-image:ubi8-latest
                       name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile, that

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -2230,7 +2230,7 @@ spec:
                   workspaceDefaultComponents:
                     default:
                     - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                        image: quay.io/devfile/universal-developer-image:ubi8-latest
                       name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile does
@@ -5253,7 +5253,7 @@ spec:
                 default:
                   defaultComponents:
                   - container:
-                      image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                      image: quay.io/devfile/universal-developer-image:ubi8-latest
                     name: universal-developer-image
                   defaultEditor: che-incubator/che-code/latest
                   defaultNamespace:
@@ -5280,7 +5280,7 @@ spec:
                   defaultComponents:
                     default:
                     - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                        image: quay.io/devfile/universal-developer-image:ubi8-latest
                       name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile, that

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -2225,7 +2225,7 @@ spec:
                   workspaceDefaultComponents:
                     default:
                     - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                        image: quay.io/devfile/universal-developer-image:ubi8-latest
                       name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile does
@@ -5248,7 +5248,7 @@ spec:
                 default:
                   defaultComponents:
                   - container:
-                      image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                      image: quay.io/devfile/universal-developer-image:ubi8-latest
                     name: universal-developer-image
                   defaultEditor: che-incubator/che-code/latest
                   defaultNamespace:
@@ -5275,7 +5275,7 @@ spec:
                   defaultComponents:
                     default:
                     - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                        image: quay.io/devfile/universal-developer-image:ubi8-latest
                       name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile, that

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -2225,7 +2225,7 @@ spec:
                   workspaceDefaultComponents:
                     default:
                     - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                        image: quay.io/devfile/universal-developer-image:ubi8-latest
                       name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile does
@@ -5248,7 +5248,7 @@ spec:
                 default:
                   defaultComponents:
                   - container:
-                      image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                      image: quay.io/devfile/universal-developer-image:ubi8-latest
                     name: universal-developer-image
                   defaultEditor: che-incubator/che-code/latest
                   defaultNamespace:
@@ -5275,7 +5275,7 @@ spec:
                   defaultComponents:
                     default:
                     - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                        image: quay.io/devfile/universal-developer-image:ubi8-latest
                       name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile, that


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Updates **workspaceDefaultComponents** to use `quay.io/devfile/universal-developer-image:ubi8-latest` image

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![screenshot-127 0 0 1_35409-2023 03 22-14_25_12](https://user-images.githubusercontent.com/1271546/226905458-ab06a0e6-f467-4257-af85-47591026a6fb.png)

![screenshot-192 168 59 101 nip io-2023 03 22-14_32_39](https://user-images.githubusercontent.com/1271546/226905933-8ad404d8-5705-4885-8374-4f7605a53637.png)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21979

### How to test this PR?
- go into the branch with current changes
- `make gen-chectl-tmpl TEMPLATES=`/tmp/templates/`
- `chectl server:deploy -p minikube --che-operator-image=vsvydenko/che-operator:udi-latest --templates=/tmp/templates/`
- check che-cluster CRD it should contain
```
    workspaceDefaultComponents:
      - container:
          image: quay.io/devfile/universal-developer-image:ubi8-latest
          sourceMapping: /projects
        name: universal-developer-image
```


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
