### PR TITLE
Fix subdomain for public endpoint urls

### DIFF
--- a/controllers/devworkspace/solver/che_routing_test.go
+++ b/controllers/devworkspace/solver/che_routing_test.go
@@ -995,14 +995,14 @@ func TestCreateSubDomainObjects(t *testing.T) {
 		if len(objs.Ingresses) != 3 {
 			t.Error("Expected 3 ingress, found ", len(objs.Ingresses))
 		}
-		if objs.Ingresses[0].Spec.Rules[0].Host != "username.my-workspace.e1.down.on.earth" {
-			t.Error("Expected Ingress host 'username.my-workspace.e1.down.on.earth', but got ", objs.Ingresses[0].Spec.Rules[0].Host)
+		if objs.Ingresses[0].Spec.Rules[0].Host != "username-my-workspace-e1.down.on.earth" {
+			t.Error("Expected Ingress host 'username-my-workspace-e1.down.on.earth', but got ", objs.Ingresses[0].Spec.Rules[0].Host)
 		}
-		if objs.Ingresses[1].Spec.Rules[0].Host != "username.my-workspace.e2.down.on.earth" {
-			t.Error("Expected Ingress host 'username.my-workspace.e2.down.on.earth', but got ", objs.Ingresses[1].Spec.Rules[0].Host)
+		if objs.Ingresses[1].Spec.Rules[0].Host != "username-my-workspace-e2.down.on.earth" {
+			t.Error("Expected Ingress host 'username-my-workspace-e2.down.on.earth', but got ", objs.Ingresses[1].Spec.Rules[0].Host)
 		}
-		if objs.Ingresses[2].Spec.Rules[0].Host != "username.my-workspace.e3.down.on.earth" {
-			t.Error("Expected Ingress host 'username.my-workspace.e3.down.on.earth', but got ", objs.Ingresses[2].Spec.Rules[0].Host)
+		if objs.Ingresses[2].Spec.Rules[0].Host != "username-my-workspace-e3.down.on.earth" {
+			t.Error("Expected Ingress host 'username-my-workspace-e3.down.on.earth', but got ", objs.Ingresses[2].Spec.Rules[0].Host)
 		}
 	})
 
@@ -1011,8 +1011,8 @@ func TestCreateSubDomainObjects(t *testing.T) {
 		if len(objs.Routes) != 3 {
 			t.Error("Expected 3 Routes, found ", len(objs.Routes))
 		}
-		if objs.Routes[0].Spec.Host != "username.my-workspace.e1.down.on.earth" {
-			t.Error("Expected Route host 'username.my-workspace.e1.down.on.earth', but got ", objs.Routes[0].Spec.Host)
+		if objs.Routes[0].Spec.Host != "username-my-workspace-e1.down.on.earth" {
+			t.Error("Expected Route host 'username-my-workspace-e1.down.on.earth', but got ", objs.Routes[0].Spec.Host)
 		}
 	})
 }
@@ -1335,7 +1335,7 @@ func TestExposeEndpoints(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, 1, len(spnr))
 	assert.Equal(t, "server-pub-nr", spnr[0].Name)
-	assert.Equal(t, "http://username.my-workspace.server-pub-nr.down.on.earth/", spnr[0].Url)
+	assert.Equal(t, "http://username-my-workspace-server-pub-nr.down.on.earth/", spnr[0].Url)
 }
 
 func TestExposeEndpointsLegacy(t *testing.T) {
@@ -1499,24 +1499,24 @@ func TestReportSubdomainExposedEndpoints(t *testing.T) {
 	if e1.Name != "e1" {
 		t.Errorf("The first endpoint should have been e1 but is %s", e1.Name)
 	}
-	if e1.Url != "https://username.my-workspace.e1.down.on.earth/1/" {
-		t.Errorf("The e1 endpoint should have the following URL: '%s' but has '%s'.", "https://username.my-workspace.e1.down.on.earth/1/", e1.Url)
+	if e1.Url != "https://username-my-workspace-e1.down.on.earth/1/" {
+		t.Errorf("The e1 endpoint should have the following URL: '%s' but has '%s'.", "https://username-my-workspace-e1.down.on.earth/1/", e1.Url)
 	}
 
 	e2 := m1[1]
 	if e2.Name != "e2" {
 		t.Errorf("The second endpoint should have been e2 but is %s", e1.Name)
 	}
-	if e2.Url != "https://username.my-workspace.e2.down.on.earth/2.js" {
-		t.Errorf("The e2 endpoint should have the following URL: '%s' but has '%s'.", "https://username.my-workspace.e2.down.on.earth/2.js", e2.Url)
+	if e2.Url != "https://username-my-workspace-e2.down.on.earth/2.js" {
+		t.Errorf("The e2 endpoint should have the following URL: '%s' but has '%s'.", "https://username-my-workspace-e2.down.on.earth/2.js", e2.Url)
 	}
 
 	e3 := m1[2]
 	if e3.Name != "e3" {
 		t.Errorf("The third endpoint should have been e3 but is %s", e1.Name)
 	}
-	if e3.Url != "http://username.my-workspace.e3.down.on.earth/" {
-		t.Errorf("The e3 endpoint should have the following URL: '%s' but has '%s'.", "http://username.my-workspace.e3.down.on.earth/", e3.Url)
+	if e3.Url != "http://username-my-workspace-e3.down.on.earth/" {
+		t.Errorf("The e3 endpoint should have the following URL: '%s' but has '%s'.", "http://username-my-workspace-e3.down.on.earth/", e3.Url)
 	}
 }
 
@@ -1712,7 +1712,7 @@ func TestUsesCustomCertificateForWorkspaceEndpointIngresses(t *testing.T) {
 		t.Fatalf("Unexpected number of host records on the TLS spec: %d", len(ingress.Spec.TLS[0].Hosts))
 	}
 
-	if ingress.Spec.TLS[0].Hosts[0] != "username.my-workspace.e1.almost.trivial" {
+	if ingress.Spec.TLS[0].Hosts[0] != "username-my-workspace-e1.almost.trivial" {
 		t.Errorf("Unexpected host name of the TLS spec: %s", ingress.Spec.TLS[0].Hosts[0])
 	}
 
@@ -1730,7 +1730,7 @@ func TestUsesCustomCertificateForWorkspaceEndpointIngresses(t *testing.T) {
 		t.Fatalf("Unexpected number of host records on the TLS spec: %d", len(ingress.Spec.TLS[0].Hosts))
 	}
 
-	if ingress.Spec.TLS[0].Hosts[0] != "username.my-workspace.e2.almost.trivial" {
+	if ingress.Spec.TLS[0].Hosts[0] != "username-my-workspace-e2.almost.trivial" {
 		t.Errorf("Unexpected host name of the TLS spec: %s", ingress.Spec.TLS[0].Hosts[0])
 	}
 

--- a/controllers/devworkspace/solver/endpoint_strategy.go
+++ b/controllers/devworkspace/solver/endpoint_strategy.go
@@ -35,7 +35,7 @@ type EndpointStrategy interface {
 // <CHE_DOMAIN>/<USERNAME>/<WORKSPACE_NAME>/<PORT>/
 
 // Public endpoints defined in the devfile are exposed on the following path via route or ingress:
-// <USERNAME>.<WORKSPACE_NAME>.<ENDPOINT_NAME>.<CLUSTER_INGRESS_DOMAIN>/<ENDPOINT_PATH>
+// <USERNAME>-<WORKSPACE_NAME>-<ENDPOINT_NAME>.<CLUSTER_INGRESS_DOMAIN>/<ENDPOINT_PATH>
 type UsernameWkspName struct {
 	username      string
 	workspaceName string
@@ -68,7 +68,7 @@ func (u UsernameWkspName) getEndpointPathPrefix(endpointPath string) string {
 }
 
 func (u UsernameWkspName) getHostname(endpointInfo *EndpointInfo, baseDomain string) string {
-	return fmt.Sprintf("%s.%s.%s.%s", u.username, u.workspaceName, endpointInfo.endpointName, baseDomain)
+	return fmt.Sprintf("%s-%s-%s.%s", u.username, u.workspaceName, endpointInfo.endpointName, baseDomain)
 }
 
 // Main workspace URL is exposed on the following path:


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Fixes the hostname for public endpoints urls so that the `username`, `workspace name`, and `endpoint name` are part of the subdomain.

Before this PR:
```
http://<username>.<workspace name>.<endpoint name>.apps.che-dev.x6e0.p1.openshiftapps.com/food
```

After this PR:
```
http://<username>-<workspace name>-<endpoint name>.apps.che-dev.x6e0.p1.openshiftapps.com/food
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Related to: https://github.com/eclipse/che/issues/22267

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
1. Deploy:
```
chectl server:deploy \
     --platform openshift \
     --che-operator-image quay.io/dkwon17/che-operator:friendlypathupdate
```

2. Create and start a workspace with this project: https://github.com/che-incubator/quarkus-api-example
3. Confirm that there is an OpenShift route named `{DW-ID}-tools-8080-list-all-food`, where the `spec.host` is `{USERNAME}-{DW-NAME}-list-all-food.{INGRESS-DOMAIN}`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
