### PR TITLE
fix: stop using mirror.centos.org repo in e2e tests

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -16,6 +16,11 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19
 
 SHELL ["/bin/bash", "-c"]
 
+# Temporary workaround since mirror.centos.org is down and can be replaced with vault.centos.org
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 # Install yq, kubectl, chectl cli.
 RUN yum install --assumeyes -d1 python3-pip nodejs && \
     pip3 install --upgrade pip && \


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
fix: stop using mirror.centos.org repo in e2e tests

