### PR TITLE
Support setting the _oauth2_proxy cookie expiration time

### DIFF
--- a/api/v2/checluster_types.go
+++ b/api/v2/checluster_types.go
@@ -541,6 +541,9 @@ type Gateway struct {
 	// Configuration for kube-rbac-proxy within the Che gateway pod.
 	// +optional
 	KubeRbacProxy *KubeRbacProxy `json:"kubeRbacProxy,omitempty"`
+	// Configuration for oauth-proxy within the Che gateway pod.
+	// +optional
+	OauthProxy *OauthProxy `json:"oauthProxy,omitempty"`
 }
 
 // Proxy server configuration.
@@ -758,6 +761,13 @@ type KubeRbacProxy struct {
 	// +kubebuilder:default:=0
 	// +kubebuilder:validation:Minimum:=0
 	LogLevel *int32 `json:"logLevel,omitempty"`
+}
+
+// Configuration for oauth-proxy within the Che gateway pod.
+type OauthProxy struct {
+	// How long the _oauth2_proxy cookie lasts.
+	// +optional
+	CookieExpire string `json:"cookieExpire,omitempty"`
 }
 
 // GatewayPhase describes the different phases of the Che gateway lifecycle.

--- a/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
@@ -8197,6 +8197,14 @@ spec:
                                     - PANIC
                                   type: string
                               type: object
+                            oauthProxy:
+                              description: Configuration for oauth-proxy within the Che gateway pod.
+                              type: object
+                              properties:
+                                cookieExpire:
+                                  description: How long the _oauth2_proxy cookie lasts.
+                                  type: string
+                                  default: '24h0m0s'
                           type: object
                         identityProviderURL:
                           description: Public URL of the Identity Provider server.

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -7980,6 +7980,14 @@ spec:
                                 - PANIC
                                 type: string
                             type: object
+                          oauthProxy:
+                            description: Configuration for oauth-proxy within the Che gateway pod.
+                            type: object
+                            properties:
+                              cookieExpire:
+                                description: How long the _oauth2_proxy cookie lasts.
+                                type: string
+                                default: '24h0m0s'
                         type: object
                       identityProviderURL:
                         description: Public URL of the Identity Provider server.

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -7999,6 +7999,14 @@ spec:
                                 - PANIC
                                 type: string
                             type: object
+                          oauthProxy:
+                            description: Configuration for oauth-proxy within the Che gateway pod.
+                            type: object
+                            properties:
+                              cookieExpire:
+                                description: How long the _oauth2_proxy cookie lasts.
+                                type: string
+                                default: '24h0m0s'
                         type: object
                       identityProviderURL:
                         description: Public URL of the Identity Provider server.

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -7994,6 +7994,14 @@ spec:
                                 - PANIC
                                 type: string
                             type: object
+                          oauthProxy:
+                            description: Configuration for oauth-proxy within the Che gateway pod.
+                            type: object
+                            properties:
+                              cookieExpire:
+                                description: How long the _oauth2_proxy cookie lasts.
+                                type: string
+                                default: '24h0m0s'
                         type: object
                       identityProviderURL:
                         description: Public URL of the Identity Provider server.

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -7999,6 +7999,14 @@ spec:
                                 - PANIC
                                 type: string
                             type: object
+                          oauthProxy:
+                            description: Configuration for oauth-proxy within the Che gateway pod.
+                            type: object
+                            properties:
+                              cookieExpire:
+                                description: How long the _oauth2_proxy cookie lasts.
+                                type: string
+                                default: '24h0m0s'
                         type: object
                       identityProviderURL:
                         description: Public URL of the Identity Provider server.

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -7994,6 +7994,14 @@ spec:
                                 - PANIC
                                 type: string
                             type: object
+                          oauthProxy:
+                            description: Configuration for oauth-proxy within the Che gateway pod.
+                            type: object
+                            properties:
+                              cookieExpire:
+                                description: How long the _oauth2_proxy cookie lasts.
+                                type: string
+                                default: '24h0m0s'
                         type: object
                       identityProviderURL:
                         description: Public URL of the Identity Provider server.

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -7994,6 +7994,14 @@ spec:
                                 - PANIC
                                 type: string
                             type: object
