### PR TITLE
feat: when accessing workspace, redirect to dashboard on 404 response

### DIFF
--- a/pkg/deploy/gateway/traefik_config_util_test.go
+++ b/pkg/deploy/gateway/traefik_config_util_test.go
@@ -93,7 +93,7 @@ func TestAddOpenShiftTokenCheck(t *testing.T) {
 }
 
 func TestAddErrors(t *testing.T) {
-	status := "500-599"
+	status := "404,500-599"
 	service := "service"
 	query := "/"
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Helps alleviate (ie. not completely fix):
 * https://github.com/eclipse/che/issues/22163 from the che-operator/che-dashboard side.
 * https://issues.redhat.com/browse/CRW-3864

If when accessing a workspace url (ie, https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/workspace6b4fae98f3bc4d9e/tools/3100), if a 404 response is detected, this PR redirects the user to the dashboard.

In this case, the dashboard can redirect the user back to the workspace url if the workspace is running

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

From the dashboard, when redirecting back to the workspace url sometimes the dashboard UI will be visible for about a second, like in demo 1 (at the 24 second mark):

<details>
<summary>Demo 1</summary>

https://user-images.githubusercontent.com/83611742/234124850-cbdce33f-58f4-4c47-80e1-7952c4bec3ab.mov

</details>

In other times, the dashboard UI will not be displayed like in demo 2:

<details>
<summary>Demo 2</summary>

https://user-images.githubusercontent.com/83611742/234124923-347c5b8b-19cf-4eba-8175-973f9486fe0e.mov

</details>

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

```bash
chectl server:deploy \
     --platform openshift \
     --che-operator-image quay.io/dkwon17/che-operator:404 \
```

1. Start a workspace, wait until the editor opens
2. From the workspace url, add a random path at the end of the url in order to cause a 404 error, and press `Enter`
3. You should be redirected to the dashboard

The issue with the 404 error being displayed on workspace startup is reproducible quite often on the cluster bot cluster.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
