### PR TITLE
Update how too-long endpoint hostnames are handled

### DIFF
--- a/controllers/devworkspace/solver/che_routing_test.go
+++ b/controllers/devworkspace/solver/che_routing_test.go
@@ -1569,24 +1569,24 @@ func TestReportSubdomainExposedEndpointsLongUsername(t *testing.T) {
 	if e1.Name != "e1" {
 		t.Errorf("The first endpoint should have been e1 but is %s", e1.Name)
 	}
-	if e1.Url != "https://wsid-1.down.on.earth/1/" {
-		t.Errorf("The e1 endpoint should have the following URL: '%s' but has '%s'.", "https://wsid-1.down.on.earth/1/", e1.Url)
+	if e1.Url != "https://wsid-e1.down.on.earth/1/" {
+		t.Errorf("The e1 endpoint should have the following URL: '%s' but has '%s'.", "https://wsid-e1.down.on.earth/1/", e1.Url)
 	}
 
 	e2 := m1[1]
 	if e2.Name != "e2" {
 		t.Errorf("The second endpoint should have been e2 but is %s", e1.Name)
 	}
-	if e2.Url != "https://wsid-2.down.on.earth/2.js" {
-		t.Errorf("The e2 endpoint should have the following URL: '%s' but has '%s'.", "https://wsid-2.down.on.earth/2.js", e2.Url)
+	if e2.Url != "https://wsid-e2.down.on.earth/2.js" {
+		t.Errorf("The e2 endpoint should have the following URL: '%s' but has '%s'.", "https://wsid-e2.down.on.earth/2.js", e2.Url)
 	}
 
 	e3 := m1[2]
 	if e3.Name != "e3" {
 		t.Errorf("The third endpoint should have been e3 but is %s", e1.Name)
 	}
-	if e3.Url != "http://wsid-3.down.on.earth/" {
-		t.Errorf("The e3 endpoint should have the following URL: '%s' but has '%s'.", "https://wsid-3.down.on.earth/", e3.Url)
+	if e3.Url != "http://wsid-e3.down.on.earth/" {
+		t.Errorf("The e3 endpoint should have the following URL: '%s' but has '%s'.", "https://wsid-e3.down.on.earth/", e3.Url)
 	}
 }
 

--- a/controllers/devworkspace/solver/endpoint_strategy.go
+++ b/controllers/devworkspace/solver/endpoint_strategy.go
@@ -72,8 +72,10 @@ func (u UsernameWkspName) getEndpointPathPrefix(endpointPath string) string {
 func (u UsernameWkspName) getHostname(endpointInfo *EndpointInfo, baseDomain string) string {
 	subDomain := fmt.Sprintf("%s-%s-%s", u.username, u.workspaceName, endpointInfo.endpointName)
 	if errs := validation.IsValidLabelValue(subDomain); len(errs) > 0 {
-		// if subdomain is not valid, use legacy paths
-		return fmt.Sprintf("%s-%d.%s", u.workspaceID, endpointInfo.order, baseDomain)
+		// If subdomain is not valid (e.g. too long), use alternate format
+		// The below should always be under 63 characters, as endpoint names are limited to 15 characters and workspace IDs are
+		// 25 characters.
+		return fmt.Sprintf("%s-%s.%s", u.workspaceID, endpointInfo.endpointName, baseDomain)
 	}
 
 	return fmt.Sprintf("%s.%s", subDomain, baseDomain)


### PR DESCRIPTION
### What does this PR do?
Update the hostname format used for endpoints whose hostnames are too long from
```
  <workspace-id>-<order>.<base-domain>
```
to
```
  <workspace-id>-<endpoint-name>.<base-domain>
```
This is necessary as the iteration order through endpoints is random (iterating through Go maps is random), resulting in inconsistent numbers used for `<order>`.

Using a combination of workspace ID and endpoint name should always be valid:

* Workspace IDs are 25 characters long ([ref](https://github.com/devfile/devworkspace-operator/blob/21aaf77d61f8801fbfad940b607f2e9e420b49dd/controllers/workspace/devworkspace_controller.go#L646-L668))
* Endpoint names are restricted to max 15 characters by the Devfile API ([ref](https://devfile.io/docs/2.2.0/devfile-schema#components-container-endpoints-name))
* Endpoint names and workspace IDs are required to be alphanumeric with dashes, starting and ending with an alphanumeric character ([ref](https://devfile.io/docs/2.2.0/devfile-schema#components-container-endpoints-name))
* Endpoint names are unique across all endpoints in the workspace ([ref](https://devfile.io/docs/2.2.1/devfile-validation-rules#endpoints))

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
Closes https://github.com/eclipse/che/issues/22774

### How to test this PR?
See reproducer in linked issue; after change, long endpoints should get the hostname
```
workspaceID-endpointname.baseDomain
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
