### PR TITLE
feat: Automation of the expected images to be used by ImagePuller

### DIFF
--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -100,7 +100,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che.v7.84.0-861.next
+  name: eclipse-che.v7.84.0-862.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1032,7 +1032,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Eclipse Foundation
-  version: 7.84.0-861.next
+  version: 7.84.0-862.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/pkg/deploy/image-puller/imagepuller.go
+++ b/pkg/deploy/image-puller/imagepuller.go
@@ -215,10 +215,11 @@ func sortImages(images map[string]bool) []string {
 func convertToSpecField(images []string) string {
 	specField := ""
 	for index, image := range images {
-		imageEntries := strings.Split(image, "/")
-		name, err := convertToRFC1123(imageEntries[len(imageEntries)-1])
+		imageName, _ := utils.GetImageNameAndTag(image)
+		imageNameEntries := strings.Split(imageName, "/")
+		name, err := convertToRFC1123(imageNameEntries[len(imageNameEntries)-1])
 		if err != nil {
-			name = fmt.Sprintf("image-%d", index)
+			name = "image"
 		}
 
 		// Adding index make the name unique

--- a/pkg/deploy/image-puller/imagepuller_test.go
+++ b/pkg/deploy/image-puller/imagepuller_test.go
@@ -14,7 +14,6 @@ package imagepuller
 
 import (
 	"context"
-	"os"
 
 	chev1alpha1 "github.com/che-incubator/kubernetes-image-puller-operator/api/v1alpha1"
 	"github.com/eclipse-che/che-operator/pkg/deploy"
@@ -23,19 +22,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/errors"
 
+	chev2 "github.com/eclipse-che/che-operator/api/v2"
 	"github.com/eclipse-che/che-operator/pkg/common/constants"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	"github.com/eclipse-che/che-operator/pkg/common/utils"
-
-	chev2 "github.com/eclipse-che/che-operator/api/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	fakeDiscovery "k8s.io/client-go/discovery/fake"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"testing"
 )
@@ -48,15 +41,6 @@ func TestImagePullerConfiguration(t *testing.T) {
 		expectedImagePuller *chev1alpha1.KubernetesImagePuller
 	}
 
-	// unset RELATED_IMAGE environment variables, set them back after tests complete
-	matches := utils.GetGetArchitectureDependentEnvsByRegExp("^RELATED_IMAGE_.*")
-	for _, match := range matches {
-		if originalValue, exists := os.LookupEnv(match.Name); exists {
-			os.Unsetenv(match.Name)
-			defer os.Setenv(match.Name, originalValue)
-		}
-	}
-
 	testCases := []testCase{
 		{
 			name: "case #1: KubernetesImagePuller with defaults",
@@ -67,7 +51,6 @@ func TestImagePullerConfiguration(t *testing.T) {
 				DeploymentName:   defaultDeploymentName,
 				ConfigMapName:    defaultConfigMapName,
 				ImagePullerImage: defaultImagePullerImage,
-				Images:           getDefaultImages(),
 			}),
 		},
 		{
@@ -97,14 +80,12 @@ func TestImagePullerConfiguration(t *testing.T) {
 					DeploymentName:   defaultDeploymentName,
 					ConfigMapName:    defaultConfigMapName,
 					ImagePullerImage: defaultImagePullerImage,
-					Images:           getDefaultImages(),
 				}),
 			},
 			expectedImagePuller: InitImagePuller(chev1alpha1.KubernetesImagePullerSpec{
 				DeploymentName:   defaultDeploymentName,
 				ConfigMapName:    defaultConfigMapName,
 				ImagePullerImage: defaultImagePullerImage,
-				Images:           getDefaultImages(),
 			}),
 		},
 		{
@@ -122,7 +103,6 @@ func TestImagePullerConfiguration(t *testing.T) {
 					DeploymentName:   defaultDeploymentName,
 					ConfigMapName:    defaultConfigMapName,
 					ImagePullerImage: defaultImagePullerImage,
-					Images:           getDefaultImages(),
 				}),
 			},
 			expectedImagePuller: InitImagePuller(chev1alpha1.KubernetesImagePullerSpec{
@@ -142,7 +122,6 @@ func TestImagePullerConfiguration(t *testing.T) {
 					DeploymentName:   defaultDeploymentName,
 					ConfigMapName:    defaultConfigMapName,
 					ImagePullerImage: defaultImagePullerImage,
-					Images:           getDefaultImages(),
 				}),
 			},
 		},
