### PR TITLE
fix: Mount RELATED_IMAGES_sample env vars into dashboard container

### DIFF
--- a/pkg/deploy/dashboard/dashboard_deployment_test.go
+++ b/pkg/deploy/dashboard/dashboard_deployment_test.go
@@ -16,12 +16,12 @@ import (
 	"fmt"
 	"os"
 
-	"k8s.io/apimachinery/pkg/api/resource"
 	fakeDiscovery "k8s.io/client-go/discovery/fake"
 
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
@@ -141,196 +141,159 @@ func TestDashboardDeploymentResources(t *testing.T) {
 }
 
 func TestDashboardDeploymentEnvVars(t *testing.T) {
+	_ = os.Setenv("RELATED_IMAGE_sample_image", "sample_image")
+	_ = os.Setenv("RELATED_IMAGE_sample_encoded_image", "sample_encoded_image")
+
+	defer func() {
+		_ = os.Unsetenv("RELATED_IMAGE_sample_image")
+		_ = os.Unsetenv("RELATED_IMAGE_sample_encoded_")
+	}()
+
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
-
-	type resourcesTestCase struct {
-		name        string
-		initObjects []runtime.Object
-		envVars     []corev1.EnvVar
-		cheCluster  *chev2.CheCluster
-	}
-	testCases := []resourcesTestCase{
-		{
-			name:        "Test provisioning Che URLs",
-			initObjects: []runtime.Object{},
-			envVars: []corev1.EnvVar{
-				{
-					Name:  "CHE_HOST",
-					Value: "https://che-host",
-				},
-				{
-					Name:  "CHE_URL",
-					Value: "https://che-host",
-				},
-				{
-					Name:  "CHECLUSTER_CR_NAMESPACE",
-					Value: "eclipse-che",
-				},
-				{
-					Name:  "CHECLUSTER_CR_NAME",
-					Value: "eclipse-che",
-				},
-				{
-					Name:  "CHE_DASHBOARD_INTERNAL_URL",
-					Value: fmt.Sprintf("http://%s-dashboard.eclipse-che.svc:8080", defaults.GetCheFlavor()),
-				},
-				{
-					Name:  "CHE_INTERNAL_URL",
-					Value: "http://che-host.eclipse-che.svc:8080/api",
-				},
-				{
-					Name:  "CHE_WORKSPACE_PLUGIN__REGISTRY__INTERNAL__URL",
-					Value: "http://plugin-registry.eclipse-che.svc:8080/v3",
-				},
-				{
-					Name: "OPENSHIFT_CONSOLE_URL",
-				},
-				{
-					Name:  "CHE_DEFAULT_SPEC_COMPONENTS_DASHBOARD_HEADERMESSAGE_TEXT",
-					Value: defaults.GetDashboardHeaderMessageText(),
-				},
-				{
-					Name:  "CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR",
-					Value: defaults.GetDevEnvironmentsDefaultEditor(),
-				},
-				{
-					Name:  "CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS",
-					Value: defaults.GetDevEnvironmentsDefaultComponents(),
-				},
-				{
-					Name:  "CHE_DEFAULT_SPEC_COMPONENTS_DEVFILEREGISTRY_EXTERNAL_DEVFILE_REGISTRIES",
-					Value: defaults.GetDevfileRegistryExternalDevfileRegistries(),
-				},
-				{
-					Name:  "CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL",
-					Value: defaults.GetPluginRegistryOpenVSXURL(),
-				},
-				{
-					Name:  "CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DISABLECONTAINERBUILDCAPABILITIES",
-					Value: defaults.GetDevEnvironmentsDisableContainerBuildCapabilities(),
-				},
-				{
-					Name:  "CHE_DEFAULT_SPEC_DEVENVIRONMENTS_CONTAINERSECURITYCONTEXT",
-					Value: defaults.GetDevEnvironmentsContainerSecurityContext(),
-				},
-			},
-			cheCluster: &chev2.CheCluster{
+	ctx := test.GetDeployContext(
+		nil,
+		[]runtime.Object{
+			&configv1.Console{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "eclipse-che",
-					Name:      "eclipse-che",
+					Name:      "cluster",
+					Namespace: "openshift-console",
 				},
-				Status: chev2.CheClusterStatus{
-					CheURL: "https://che-host",
-				},
-			},
-		},
-		{
-			name: "Test provisioning OpenShift Console URL",
-			initObjects: []runtime.Object{
-				&configv1.Console{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cluster",
-						Namespace: "openshift-console",
-					},
-					Status: configv1.ConsoleStatus{
-						ConsoleURL: "https://console-openshift-console.apps.my-host/",
-					},
+				Status: configv1.ConsoleStatus{
+					ConsoleURL: "https://console-openshift-console.apps.my-host/",
 				},
 			},
-			envVars: []corev1.EnvVar{
-				{
-					Name:  "CHE_HOST",
-					Value: "https://che-host",
-				},
-				{
-					Name:  "CHE_URL",
-					Value: "https://che-host",
-				},
-				{
-					Name:  "CHECLUSTER_CR_NAMESPACE",
-					Value: "eclipse-che",
-				},
-				{
-					Name:  "CHECLUSTER_CR_NAME",
-					Value: "eclipse-che",
-				},
-				{
-					Name:  "CHE_DASHBOARD_INTERNAL_URL",
-					Value: fmt.Sprintf("http://%s-dashboard.eclipse-che.svc:8080", defaults.GetCheFlavor()),
-				},
-				{
-					Name:  "CHE_INTERNAL_URL",
-					Value: "http://che-host.eclipse-che.svc:8080/api",
-				},
-				{
-					Name:  "CHE_WORKSPACE_PLUGIN__REGISTRY__INTERNAL__URL",
-					Value: "http://plugin-registry.eclipse-che.svc:8080/v3",
-				},
-				{
-					Name:  "CHE_DEFAULT_SPEC_COMPONENTS_DEVFILEREGISTRY_EXTERNAL_DEVFILE_REGISTRIES",
-					Value: defaults.GetDevfileRegistryExternalDevfileRegistries(),
-				},
-				{
-					Name:  "OPENSHIFT_CONSOLE_URL",
-					Value: "https://console-openshift-console.apps.my-host/",
-				},
-				{
-					Name:  "CHE_DEFAULT_SPEC_COMPONENTS_DASHBOARD_HEADERMESSAGE_TEXT",
-					Value: defaults.GetDashboardHeaderMessageText(),
-				},
-				{
-					Name:  "CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR",
-					Value: defaults.GetDevEnvironmentsDefaultEditor(),
-				},
-				{
-					Name:  "CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS",
-					Value: defaults.GetDevEnvironmentsDefaultComponents(),
-				},
-				{
-					Name:  "CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL",
-					Value: defaults.GetPluginRegistryOpenVSXURL(),
-				},
-				{
-					Name:  "CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DISABLECONTAINERBUILDCAPABILITIES",
-					Value: defaults.GetDevEnvironmentsDisableContainerBuildCapabilities(),
-				},
-				{
-					Name:  "CHE_DEFAULT_SPEC_DEVENVIRONMENTS_CONTAINERSECURITYCONTEXT",
-					Value: defaults.GetDevEnvironmentsContainerSecurityContext(),
-				},
-			},
-			cheCluster: &chev2.CheCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "eclipse-che",
-					Name:      "eclipse-che",
-				},
-				Status: chev2.CheClusterStatus{
-					CheURL: "https://che-host",
-				},
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			logf.SetLogger(zap.New(zap.WriteTo(os.Stdout), zap.UseDevMode(true)))
-			ctx := test.GetDeployContext(testCase.cheCluster, testCase.initObjects)
-			ctx.ClusterAPI.DiscoveryClient.(*fakeDiscovery.FakeDiscovery).Fake.Resources = []*metav1.APIResourceList{
-				{
-					APIResources: []metav1.APIResource{
-						{Name: ConsoleLinksResourceName},
-					},
-				},
-			}
-
-			dashboard := NewDashboardReconciler()
-			deployment, err := dashboard.getDashboardDeploymentSpec(ctx)
-
-			assert.Nil(t, err)
-			assert.Equal(t, len(deployment.Spec.Template.Spec.Containers), 1)
-			test.AssertEqualEnvVars(t, testCase.envVars, deployment.Spec.Template.Spec.Containers[0].Env)
 		})
+	ctx.ClusterAPI.DiscoveryClient.(*fakeDiscovery.FakeDiscovery).Fake.Resources = []*metav1.APIResourceList{
+		{
+			APIResources: []metav1.APIResource{
+				{Name: ConsoleLinksResourceName},
+			},
+		},
 	}
+
+	deployment, err := NewDashboardReconciler().getDashboardDeploymentSpec(ctx)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "CHE_HOST",
+			Value: "https://che-host",
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "CHE_URL",
+			Value: "https://che-host",
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "CHE_HOST",
+			Value: "https://che-host",
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "CHECLUSTER_CR_NAMESPACE",
+			Value: "eclipse-che",
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "CHECLUSTER_CR_NAME",
+			Value: "eclipse-che",
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "CHE_INTERNAL_URL",
+			Value: "http://che-host.eclipse-che.svc:8080/api",
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "CHE_DASHBOARD_INTERNAL_URL",
+			Value: fmt.Sprintf("http://%s-dashboard.eclipse-che.svc:8080", defaults.GetCheFlavor()),
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "CHE_WORKSPACE_PLUGIN__REGISTRY__INTERNAL__URL",
+			Value: "http://plugin-registry.eclipse-che.svc:8080/v3",
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "CHE_DEFAULT_SPEC_COMPONENTS_DASHBOARD_HEADERMESSAGE_TEXT",
+			Value: defaults.GetDashboardHeaderMessageText(),
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR",
+			Value: defaults.GetDevEnvironmentsDefaultEditor(),
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS",
+			Value: defaults.GetDevEnvironmentsDefaultComponents(),
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL",
+			Value: defaults.GetPluginRegistryOpenVSXURL(),
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DISABLECONTAINERBUILDCAPABILITIES",
+			Value: defaults.GetDevEnvironmentsDisableContainerBuildCapabilities(),
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "CHE_DEFAULT_SPEC_DEVENVIRONMENTS_CONTAINERSECURITYCONTEXT",
+			Value: defaults.GetDevEnvironmentsContainerSecurityContext(),
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "OPENSHIFT_CONSOLE_URL",
+			Value: "https://console-openshift-console.apps.my-host/",
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "RELATED_IMAGE_sample_image",
+			Value: "sample_image",
+		})
+	assert.Contains(
+		t,
+		deployment.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "RELATED_IMAGE_sample_encoded_image",
+			Value: "sample_encoded_image",
+		})
 }
 
 func TestDashboardDeploymentVolumes(t *testing.T) {

--- a/pkg/deploy/dashboard/deployment_dashboard.go
+++ b/pkg/deploy/dashboard/deployment_dashboard.go
@@ -40,7 +40,6 @@ const (
 func (d *DashboardReconciler) getDashboardDeploymentSpec(ctx *chetypes.DeployContext) (*appsv1.Deployment, error) {
 	var volumes []corev1.Volume
 	var volumeMounts []corev1.VolumeMount
-	var envVars []corev1.EnvVar
 
 	volumes, volumeMounts = d.provisionCustomPublicCA(volumes, volumeMounts)
 
@@ -52,6 +51,9 @@ func (d *DashboardReconciler) getDashboardDeploymentSpec(ctx *chetypes.DeployCon
 		volumes, volumeMounts = d.provisionCheSelfSignedCA(volumes, volumeMounts)
 	}
 
+	// Get all env vars that are related to the sample components and add them to the deployment.
+	// They are used to replace images with tags on images with digests.
+	envVars := utils.GetGetArchitectureDependentEnvsByRegExp("^RELATED_IMAGE_sample_.*$")
 	envVars = append(envVars,
 		// todo handle HTTP_PROXY related env vars
 		// CHE_HOST is here for backward compatibility. Replaced with CHE_URL


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Mount RELATED_IMAGES_sample env vars into dashboard container

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-6918

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Prepare a patch file if needed:
```bash
cat > /tmp/cr-patch.yaml <<EOF
apiVersion: org.eclipse.che/v2
kind: CheCluster
spec: {}
EOF
```

2. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
