### PR TITLE
ci: Support --dry-run flag for make-release.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ on:
         description: If true, tags will be recreated. Use with caution
         required: false
         default: 'false'
+      dryRun:
+        description: If true, dry run will be performed. No changes will be pushed to the repository
+        required: false
+        default: 'false'
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -77,6 +82,8 @@ jobs:
           IMAGE_REGISTRY_USER_NAME: eclipse
         run: |
           CHE_VERSION=${{ github.event.inputs.version }}
+          DRY_RUN=${{ github.event.inputs.dryRun }}
+          DRY_RUN_FLAG=[[ ${DRY_RUN} == "true" ]] && DRY_RUN_FLAG="--dry-run"
           echo "CHE_VERSION=${CHE_VERSION}"
           BRANCH=${CHE_VERSION%.*}.x
           echo "BRANCH=${BRANCH}"
@@ -96,10 +103,10 @@ jobs:
           export QUAY_ECLIPSE_CHE_PASSWORD=${{ secrets.QUAY_PASSWORD }}
 
           if [[ ${CHE_VERSION} == *".0" ]]; then
-            build/scripts/release/make-release.sh ${CHE_VERSION} --release --check-resources --release-olm-files
+            build/scripts/release/make-release.sh ${CHE_VERSION} --release --check-resources --release-olm-files ${DRY_RUN_FLAG}
           else
             git checkout ${BRANCH}
-            build/scripts/release/make-release.sh ${CHE_VERSION} --release --release-olm-files
+            build/scripts/release/make-release.sh ${CHE_VERSION} --release --release-olm-files ${DRY_RUN_FLAG}
           fi
 
           # default robot account on quay does not have permissions for application repos
@@ -113,14 +120,14 @@ jobs:
           # echo "[DEBUG] QUAY_USERNAME_OS = ${QUAY_USERNAME_OS}"
 
           git checkout ${CHE_VERSION}-release
-          build/scripts/release/make-release.sh ${CHE_VERSION} --push-olm-bundles
+          build/scripts/release/make-release.sh ${CHE_VERSION} --push-olm-bundles ${DRY_RUN_FLAG}
 
           # perform extra checkouts to ensure branches exist locally
           git checkout ${BRANCH}
           git checkout ${CHE_VERSION}-release
           force_update=""
           if [[ ${{ github.event.inputs.forceRecreateTags }} == "true" ]]; then force_update="--force"; fi
-          build/scripts/release/make-release.sh ${CHE_VERSION} --push-git-changes --pull-requests ${force_update}
+          build/scripts/release/make-release.sh ${CHE_VERSION} --push-git-changes --pull-requests ${force_update} ${DRY_RUN_FLAG}
       #- name: Create failure MM message
         #if: ${{ failure() }}
         #run: |

--- a/build/scripts/release/make-release.sh
+++ b/build/scripts/release/make-release.sh
@@ -15,6 +15,7 @@ set -e
 
 init() {
   RELEASE="$1"
+  DRY_RUN=false
   BRANCH=$(echo $RELEASE | sed 's/.$/x/')
   RELEASE_BRANCH="${RELEASE}-release"
   GIT_REMOTE_UPSTREAM="https://github.com/eclipse-che/che-operator.git"
@@ -42,6 +43,7 @@ init() {
   while [[ "$#" -gt 0 ]]; do
     case $1 in
       '--release') RUN_RELEASE=true; shift 0;;
+      '--dry-run') DRY_RUN=true; shift 0;;
       '--push-olm-bundles') PUSH_OLM_BUNDLES=true; shift 0;;
       '--push-git-changes') PUSH_GIT_CHANGES=true; shift 0;;
       '--pull-requests') CREATE_PULL_REQUESTS=true; shift 0;;
@@ -262,7 +264,11 @@ run() {
   updateVersionFile
   releaseEditorsDefinitions
   releaseManagerYaml
-  buildOperatorImage
+  if [[ $DRY_RUN == "false" ]]; then
+    buildOperatorImage
+  else
+    echo "[INFO] Dry run is enabled. Skipping buildOperatorImage"
+  fi
   if [[ $RELEASE_OLM_FILES == "true" ]]; then
     releaseOlmFiles
     addDigests
@@ -280,7 +286,11 @@ if [[ $RUN_RELEASE == "true" ]]; then
 fi
 
 if [[ $PUSH_OLM_BUNDLES == "true" ]]; then
-  pushOlmBundlesToQuayIo
+  if [[ $DRY_RUN == "false" ]]; then
+    pushOlmBundlesToQuayIo
+  else
+    echo "[INFO] Dry run is enabled. Skipping pushOlmBundlesToQuayIo"
+  fi
 fi
 
 if [[ $PUSH_GIT_CHANGES == "true" ]]; then
@@ -293,5 +303,9 @@ if [[ $CREATE_PULL_REQUESTS == "true" ]]; then
 fi
 
 if [[ $PREPARE_COMMUNITY_OPERATORS_UPDATE == "true" ]]; then
-  prepareCommunityOperatorsUpdate
+  if [[ $DRY_RUN == "false" ]]; then
+    prepareCommunityOperatorsUpdate
+  else
+    echo "[INFO] Dry run is enabled. Skipping prepareCommunityOperatorsUpdate"
+  fi
 fi


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
ci: Support --dry-run flag for make-release.sh