@@ -150,9 +129,7 @@ func TestImagePullerConfiguration(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			logf.SetLogger(zap.New(zap.WriteTo(os.Stdout), zap.UseDevMode(true)))
-
-			ctx := test.GetDeployContext(testCase.cheCluster, []runtime.Object{})
+			ctx := test.GetDeployContext(testCase.cheCluster, testCase.initObjects)
 			ctx.ClusterAPI.DiscoveryClient.(*fakeDiscovery.FakeDiscovery).Fake.Resources = []*metav1.APIResourceList{
 				{
 					GroupVersion: "che.eclipse.org/v1alpha1",
@@ -162,11 +139,6 @@ func TestImagePullerConfiguration(t *testing.T) {
 						},
 					},
 				},
-			}
-
-			for _, obj := range testCase.initObjects {
-				err := ctx.ClusterAPI.Client.Create(context.TODO(), obj.(client.Object))
-				assert.NoError(t, err)
 			}
 
 			ip := NewImagePuller()
@@ -187,56 +159,6 @@ func TestImagePullerConfiguration(t *testing.T) {
 				}
 			} else {
 				assert.True(t, errors.IsNotFound(err))
-			}
-		})
-	}
-}
-
-func TestDefaultImages(t *testing.T) {
-	type testcase struct {
-		name                   string
-		env                    map[string]string
-		expected               string
-		expectedImagesAsString string
-	}
-
-	// unset RELATED_IMAGE environment variables, set them back after tests complete
-	matches := utils.GetGetArchitectureDependentEnvsByRegExp("^RELATED_IMAGE_.*")
-	for _, match := range matches {
-		if originalValue, exists := os.LookupEnv(match.Name); exists {
-			os.Unsetenv(match.Name)
-			defer os.Setenv(match.Name, originalValue)
-		}
-	}
-
-	cases := []testcase{
-		{
-			name: "case #1",
-			env: map[string]string{
-				"RELATED_IMAGE_che_theia_plugin_registry_image_IBZWQYJ":                         "quay.io/eclipse/che-theia",
-				"RELATED_IMAGE_che_theia_endpoint_runtime_binary_plugin_registry_image_IBZWQYJ": "quay.io/eclipse/che-theia-endpoint-runtime-binary",
-			},
-			expected: "che-theia-endpoint-runtime-binary-plugin-registry-image-ibzwqyj=quay.io/eclipse/che-theia-endpoint-runtime-binary;che-theia-plugin-registry-image-ibzwqyj=quay.io/eclipse/che-theia;",
-		},
-		{
-			name: "case #2",
-			env: map[string]string{
-				"RELATED_IMAGE_che_machine_exec_plugin_registry_image_IBZWQYJ":                  "quay.io/eclipse/che-machine-exec",
-				"RELATED_IMAGE_codeready_workspaces_machineexec_plugin_registry_image_GIXDCMQK": "registry.redhat.io/codeready-workspaces/machineexec-rhel8",
-			},
-			expected: "che-machine-exec-plugin-registry-image-ibzwqyj=quay.io/eclipse/che-machine-exec;codeready-workspaces-machineexec-plugin-registry-image-gixdcmqk=registry.redhat.io/codeready-workspaces/machineexec-rhel8;",
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			for k, v := range c.env {
-				os.Setenv(k, v)
-				defer os.Unsetenv(k)
-			}
-			actual := getDefaultImages()
-			if d := cmp.Diff(c.expected, actual); d != "" {
-				t.Errorf("Error, collected images differ (-want, +got): %v", d)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
1. Operator automatically fetches images from both devfile and plugin registries and creates KIP custom resource with those images.
2. Once operands are updated, the KIP resource will be updated as well.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-5723

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
1. Install Kubernetes Image Puller operator
2. Prepare a patch file:
```bash
cat > /tmp/cr-patch.yaml <<EOF
apiVersion: org.eclipse.che/v2
kind: CheCluster
spec:
  components:
    devfileRegistry:
      disableInternalRegistry: false
      externalDevfileRegistries: []
    imagePuller:
      enable: true
      spec: {}
EOF
```
3. Deploy the operator:
```bash
./build/scripts/olm/test-catalog-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

4. Check KIP custom resource
```bash
$ oc get -n eclipse-che KubernetesImagePuller eclipse-che-image-puller -o jsonpath="{.spec.images}" | tr ";" "\n"
code-server-0=index.docker.io/codercom/code-server@sha256:ef07281004909bb2c228422df2e99a5ba5e450fce7546b8fa186852f23bf6751
dirigible-openshift-1=index.docker.io/dirigiblelabs/dirigible-openshift@sha256:3365635d1e0403697dea0674bbbdc749c4be2db29818a93b8e1e53c3c5144113
che-editor-jupyter-2=index.docker.io/ksmster/che-editor-jupyter@sha256:83439ae9edcaa3a97536742315a7912f93e499f49847da094c480031eae4ba47
eclipse-broadway-3=index.docker.io/wsskeleton/eclipse-broadway@sha256:57c82cd806a56f69aa8663f68405d0778b628a29a64fb16881b11ce9f484dda7
che-code-4=quay.io/che-incubator/che-code:insiders
che-code-5=quay.io/che-incubator/che-code@sha256:abb7bfc64304c7adc403d89ebae91ad6e82914fbff3322e63d8e634e9e5c5845
che-idea-dev-server-6=quay.io/che-incubator/che-idea-dev-server:next
che-idea-dev-server-7=quay.io/che-incubator/che-idea-dev-server@sha256:55d433645dec56ea178df03f466623e045fde046e1cb43b37493999bdb9494de
che-idea-8=quay.io/che-incubator/che-idea:next
che-idea-9=quay.io/che-incubator/che-idea@sha256:8aae69dc4b0c122491a75400639af0fe92b5e214c6e68ac97cda29fb58b44151
che-pycharm-10=quay.io/che-incubator/che-pycharm:next
che-pycharm-11=quay.io/che-incubator/che-pycharm@sha256:7c0e3eabd62495201cf5ba0a913776d972a1e6fb9cf1bcdc78afcf4d7256af47
universal-developer-image-12=quay.io/devfile/universal-developer-image:ubi8-latest
universal-developer-image-13=quay.io/devfile/universal-developer-image@sha256:85516cb612d46ce37759a045b82fbbcc37391c8fa27729418f79592e522db2a5
universal-developer-image-14=quay.io/devfile/universal-developer-image@sha256:ba03058298b8f67bce60226a0ebcb243f60ac59ce77b02b97735467ecedce56f
che--centos--mongodb-36-centos7-15=quay.io/eclipse/che--centos--mongodb-36-centos7:latest-a915db7beca87198fcd7860086989fe8a327a1a4f6508025b64ab28fcc7423b2
che--centos--mongodb-36-centos7-16=quay.io/eclipse/che--centos--mongodb-36-centos7:latest-ffdf2431bbc6d9a9d2a03e95bbbe8adb49ab9eac301f268a35038c84288259c1
che--centos--mysql-57-centos7-17=quay.io/eclipse/che--centos--mysql-57-centos7:latest-e08ee4d43b7356607685b69bde6335e27cf20c020f345b6c6c59400183882764
che--mariadb-18=quay.io/eclipse/che--mariadb:10.7.1-5a8009369ee57c85b6f4a08406147bd9c505cde6b8250d16a27d2a5febfdead7
ubi-minimal-19=registry.access.redhat.com/ubi8/ubi-minimal
```


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
