### PR TITLE
fix: Removing '-Dcom.redhat.fips=false' from the default JAVA_OPTS

### DIFF
--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -53,12 +53,10 @@ const (
 	DefaultServerTrustStoreConfigMapName   = "ca-certs"
 	DefaultProxyCredentialsSecret          = "proxy-credentials"
 	DefaultGitSelfSignedCertsConfigMapName = "che-git-self-signed-cert"
-	// -Dcom.redhat.fips=false workaround allows to run che-server on OpenShift with FIPS enabled
-	// See https://issues.redhat.com/browse/CRW-3301
-	DefaultJavaOpts                 = "-XX:MaxRAMPercentage=85.0 -Dcom.redhat.fips=false"
-	DefaultSecurityContextFsGroup   = 1724
-	DefaultSecurityContextRunAsUser = 1724
-	DefaultCheServiceAccountName    = "che"
+	DefaultJavaOpts                        = "-XX:MaxRAMPercentage=85.0"
+	DefaultSecurityContextFsGroup          = 1724
+	DefaultSecurityContextRunAsUser        = 1724
+	DefaultCheServiceAccountName           = "che"
 
 	// OAuth
 	BitBucketOAuthConfigClientIdFileName       = "id"


### PR DESCRIPTION
### What does this PR do?

Removing '-Dcom.redhat.fips=false' from the default JAVA_OPTS 

In the latest Dev Spaces release the latest 6.8.1 version of k8s client is used which is FIPS compatible - https://github.com/fabric8io/kubernetes-client/issues/3582 and there is no need to disable fips via `-Dcom.redhat.fips=false` on the che-server end.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4592

### How to test this PR?

- Provision cluster with FIPS enabled (the easiest way to do it is via clusterbot `launch 4.13 azure,fips`)
- Check that the FIPS mode is enabled on the cluster via `oc get cm cluster-config-v1 -n kube-system -o json | jq -r '.data' | grep -i "fips"` command

<img width="1716" alt="Screenshot 2023-11-09 at 16 45 11" src="https://github.com/eclipse-che/che-operator/assets/1461122/93544dec-5889-4a91-89ec-f86f94b689f4">

- Install the latest version of Dev Spaces 3.9.0 / 3.9.1 and create a CR with updated JAVA_OPTS without `-Dcom.redhat.fips=false`

```
spec:
  components:
    cheServer:
      extraProperties:
        JAVA_OPTS : '-XX:MaxRAMPercentage=85.0'
```

- Check the value of the `JAVA_OPTS` env var in che-server / devspaces pod as well as in the `che` configmap - it should be `-XX:MaxRAMPercentage=85.0` 

<img width="670" alt="Screenshot 2023-11-09 at 16 56 07" src="https://github.com/eclipse-che/che-operator/assets/1461122/2ba1e468-5b93-467f-83e8-13302d3582b7">

- start / stop a few workspace and verify that workspace startup has no issues / no errors in the che-server logs

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

