### PR TITLE
fix: RELATED_IMAGE environment name for editor definition

### DIFF
--- a/pkg/deploy/editors-definitions/editors_definitions.go
+++ b/pkg/deploy/editors-definitions/editors_definitions.go
@@ -31,6 +31,10 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/deploy"
 )
 
+const (
+	editorDefinitionEnvNamePrefix = "RELATED_IMAGE_editor_definition"
+)
+
 var (
 	editorsDefinitionsDir           = "/tmp/editors-definitions"
 	editorsDefinitionsConfigMapName = "editors-definitions"
@@ -121,7 +125,7 @@ func updateEditorDefinitionImages(devfile map[string]interface{}) {
 	for _, component := range components {
 		componentName := component.(map[string]interface{})["name"].(string)
 		if container, ok := component.(map[string]interface{})["container"].(map[string]interface{}); ok {
-			imageEnvName := fmt.Sprintf("RELATED_IMAGE_%s_%s_%s", devfileName, devfileVersion, componentName)
+			imageEnvName := fmt.Sprintf("%s_%s_%s_%s", editorDefinitionEnvNamePrefix, devfileName, devfileVersion, componentName)
 			imageEnvName = notAllowedCharsReg.ReplaceAllString(imageEnvName, "_")
 			imageEnvName = utils.GetArchitectureDependentEnvName(imageEnvName)
 

--- a/pkg/deploy/editors-definitions/editors_definitions_test.go
+++ b/pkg/deploy/editors-definitions/editors_definitions_test.go
@@ -23,11 +23,11 @@ import (
 )
 
 func TestReadEditorDefinitions(t *testing.T) {
-	err := os.Setenv("RELATED_IMAGE_che_code_1_2_3_component_a", "image-new-a")
+	err := os.Setenv("RELATED_IMAGE_editor_definition_che_code_1_2_3_component_a", "image-new-a")
 	assert.NoError(t, err)
 
 	defer func() {
-		_ = os.Setenv("RELATED_IMAGE_che_code_1_2_3_component_a", "")
+		_ = os.Setenv("RELATED_IMAGE_editor_definition_che_code_1_2_3_component_a", "")
 	}()
 
 	editorDefinitions, err := readEditorDefinitions()


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
fix: RELATED_IMAGE environment name for editor definition

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse-che/che/issues/22978

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Prepare a patch file if needed:
```bash
cat > /tmp/cr-patch.yaml <<EOF
apiVersion: org.eclipse.che/v2
kind: CheCluster
spec: {}
EOF
```

2. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
