### PR TITLE
Add Kubernetes host to the no proxy list

### DIFF
--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -77,7 +77,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che.v7.79.0-828.next
+  name: eclipse-che.v7.81.0-829.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1240,7 +1240,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Eclipse Foundation
-  version: 7.79.0-828.next
+  version: 7.81.0-829.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/controllers/usernamespace/controller_test.go
+++ b/controllers/usernamespace/controller_test.go
@@ -332,19 +332,6 @@ func TestCreatesDataInNamespace(t *testing.T) {
 
 		assert.False(t, res.Requeue, "The reconciliation request should have succeeded but it is requesting a requeue")
 
-		proxySettings := corev1.ConfigMap{}
-		assert.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "che-proxy-settings", Namespace: namespace.GetName()}, &proxySettings))
-
-		assert.Equal(t, "env", proxySettings.GetAnnotations()[dwconstants.DevWorkspaceMountAsAnnotation],
-			"proxy settings should be annotated as mount as 'env'")
-
-		assert.Equal(t, "true", proxySettings.GetLabels()[dwconstants.DevWorkspaceMountLabel],
-			"proxy settings should be labeled as mounted")
-
-		assert.Equal(t, 2, len(proxySettings.Data), "Expecting 2 elements in the default proxy settings")
-
-		assert.Equal(t, ".svc", proxySettings.Data["NO_PROXY"], "Unexpected proxy settings")
-
 		idleSettings := corev1.ConfigMap{}
 		assert.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "che-idle-settings", Namespace: namespace.GetName()}, &idleSettings))
 

--- a/pkg/deploy/proxy.go
+++ b/pkg/deploy/proxy.go
@@ -122,7 +122,9 @@ func ReadCheClusterProxyConfiguration(ctx *chetypes.DeployContext) (*chetypes.Pr
 }
 
 func MergeNonProxy(noProxy1 string, noProxy2 string) string {
-	if noProxy1 == "" {
+	if noProxy1 == "" && noProxy2 == "" {
+		return ""
+	} else if noProxy1 == "" {
 		return noProxy2
 	} else if noProxy2 == "" {
 		return noProxy1

--- a/pkg/deploy/proxy.go
+++ b/pkg/deploy/proxy.go
@@ -122,9 +122,7 @@ func ReadCheClusterProxyConfiguration(ctx *chetypes.DeployContext) (*chetypes.Pr
 }
 
 func MergeNonProxy(noProxy1 string, noProxy2 string) string {
-	if noProxy1 == "" && noProxy2 == "" {
-		return ""
-	} else if noProxy1 == "" {
+	if noProxy1 == "" {
 		return noProxy2
 	} else if noProxy2 == "" {
 		return noProxy1

--- a/pkg/deploy/server/server_configmap.go
+++ b/pkg/deploy/server/server_configmap.go
@@ -15,7 +15,6 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -89,11 +88,6 @@ func (s *CheServerReconciler) getCheConfigMapData(ctx *chetypes.DeployContext) (
 	proxyJavaOpts := ""
 	cheWorkspaceNoProxy := ctx.Proxy.NoProxy
 	if ctx.Proxy.HttpProxy != "" {
-		if ctx.Proxy.NoProxy == "" {
-			cheWorkspaceNoProxy = os.Getenv("KUBERNETES_SERVICE_HOST")
-		} else {
-			cheWorkspaceNoProxy = cheWorkspaceNoProxy + "," + os.Getenv("KUBERNETES_SERVICE_HOST")
-		}
 		proxyJavaOpts, err = deploy.GenerateProxyJavaOpts(ctx.Proxy, cheWorkspaceNoProxy)
 		if err != nil {
 			logrus.Errorf("Failed to generate java proxy options: %v", err)


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Add Kubernetes host to the no proxy list

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-5421

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Prepare a patch file if needed:
```bash
cat > /tmp/cr-patch.yaml <<EOF
apiVersion: org.eclipse.che/v2
kind: CheCluster
spec: {}
EOF
```

2. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```
3. Start a workspace
4. Open a terminal and run `env | grep NO_PROXY`

See: `172.30.0.1` is included to the no proxy env variable.
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
