### PR TITLE
chore: Update oauth-proxy and kube-rbac-proxy gateway images

### DIFF
--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -77,7 +77,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che.v7.73.0-808.next
+  name: eclipse-che.v7.75.0-809.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -921,9 +921,9 @@ spec:
                       - name: RELATED_IMAGE_single_host_gateway_config_sidecar
                         value: quay.io/che-incubator/configbump:0.1.4
                       - name: RELATED_IMAGE_gateway_authentication_sidecar
-                        value: quay.io/openshift/origin-oauth-proxy:4.9
+                        value: quay.io/openshift/origin-oauth-proxy:4.15
                       - name: RELATED_IMAGE_gateway_authorization_sidecar
-                        value: quay.io/openshift/origin-kube-rbac-proxy:4.9
+                        value: quay.io/openshift/origin-kube-rbac-proxy:4.15
                       - name: RELATED_IMAGE_gateway_authentication_sidecar_k8s
                         value: quay.io/oauth2-proxy/oauth2-proxy:v7.4.0
                       - name: RELATED_IMAGE_gateway_authorization_sidecar_k8s
@@ -1234,7 +1234,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Eclipse Foundation
-  version: 7.73.0-808.next
+  version: 7.75.0-809.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,9 +76,9 @@ spec:
             - name: RELATED_IMAGE_single_host_gateway_config_sidecar
               value: quay.io/che-incubator/configbump:0.1.4
             - name: RELATED_IMAGE_gateway_authentication_sidecar
-              value: quay.io/openshift/origin-oauth-proxy:4.9
+              value: quay.io/openshift/origin-oauth-proxy:4.15
             - name: RELATED_IMAGE_gateway_authorization_sidecar
-              value: quay.io/openshift/origin-kube-rbac-proxy:4.9
+              value: quay.io/openshift/origin-kube-rbac-proxy:4.15
             - name: RELATED_IMAGE_gateway_authentication_sidecar_k8s
               value: quay.io/oauth2-proxy/oauth2-proxy:v7.4.0
             - name: RELATED_IMAGE_gateway_authorization_sidecar_k8s

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -8847,9 +8847,9 @@ spec:
         - name: RELATED_IMAGE_single_host_gateway_config_sidecar
           value: quay.io/che-incubator/configbump:0.1.4
         - name: RELATED_IMAGE_gateway_authentication_sidecar
-          value: quay.io/openshift/origin-oauth-proxy:4.9
+          value: quay.io/openshift/origin-oauth-proxy:4.15
         - name: RELATED_IMAGE_gateway_authorization_sidecar
-          value: quay.io/openshift/origin-kube-rbac-proxy:4.9
+          value: quay.io/openshift/origin-kube-rbac-proxy:4.15
         - name: RELATED_IMAGE_gateway_authentication_sidecar_k8s
           value: quay.io/oauth2-proxy/oauth2-proxy:v7.4.0
         - name: RELATED_IMAGE_gateway_authorization_sidecar_k8s

--- a/deploy/deployment/kubernetes/objects/che-operator.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/che-operator.Deployment.yaml
@@ -70,9 +70,9 @@ spec:
         - name: RELATED_IMAGE_single_host_gateway_config_sidecar
           value: quay.io/che-incubator/configbump:0.1.4
         - name: RELATED_IMAGE_gateway_authentication_sidecar
-          value: quay.io/openshift/origin-oauth-proxy:4.9
+          value: quay.io/openshift/origin-oauth-proxy:4.15
         - name: RELATED_IMAGE_gateway_authorization_sidecar
-          value: quay.io/openshift/origin-kube-rbac-proxy:4.9
+          value: quay.io/openshift/origin-kube-rbac-proxy:4.15
         - name: RELATED_IMAGE_gateway_authentication_sidecar_k8s
           value: quay.io/oauth2-proxy/oauth2-proxy:v7.4.0
         - name: RELATED_IMAGE_gateway_authorization_sidecar_k8s

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -8849,9 +8849,9 @@ spec:
         - name: RELATED_IMAGE_single_host_gateway_config_sidecar
           value: quay.io/che-incubator/configbump:0.1.4
         - name: RELATED_IMAGE_gateway_authentication_sidecar
