### PR TITLE
chore: disable mattermost notification as it...

### DIFF
--- a/.github/workflows/release-community-operator-PRs.yml
+++ b/.github/workflows/release-community-operator-PRs.yml
@@ -60,17 +60,17 @@ jobs:
           export QUAY_USERNAME_OS=${{ secrets.QUAY_ECLIPSE_CHE_OPERATOR_OPENSHIFT_USERNAME }}
           export QUAY_PASSWORD_OS=${{ secrets.QUAY_ECLIPSE_CHE_OPERATOR_OPENSHIFT_PASSWORD }}
           build/scripts/release/make-release.sh --prepare-community-operators-update ${{ github.event.inputs.forceflag }}
-      - name: Create failure MM message
-        if: ${{ failure() }}
-        run: |
-          echo "{\"text\":\":no_entry_sign: Che Community Operator ${{ github.event.inputs.version }} release has failed: https://github.com/eclipse-che/che-operator/actions/workflows/release-community-operator-PRs.yml\"}" > mattermost.json
-      - name: Create success MM message
-        run: |
-          echo "{\"text\":\":white_check_mark: Che Community Operator ${{ github.event.inputs.version }} release PR has been created: https://github.com/redhat-openshift-ecosystem/community-operators-prod/pulls?q=is%3Apr+is%3Aopen+eclipse-che\"}" > mattermost.json
-      - name: Send MM message
-        if: ${{ success() }} || ${{ failure() }}
-        uses: mattermost/action-mattermost-notify@1.1.0
-        env:
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-          MATTERMOST_CHANNEL: eclipse-che-releases
-          MATTERMOST_USERNAME: che-bot
+      # - name: Create failure MM message
+      #   if: ${{ failure() }}
+      #   run: |
+      #     echo "{\"text\":\":no_entry_sign: Che Community Operator ${{ github.event.inputs.version }} release has failed: https://github.com/eclipse-che/che-operator/actions/workflows/release-community-operator-PRs.yml\"}" > mattermost.json
+      # - name: Create success MM message
+      #   run: |
+      #     echo "{\"text\":\":white_check_mark: Che Community Operator ${{ github.event.inputs.version }} release PR has been created: https://github.com/redhat-openshift-ecosystem/community-operators-prod/pulls?q=is%3Apr+is%3Aopen+eclipse-che\"}" > mattermost.json
+      # - name: Send MM message
+      #   if: ${{ success() }} || ${{ failure() }}
+      #   uses: mattermost/action-mattermost-notify@1.1.0
+      #   env:
+      #     MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+      #     MATTERMOST_CHANNEL: eclipse-che-releases
+      #     MATTERMOST_USERNAME: che-bot


### PR DESCRIPTION
### What does this PR do?

chore: disable mattermost notification as it doesn't work

Change-Id: I9c8742a02305e24daff786ef84e86989e99aecca
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.