+                          oauthProxy:
+                            description: Configuration for oauth-proxy within the Che gateway pod.
+                            type: object
+                            properties:
+                              cookieExpire:
+                                description: How long the _oauth2_proxy cookie lasts.
+                                type: string
+                                default: '24h0m0s'
                         type: object
                       identityProviderURL:
                         description: Public URL of the Identity Provider server.

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -20,12 +20,13 @@ const (
 	DefaultDashboardCpuRequest    = "100m"
 
 	// Gateway
-	DefaultGatewayMemoryLimit    = "256Mi"
-	DefaultGatewayMemoryRequest  = "64Mi"
-	DefaultGatewayCpuLimit       = "500m"
-	DefaultGatewayCpuRequest     = "50m"
-	DefaultTraefikLogLevel       = "INFO"
-	DefaultKubeRbacProxyLogLevel = int32(0)
+	DefaultGatewayMemoryLimit     = "256Mi"
+	DefaultGatewayMemoryRequest   = "64Mi"
+	DefaultGatewayCpuLimit        = "500m"
+	DefaultGatewayCpuRequest      = "50m"
+	DefaultTraefikLogLevel        = "INFO"
+	DefaultKubeRbacProxyLogLevel  = int32(0)
+	DefaultOauthProxyCookieExpire = "24h0m0s"
 
 	// PluginRegistry
 	DefaultPluginRegistryMemoryLimit                          = "256Mi"

--- a/pkg/deploy/gateway/oauth_proxy_test.go
+++ b/pkg/deploy/gateway/oauth_proxy_test.go
@@ -1,4 +1,3 @@
-//
 // Copyright (c) 2019-2021 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
@@ -7,8 +6,8 @@
 // SPDX-License-Identifier: EPL-2.0
 //
 // Contributors:
-//   Red Hat, Inc. - initial API and implementation
 //
+//	Red Hat, Inc. - initial API and implementation
 package gateway
 
 import (
@@ -16,6 +15,7 @@ import (
 
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 	chev2 "github.com/eclipse-che/che-operator/api/v2"
+	"github.com/eclipse-che/che-operator/pkg/common/constants"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -35,7 +35,7 @@ func TestKubernetesOauthProxyConfig(t *testing.T) {
 	ctx.CheHost = "che-site.che-domain.com"
 	infrastructure.InitializeForTesting(infrastructure.Kubernetes)
 
-	config := kubernetesOauthProxyConfig(ctx, "blabol")
+	config := kubernetesOauthProxyConfig(ctx, "blabol", constants.DefaultOauthProxyCookieExpire)
 	assert.Contains(t, config, "pass_authorization_header = true")
 	assert.Contains(t, config, "whitelist_domains = \".che-domain.com\"")
 	assert.Contains(t, config, "cookie_domains = \".che-domain.com\"")
@@ -58,7 +58,7 @@ func TestScopeDefinedForKubernetesOauthProxyConfig(t *testing.T) {
 		}, nil)
 	infrastructure.InitializeForTesting(infrastructure.Kubernetes)
 
-	config := kubernetesOauthProxyConfig(ctx, "blabol")
+	config := kubernetesOauthProxyConfig(ctx, "blabol", constants.DefaultOauthProxyCookieExpire)
 	assert.Contains(t, config, "scope = \"scope1 scope2 scope3 scope4 scope5\"")
 }
 
@@ -77,7 +77,7 @@ func TestAccessTokenDefinedForKubernetesOauthProxyConfig(t *testing.T) {
 		}, nil)
 	infrastructure.InitializeForTesting(infrastructure.Kubernetes)
 
-	config := kubernetesOauthProxyConfig(ctx, "blabol")
+	config := kubernetesOauthProxyConfig(ctx, "blabol", constants.DefaultOauthProxyCookieExpire)
 	assert.Contains(t, config, "pass_access_token = true")
 	assert.NotContains(t, config, "pass_authorization_header = true")
 }


### PR DESCRIPTION
### What does this PR do?

Adds a setting in the che CRD, `spec.networking.auth.gateway.cookieExpire`, that controls how long the `_oauth2_proxy` cookie lasts.

This PR is a draft. I'm struggling to test it because, while I can deploy the new che-operator image to my cluster, k8s won't let me add a value for the `cookieExpire` field because it doesn't recognize the new schema. I'm not sure how to update k8s's knowledge of the che CRD schema. I'm looking for help figuring that out.

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/22460

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
