### PR TITLE
CRW-4824 Updating annotations for operators to meet new OpenShift requirements

### DIFF
--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -85,9 +85,17 @@ metadata:
     createdAt: "2021-05-11T18:38:31Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "true"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: openshift-operators
-    operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware",
-      "fips"]'
     operators.operatorframework.io/builder: operator-sdk-v1.9.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -100,7 +100,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che.v7.83.0-858.next
+  name: eclipse-che.v7.83.0-860.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1032,7 +1032,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Eclipse Foundation
-  version: 7.83.0-858.next
+  version: 7.83.0-860.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -91,7 +91,7 @@ metadata:
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
-    features.operators.openshift.io/tls-profiles: "true"
+    features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"

--- a/bundle/stable/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/stable/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -85,17 +85,9 @@ metadata:
     createdAt: "2024-02-21T21:09:52Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
-    features.operators.openshift.io/cnf: "false"
-    features.operators.openshift.io/cni: "false"
-    features.operators.openshift.io/csi: "false"
-    features.operators.openshift.io/disconnected: "true"
-    features.operators.openshift.io/fips-compliant: "true"
-    features.operators.openshift.io/proxy-aware: "true"
-    features.operators.openshift.io/tls-profiles: "false"
-    features.operators.openshift.io/token-auth-aws: "false"
-    features.operators.openshift.io/token-auth-azure: "false"
-    features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: openshift-operators
+    operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware",
+      "fips"]'
     operators.operatorframework.io/builder: operator-sdk-v1.9.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator

--- a/bundle/stable/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/stable/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -85,9 +85,17 @@ metadata:
     createdAt: "2024-02-21T21:09:52Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "true"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: openshift-operators
-    operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware",
-      "fips"]'
     operators.operatorframework.io/builder: operator-sdk-v1.9.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator

--- a/bundle/stable/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/stable/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -91,7 +91,7 @@ metadata:
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
-    features.operators.openshift.io/tls-profiles: "true"
+    features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"

--- a/config/manifests/bases/che-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/che-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
-    features.operators.openshift.io/tls-profiles: "true"
+    features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"

--- a/config/manifests/bases/che-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/che-operator.clusterserviceversion.yaml
@@ -22,9 +22,17 @@ metadata:
     createdAt: "2021-05-11T18:38:31Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "true"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: openshift-operators
-    operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware",
-      "fips"]'
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
   name: eclipse-che.v0.0.0


### PR DESCRIPTION
### What does this PR do?
There are newly implemented requirements (tests became mandatory last week) that requires a change in operator annotations:

https://docs.openshift.com/container-platform/4.15/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-annotations-infra_osdk-generating-csvs (see table 3)

So I’ve replaced   
```
operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware",
  	"fips"]'
```
with
```
features.operators.openshift.io/disconnected: “true”
features.operators.openshift.io/fips-compliant: “true”
features.operators.openshift.io/proxy-aware: “true”
features.operators.openshift.io/tls-profiles: “true”
features.operators.openshift.io/token-auth-aws: “false” 
features.operators.openshift.io/token-auth-azure: “false” 
features.operators.openshift.io/token-auth-gcp: “false” 
```

Optional:
```
features.operators.openshift.io/cnf: “false” 
features.operators.openshift.io/cni: “false” 
features.operators.openshift.io/csi: “false” 
```

Justifications for true/false:
- Disconnected, fips and proxy-aware were already set using the old format
- tls-profiles I set to true because TLS mode is on by default and configurable.
- aws is false because I found AWS in vendor files but nothing that’s configurable on our end.
- azure is false because the OpenShift docs specifically mentioned  the Cloud Credential Operator which I found no mention of/reference to.
- gcp is false for the same reason as Azure.
- cnf is false because I found no references to the Cloud-Native Network Function.
- cni is false because I only found references to the Container Network Interface in vendor files but nothing configured/configurable by Che.
- csi is false because like CNI the only references to the Container Storage Interface were in vendor files.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4824
Nick created this issue last year.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
