### PR TITLE
feat: Use  registry.devfile.io by default in Eclipse Che

### DIFF
--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -55,7 +55,16 @@ metadata:
             "namespace": "eclipse-che"
           },
           "spec": {
-            "components": {},
+            "components": {
+              "pluginRegistry": {
+                "disableInternalRegistry": true,
+                "externalPluginRegistries": [
+                  {
+                    "url": "https://registry.devfile.io/"
+                  }
+                ]
+              }
+            },
             "containerRegistry": {},
             "devEnvironments": {},
             "gitServices": {},
@@ -77,7 +86,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che.v7.82.0-835.next
+  name: eclipse-che.v7.82.0-837.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1248,7 +1257,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Eclipse Foundation
-  version: 7.82.0-835.next
+  version: 7.82.0-837.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/config/samples/org_v1_checluster.yaml
+++ b/config/samples/org_v1_checluster.yaml
@@ -17,7 +17,9 @@ metadata:
   namespace: eclipse-che
 spec:
   server:
-    workspaceNamespaceDefault: "<username>-che"
+    workspaceNamespaceDefault: '<username>-che'
+    externalPluginRegistry: true
+    pluginRegistryUrl: 'https://registry.devfile.io'
   database:
     externalDb: false
   storage:

--- a/config/samples/org_v2_checluster.yaml
+++ b/config/samples/org_v2_checluster.yaml
@@ -16,7 +16,11 @@ metadata:
   name: eclipse-che
   namespace: eclipse-che
 spec:
-  components: {}
+  components:
+    pluginRegistry:
+      disableInternalRegistry: true
+      externalPluginRegistries:
+        - url: 'https://registry.devfile.io'
   devEnvironments: {}
   networking: {}
   containerRegistry: {}

--- a/deploy/deployment/kubernetes/org_v2_checluster.yaml
+++ b/deploy/deployment/kubernetes/org_v2_checluster.yaml
@@ -16,7 +16,11 @@ metadata:
   name: eclipse-che
   namespace: eclipse-che
 spec:
-  components: {}
+  components:
+    pluginRegistry:
+      disableInternalRegistry: true
+      externalPluginRegistries:
+        - url: https://registry.devfile.io/
   devEnvironments: {}
   networking: {}
   containerRegistry: {}

--- a/deploy/deployment/openshift/org_v2_checluster.yaml
+++ b/deploy/deployment/openshift/org_v2_checluster.yaml
@@ -16,7 +16,11 @@ metadata:
   name: eclipse-che
   namespace: eclipse-che
 spec:
-  components: {}
+  components:
+    pluginRegistry:
+      disableInternalRegistry: true
+      externalPluginRegistries:
+        - url: https://registry.devfile.io/
   devEnvironments: {}
   networking: {}
   containerRegistry: {}

--- a/helmcharts/next/templates/org_v2_checluster.yaml
+++ b/helmcharts/next/templates/org_v2_checluster.yaml
@@ -16,7 +16,11 @@ metadata:
   name: eclipse-che
   namespace: eclipse-che
 spec:
-  components: {}
+  components:
+    pluginRegistry:
+      disableInternalRegistry: true
+      externalPluginRegistries:
+        - url: https://registry.devfile.io/
   devEnvironments: {}
   networking:
     tlsSecretName: che-tls


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
feat: Use  registry.devfile.io by default in Eclipse Che

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/22485

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Prepare a patch file if needed:
```bash
cat > /tmp/cr-patch.yaml <<EOF
apiVersion: org.eclipse.che/v2
kind: CheCluster
spec: {}
EOF
```

2. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
