### PR TITLE
[fix] Remove project clone config from DevWorkspace when unset

### DIFF
--- a/pkg/deploy/dev-workspace-config/dev_workspace_config.go
+++ b/pkg/deploy/dev-workspace-config/dev_workspace_config.go
@@ -166,6 +166,7 @@ func updateWorkspacePodSchedulerNameConfig(devEnvironments *chev2.CheClusterDevE
 
 func updateProjectCloneConfig(devEnvironments *chev2.CheClusterDevEnvironments, workspaceConfig *controllerv1alpha1.WorkspaceConfig) {
 	if devEnvironments.ProjectCloneContainer == nil {
+		workspaceConfig.ProjectCloneConfig = nil
 		return
 	}
 	if workspaceConfig.ProjectCloneConfig == nil {


### PR DESCRIPTION
### What does this PR do?
Removing the last field from a CheCluster's `devEnvironments.projectCloneContainer` results in the change not being propagated to the DevWorkspaceOperatorConfig.

Instead, if the CheCluster's field is unset, the DevWorkspaceOperatorConfig's corresponding field should also be unset.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
Closes https://github.com/eclipse/che/issues/22265

### How to test this PR?
1. Modify CheCluster to have 
    ```yaml
    spec:
      devEnvironments:
        projectCloneContainer:
          image: bad-image:does-not-exist
    ```
2. Verify that DevWorkspace Operator Config (`oc get dwoc devworkspace-config -n eclipse-che`) has the bad image above configured
3. Remove `.spec.devEnvironments.projectCloneContainer` field from CheCluster
4. Check that `devworkspace-config` DWOC still has image field configured

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
