### PR TITLE
fix: higher routing path match priority for longer pathnames

### DIFF
--- a/controllers/devworkspace/solver/che_routing.go
+++ b/controllers/devworkspace/solver/che_routing.go
@@ -569,13 +569,15 @@ func containPort(service *corev1.Service, port int32) bool {
 func provisionMainWorkspaceRoute(cheCluster *chev2.CheCluster, routing *dwo.DevWorkspaceRouting, cmLabels map[string]string, endpointStrategy EndpointStrategy) (*corev1.ConfigMap, error) {
 	dwId := routing.Spec.DevWorkspaceId
 	dwNamespace := routing.Namespace
+	pathPrefix := endpointStrategy.getMainWorkspacePathPrefix()
+	priority := 100 + len(pathPrefix)
 
 	cfg := gateway.CreateCommonTraefikConfig(
 		dwId,
-		fmt.Sprintf("PathPrefix(`%s`)", endpointStrategy.getMainWorkspacePathPrefix()),
-		100,
+		fmt.Sprintf("PathPrefix(`%s`)", pathPrefix),
+		priority,
 		getServiceURL(wsGatewayPort, dwId, dwNamespace),
-		[]string{endpointStrategy.getMainWorkspacePathPrefix()})
+		[]string{pathPrefix})
 
 	if cheCluster.IsAccessTokenConfigured() {
 		cfg.AddAuthHeaderRewrite(dwId)
@@ -587,7 +589,7 @@ func provisionMainWorkspaceRoute(cheCluster *chev2.CheCluster, routing *dwo.DevW
 	add5XXErrorHandling(cfg, dwId)
 
 	// make '/healthz' path of main endpoints reachable from outside
-	routeForHealthzEndpoint(cfg, dwId, routing.Spec.Endpoints, endpointStrategy)
+	routeForHealthzEndpoint(cfg, dwId, routing.Spec.Endpoints, priority+1, endpointStrategy)
 
 	if contents, err := yaml.Marshal(cfg); err != nil {
 		return nil, err
@@ -633,7 +635,7 @@ func add5XXErrorHandling(cfg *gateway.TraefikConfig, dwId string) {
 }
 
 // makes '/healthz' path of main endpoints reachable from the outside
-func routeForHealthzEndpoint(cfg *gateway.TraefikConfig, dwId string, endpoints map[string]dwo.EndpointList, endpointStrategy EndpointStrategy) {
+func routeForHealthzEndpoint(cfg *gateway.TraefikConfig, dwId string, endpoints map[string]dwo.EndpointList, priority int, endpointStrategy EndpointStrategy) {
 	for componentName, endpoints := range endpoints {
 		for _, e := range endpoints {
 			if e.Attributes.GetString(string(dwo.TypeEndpointAttribute), nil) == string(dwo.MainEndpointType) {
@@ -647,7 +649,7 @@ func routeForHealthzEndpoint(cfg *gateway.TraefikConfig, dwId string, endpoints 
 					Rule:        fmt.Sprintf("Path(`%s/healthz`)", endpointStrategy.getEndpointPathPrefix(endpointPath)),
 					Service:     dwId,
 					Middlewares: middlewares,
-					Priority:    101,
+					Priority:    priority,
 				}
 			}
 		}
@@ -657,6 +659,7 @@ func routeForHealthzEndpoint(cfg *gateway.TraefikConfig, dwId string, endpoints 
 func addEndpointToTraefikConfig(componentName string, e dwo.Endpoint, cfg *gateway.TraefikConfig, cheCluster *chev2.CheCluster, routing *dwo.DevWorkspaceRouting, endpointStrategy EndpointStrategy) {
 	routeName, prefix := endpointStrategy.getEndpointPath(&e, componentName)
 	rulePrefix := fmt.Sprintf("PathPrefix(`%s`)", prefix)
+	priority := 100 + len(prefix)
 
 	// skip if exact same route is already exposed
 	for _, r := range cfg.HTTP.Routers {
@@ -669,7 +672,7 @@ func addEndpointToTraefikConfig(componentName string, e dwo.Endpoint, cfg *gatew
 	cfg.AddComponent(
 		name,
 		rulePrefix,
-		100,
+		priority,
 		fmt.Sprintf("http://127.0.0.1:%d", e.TargetPort),
 		[]string{prefix})
 	cfg.AddAuth(name, fmt.Sprintf("http://%s.%s:8089?namespace=%s", gateway.GatewayServiceName, cheCluster.Namespace, routing.Namespace))
@@ -681,7 +684,7 @@ func addEndpointToTraefikConfig(componentName string, e dwo.Endpoint, cfg *gatew
 		cfg.AddComponent(
 			healthzName,
 			fmt.Sprintf("Path(`%s`)", healthzPath),
-			101,
+			priority+1,
 			fmt.Sprintf("http://127.0.0.1:%d", e.TargetPort),
 			[]string{prefix})
 	}

--- a/controllers/devworkspace/solver/che_routing_test.go
+++ b/controllers/devworkspace/solver/che_routing_test.go
@@ -518,6 +518,7 @@ func TestCreateRelocatedObjectsK8SLegacy(t *testing.T) {
 			assert.Contains(t, workspaceMainConfig.HTTP.Routers, wsid)
 			assert.Equal(t, workspaceMainConfig.HTTP.Routers[wsid].Service, wsid)
 			assert.Equal(t, workspaceMainConfig.HTTP.Routers[wsid].Rule, fmt.Sprintf("PathPrefix(`/%s`)", wsid))
+			assert.Equal(t, workspaceMainConfig.HTTP.Routers[wsid].Priority, 100+len("/"+wsid))
 		})
 
 		t.Run("testServerTransportInMainWorkspaceRoute", func(t *testing.T) {
@@ -536,6 +537,7 @@ func TestCreateRelocatedObjectsK8SLegacy(t *testing.T) {
 			assert.Contains(t, workspaceMainConfig.HTTP.Routers, healthzName)
 			assert.Equal(t, workspaceMainConfig.HTTP.Routers[healthzName].Service, wsid)
 			assert.Equal(t, workspaceMainConfig.HTTP.Routers[healthzName].Rule, "Path(`/wsid/m1/9999/healthz`)")
+			assert.Equal(t, workspaceMainConfig.HTTP.Routers[healthzName].Priority, 101+len("/"+wsid))
 			assert.NotContains(t, workspaceMainConfig.HTTP.Routers[healthzName].Middlewares, "wsid"+gateway.AuthMiddlewareSuffix)
 			assert.Contains(t, workspaceMainConfig.HTTP.Routers[healthzName].Middlewares, "wsid"+gateway.StripPrefixMiddlewareSuffix)
 			assert.NotContains(t, workspaceMainConfig.HTTP.Routers[healthzName].Middlewares, "wsid"+gateway.HeaderRewriteMiddlewareSuffix)
@@ -546,6 +548,7 @@ func TestCreateRelocatedObjectsK8SLegacy(t *testing.T) {
 			assert.Contains(t, workspaceConfig.HTTP.Routers, healthzName)
 			assert.Equal(t, workspaceConfig.HTTP.Routers[healthzName].Service, healthzName)
 			assert.Equal(t, workspaceConfig.HTTP.Routers[healthzName].Rule, "Path(`/m1/9999/healthz`)")
+			assert.Equal(t, workspaceConfig.HTTP.Routers[healthzName].Priority, 101+len("/m1/9999"))
 			assert.NotContains(t, workspaceConfig.HTTP.Routers[healthzName].Middlewares, healthzName+gateway.AuthMiddlewareSuffix)
 			assert.Contains(t, workspaceConfig.HTTP.Routers[healthzName].Middlewares, healthzName+gateway.StripPrefixMiddlewareSuffix)
 		})


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Updates priorities according to the PathPrefix length to the routing pathprefix rule for the traefik config.

Before & after example in the Che traefik config for the workspace:
```diff
      routers:
        workspace0d368dea85dc49aa:
          middlewares:
          - workspace0d368dea85dc49aa-strip-prefix
          - workspace0d368dea85dc49aa-header-rewrite
          - workspace0d368dea85dc49aa-auth
          - workspace0d368dea85dc49aa-headers
          - workspace0d368dea85dc49aa-errors
          - workspace0d368dea85dc49aa-retry
-         priority: 100
+         priority: 133
          rule: PathPrefix(`/cluster-admin/python-hello-world`)
          service: workspace0d368dea85dc49aa
        workspace0d368dea85dc49aa-3100-healthz:
          middlewares:
          - workspace0d368dea85dc49aa-strip-prefix
          - workspace0d368dea85dc49aa-header-rewrite
-         priority: 101
+         priority: 134
          rule: Path(`/cluster-admin/python-hello-world/3100/healthz`)
          service: workspace0d368dea85dc49aa
```

Image: quay.io/dkwon17/che-operator:routing-priority

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Fixes https://github.com/eclipse/che/issues/22288

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

To test on OpenShift,
1. Install che `next` version `chectl server:deploy -p openshift`
2. After installation start a Python sample workspace
3. After the workspace starts, stop the workspace
4. Create a new Python sample workspace 
5. When the dashboard displays the following message, press `Create a new workspace`
![image](https://github.com/eclipse-che/che-operator/assets/83611742/658e2049-cdc3-41bf-9e34-983be5d95612)
6. Repeat steps 3-5 until you can reproduce https://github.com/eclipse/che/issues/22288
7. Stop all workspaces
8. Update che-operator image to `quay.io/dkwon17/che-operator:routing-priority` by editing the Che CSV
```
$ oc get csv

NAME                                   DISPLAY                 VERSION                 REPLACES   PHASE
devworkspace-operator.v0.22.0-dev.17   DevWorkspace Operator   0.22.0-dev.17+05519ae              Succeeded
eclipse-che.v7.68.0-798.next           Eclipse Che             7.68.0-798.next                    Succeeded

$ CSV=eclipse-che.v7.68.0-798.next 
$ oc patch ClusterServiceVersion $CSV -n openshift-operators --type='json' -p='[{"op": "replace", "path": "/metadata/annotations/containerImage", "value":"quay.io/dkwon17/che-operator:routing-priority"},{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/image", "value":"quay.io/dkwon17/che-operator:routing-priority"}]'
```
9. Confirm that https://github.com/eclipse/che/issues/22288 cannot be reproduced

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
