### PR TITLE
chore:use UDI with ubi8-latest tag in the default component

### DIFF
--- a/api/v1/checluster_types.go
+++ b/api/v1/checluster_types.go
@@ -373,7 +373,6 @@ type CheClusterSpecServer struct {
 	// Default components applied to DevWorkspaces.
 	// These default components are meant to be used when a Devfile does not contain any components.
 	// +optional
-	// +kubebuilder:default:={{name: universal-developer-image, container: {image: "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}}
 	WorkspaceDefaultComponents []devfile.Component `json:"workspaceDefaultComponents,omitempty"`
 	// List of environment variables to set in the Che server container.
 	// +optional

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -77,7 +77,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che.v7.64.0-778.next
+  name: eclipse-che.v7.64.0-780.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -959,7 +959,7 @@ spec:
                         value: che-incubator/che-code/latest
                       - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS
                         value: '[{"name": "universal-developer-image", "container":
-                          {"image": "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}]'
+                          {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]'
                       - name: CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL
                         value: https://open-vsx.org
                       - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DISABLECONTAINERBUILDCAPABILITIES
@@ -1243,7 +1243,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Eclipse Foundation
-  version: 7.64.0-778.next
+  version: 7.64.0-780.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
@@ -2273,10 +2273,6 @@ spec:
                       description: Deprecated in favor of `disableInternalClusterSVCNames`.
                       type: boolean
                     workspaceDefaultComponents:
-                      default:
-                        - container:
-                            image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
-                          name: universal-developer-image
                       description: Default components applied to DevWorkspaces. These
                         default components are meant to be used when a Devfile does
                         not contain any components.

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -2209,10 +2209,6 @@ spec:
                     description: Deprecated in favor of `disableInternalClusterSVCNames`.
                     type: boolean
                   workspaceDefaultComponents:
-                    default:
-                    - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
-                      name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile does
                       not contain any components.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -102,7 +102,7 @@ spec:
             - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR
               value: che-incubator/che-code/latest
             - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS
-              value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}]'
+              value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]'
             - name: CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL
               value: https://open-vsx.org
             - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DISABLECONTAINERBUILDCAPABILITIES

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -2228,10 +2228,6 @@ spec:
                     description: Deprecated in favor of `disableInternalClusterSVCNames`.
                     type: boolean
                   workspaceDefaultComponents:
-                    default:
-                    - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
-                      name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile does
                       not contain any components.
@@ -8173,7 +8169,7 @@ spec:
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR
           value: che-incubator/che-code/latest
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS
-          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}]'
+          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]'
         - name: CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL
           value: https://open-vsx.org
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DISABLECONTAINERBUILDCAPABILITIES

--- a/deploy/deployment/kubernetes/objects/che-operator.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/che-operator.Deployment.yaml
@@ -96,7 +96,7 @@ spec:
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR
           value: che-incubator/che-code/latest
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS
-          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}]'
+          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]'
         - name: CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL
           value: https://open-vsx.org
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DISABLECONTAINERBUILDCAPABILITIES

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -2223,10 +2223,6 @@ spec:
                     description: Deprecated in favor of `disableInternalClusterSVCNames`.
                     type: boolean
                   workspaceDefaultComponents:
-                    default:
-                    - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
-                      name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile does
                       not contain any components.

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -2228,10 +2228,6 @@ spec:
                     description: Deprecated in favor of `disableInternalClusterSVCNames`.
                     type: boolean
                   workspaceDefaultComponents:
-                    default:
-                    - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
-                      name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile does
                       not contain any components.
@@ -8175,7 +8171,7 @@ spec:
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR
           value: che-incubator/che-code/latest
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS
-          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}]'
+          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]'
         - name: CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL
           value: https://open-vsx.org
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DISABLECONTAINERBUILDCAPABILITIES

--- a/deploy/deployment/openshift/objects/che-operator.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/che-operator.Deployment.yaml
@@ -96,7 +96,7 @@ spec:
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR
           value: che-incubator/che-code/latest
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS
-          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}]'
+          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]'
         - name: CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL
           value: https://open-vsx.org
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DISABLECONTAINERBUILDCAPABILITIES

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -2223,10 +2223,6 @@ spec:
                     description: Deprecated in favor of `disableInternalClusterSVCNames`.
                     type: boolean
                   workspaceDefaultComponents:
-                    default:
-                    - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
-                      name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile does
                       not contain any components.

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -2223,10 +2223,6 @@ spec:
                     description: Deprecated in favor of `disableInternalClusterSVCNames`.
                     type: boolean
                   workspaceDefaultComponents:
-                    default:
-                    - container:
-                        image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
-                      name: universal-developer-image
                     description: Default components applied to DevWorkspaces. These
                       default components are meant to be used when a Devfile does
                       not contain any components.

--- a/helmcharts/next/templates/che-operator.Deployment.yaml
+++ b/helmcharts/next/templates/che-operator.Deployment.yaml
@@ -96,7 +96,7 @@ spec:
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR
           value: che-incubator/che-code/latest
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS
-          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}]'
+          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]'
         - name: CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL
           value: https://open-vsx.org
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DISABLECONTAINERBUILDCAPABILITIES

--- a/pkg/deploy/dashboard/dashboard_deployment_test.go
+++ b/pkg/deploy/dashboard/dashboard_deployment_test.go
@@ -183,7 +183,7 @@ func TestDashboardDeploymentEnvVars(t *testing.T) {
 				},
 				{
 					Name:  "CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS",
-					Value: `[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}]`,
+					Value: `[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]`,
 				},
 				{
 					Name:  "CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL",
@@ -255,7 +255,7 @@ func TestDashboardDeploymentEnvVars(t *testing.T) {
 				},
 				{
 					Name:  "CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS",
-					Value: `[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-38da5c2"}}]`,
+					Value: `[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]`,
 				},
 				{
 					Name:  "CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL",


### PR DESCRIPTION
Replaces UDI:ubi8-38da5c2 with UDI:ubi8-latest to have latest changes form the universal developer image (UDI) in the default componen.

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Updates **workspaceDefaultComponents** to use `quay.io/devfile/universal-developer-image:ubi8-latest` image

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![screenshot-nimbusweb me-2023 03 29-12_15_44](https://user-images.githubusercontent.com/1271546/228488635-90d3b93f-feea-4b9f-93f3-b2f0cab1d7f6.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21979

### How to test this PR?
- go into the branch with current changes
- `make gen-chectl-tmpl TEMPLATES=`/tmp/templates/`
- `chectl server:deploy -p minikube --che-operator-image=vsvydenko/che-operator:udi-latest --templates=/tmp/templates/`
- open dashboard and start empty workspace, it should contain default component with quay.io/devfile/universal-developer-image:ubi8-latest image (as shown in the screenshot)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