-          value: quay.io/openshift/origin-oauth-proxy:4.9
+          value: quay.io/openshift/origin-oauth-proxy:4.15
         - name: RELATED_IMAGE_gateway_authorization_sidecar
-          value: quay.io/openshift/origin-kube-rbac-proxy:4.9
+          value: quay.io/openshift/origin-kube-rbac-proxy:4.15
         - name: RELATED_IMAGE_gateway_authentication_sidecar_k8s
           value: quay.io/oauth2-proxy/oauth2-proxy:v7.4.0
         - name: RELATED_IMAGE_gateway_authorization_sidecar_k8s

--- a/deploy/deployment/openshift/objects/che-operator.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/che-operator.Deployment.yaml
@@ -70,9 +70,9 @@ spec:
         - name: RELATED_IMAGE_single_host_gateway_config_sidecar
           value: quay.io/che-incubator/configbump:0.1.4
         - name: RELATED_IMAGE_gateway_authentication_sidecar
-          value: quay.io/openshift/origin-oauth-proxy:4.9
+          value: quay.io/openshift/origin-oauth-proxy:4.15
         - name: RELATED_IMAGE_gateway_authorization_sidecar
-          value: quay.io/openshift/origin-kube-rbac-proxy:4.9
+          value: quay.io/openshift/origin-kube-rbac-proxy:4.15
         - name: RELATED_IMAGE_gateway_authentication_sidecar_k8s
           value: quay.io/oauth2-proxy/oauth2-proxy:v7.4.0
         - name: RELATED_IMAGE_gateway_authorization_sidecar_k8s

--- a/helmcharts/next/templates/che-operator.Deployment.yaml
+++ b/helmcharts/next/templates/che-operator.Deployment.yaml
@@ -70,9 +70,9 @@ spec:
         - name: RELATED_IMAGE_single_host_gateway_config_sidecar
           value: quay.io/che-incubator/configbump:0.1.4
         - name: RELATED_IMAGE_gateway_authentication_sidecar
-          value: quay.io/openshift/origin-oauth-proxy:4.9
+          value: quay.io/openshift/origin-oauth-proxy:4.15
         - name: RELATED_IMAGE_gateway_authorization_sidecar
-          value: quay.io/openshift/origin-kube-rbac-proxy:4.9
+          value: quay.io/openshift/origin-kube-rbac-proxy:4.15
         - name: RELATED_IMAGE_gateway_authentication_sidecar_k8s
           value: quay.io/oauth2-proxy/oauth2-proxy:v7.4.0
         - name: RELATED_IMAGE_gateway_authorization_sidecar_k8s


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Updates the `oauth-proxy` and `kube-rbac-proxy` gateway images from the `che-gateway` pod.

I based this update on a previous update done here: https://github.com/eclipse-che/che-operator/commit/7d6dcbd9142cd3104359d95ee1bf32d6769fb7b6

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
<img width="1146" alt="image" src="https://github.com/eclipse-che/che-operator/assets/83611742/527fd66b-4d55-49e8-b7c8-89cf5045807d">


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
PR made in response to https://github.com/eclipse/che/issues/22353

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
1. Checkout this PR branch, and run  ./build/scripts/olm/test-catalog-from-sources.sh to install Eclipse Che on a cluster
2. Verify that the `oauth-proxy` and `kube-rbac-proxy` images are `quay.io/openshift/origin-oauth-proxy:4.15` and `quay.io/openshift/origin-kube-rbac-proxy:4.15` respectively :
```
$ oc get deployment che-gateway -n eclipse-che  -o jsonpath='{.spec.template.spec.containers[*].image}'

<traefik-image> <configbump-image> quay.io/openshift/origin-oauth-proxy:4.15 quay.io/openshift/origin-kube-rbac-proxy:4.15
```
3. Verify that you can visit the Che dashboard and start a workspace without any errors. 


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
