### PR TITLE
Support Devfile endpoint annotations in Che Router

### DIFF
--- a/controllers/devworkspace/solver/che_routing.go
+++ b/controllers/devworkspace/solver/che_routing.go
@@ -514,6 +514,7 @@ func exposeAllEndpoints(cheCluster *chev2.CheCluster, routing *dwo.DevWorkspaceR
 					port:          int32(e.TargetPort),
 					scheme:        determineEndpointScheme(e),
 					service:       commonService,
+					annotations:   e.Annotations,
 				})
 				order = order + 1
 			}

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -11,7 +11,7 @@
 #
 schemaVersion: 2.3.0
 attributes:
-  controller.devfile.io/storage-type: ephemeral
+  controller.devfile.io/storage-type: per-workspace
 metadata:
   name: che-operator
 components:


### PR DESCRIPTION
### What does this PR do?
- Adds the DWR endpoint annotations as annotations for the route (on OpenShift) or ingresse (on Kubernetes) created by the Che Router for a given endpoint

There are a few additional changes made in this PR that are not meant to be merged, though they may be desirable:
- Using per-workspace storage as well as the UDI in the Che-Operator devfile. This was helpful for developing this patch in Che.


### Screenshot/screencast of this PR
n/a


### What issues does this PR fix or reference?
Fix eclipse-che/che#23064


### How to test this PR?
1. Install DWO built from this [PR](https://github.com/devfile/devworkspace-operator/pull/1297), as well as Che-Operator built from the current PR onto your cluster. 
  - On OpenShift, this can easily be done by running `./build/scripts/olm/test-catalog-from-sources.sh ` from the root of this repo.
  - On minikube/kubernetes, you'll have to:
    1. Build DWO: From the root of the [DWO repo](https://github.com/devfile/devworkspace-operator) run `export DWO_IMG=quay.io/<username>/devworkspace-controller:endpoint-annotations && make docker` (or just use my image:  `export DWO_IMG=quay.io/<username>/devworkspace-controller:endpoint-annotations-implementation `)
    2. Install DWO: `make install_cert_manager && make install`
    3. Build Che-Operator: `make docker-build docker-push IMG=<YOUR_OPERATOR_IMAGE>`
    4. Install Che: `chectl server:deploy -p minikube --che-operator-image=<YOUR_OPERATOR_IMAGE>`

2. Once both DWO and Che are installed onto your cluster, verify there's a Che Cluster CR instance created so that you can access the Che User dashboard
3. From the Che User Dashboard, create a workspace with a devfile that defines endpoints with annotations, such as [this one](https://github.com/AObuchow/devfile-endpoint-annotation-test/blob/main/devfile.yaml).

```YAML
      endpoints:
        - name: https-python
          targetPort: 8080
          protocol: https
          annotation:
            my-annotation: test
            another-annotation: test2
```

4. Once the workspace has started up, verify the routes & ingresses for the endpoint(s) with annotations have the expected annotations from the devfile. In my example devfile, your `<workspaceid>-py-8080-https-python` route/ingress should have `my-annotation: test` & `another-annotation: test2`, as shown below:

```diff
kind: Route
apiVersion: route.openshift.io/v1
metadata:
  annotations:
+    another-annotation: test2
    che.routing.controller.devfile.io/component-name: py
    che.routing.controller.devfile.io/endpoint-name: https-python
+    my-annotation: test
  resourceVersion: '48291'
  name: workspace4b929cbc569a4473-py-8080-https-python
(...)
  namespace: che-kube-admin-che-rwxo67
  ownerReferences:
    - apiVersion: controller.devfile.io/v1alpha1
      kind: DevWorkspaceRouting
      name: routing-workspace4b929cbc569a4473
      uid: 497a6df3-9e14-47f8-9fc6-33acfda6df77
      controller: true
      blockOwnerDeletion: true
  labels:
    app.kubernetes.io/part-of: che.eclipse.org
    controller.devfile.io/devworkspace_id: workspace4b929cbc569a4473
spec:
(...)
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
