### PR TITLE
feat: Introduce new CheCluster CR field `MaxNumberOfRunningWorkspacesPerCluster`

### DIFF
--- a/api/v2/checluster_types.go
+++ b/api/v2/checluster_types.go
@@ -182,6 +182,12 @@ type CheClusterDevEnvironments struct {
 	// +kubebuilder:validation:Minimum:=-1
 	// +optional
 	MaxNumberOfRunningWorkspacesPerUser *int64 `json:"maxNumberOfRunningWorkspacesPerUser,omitempty"`
+	// The maximum number of concurrently running workspaces across the entire Kubernetes cluster.
+	// This applies to all users in the system. If the value is set to -1, it means there is
+	// no limit on the number of running workspaces.
+	// +kubebuilder:validation:Minimum:=-1
+	// +optional
+	MaxNumberOfRunningWorkspacesPerCluster *int64 `json:"maxNumberOfRunningWorkspacesPerCluster,omitempty"`
 	// User configuration.
 	// +optional
 	User *UserConfiguration `json:"user,omitempty"`

--- a/api/v2/zz_generated.deepcopy.go
+++ b/api/v2/zz_generated.deepcopy.go
@@ -297,6 +297,11 @@ func (in *CheClusterDevEnvironments) DeepCopyInto(out *CheClusterDevEnvironments
 		*out = new(int64)
 		**out = **in
 	}
+	if in.MaxNumberOfRunningWorkspacesPerCluster != nil {
+		in, out := &in.MaxNumberOfRunningWorkspacesPerCluster, &out.MaxNumberOfRunningWorkspacesPerCluster
+		*out = new(int64)
+		**out = **in
+	}
 	if in.User != nil {
 		in, out := &in.User, &out.User
 		*out = new(UserConfiguration)

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -104,7 +104,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che.v7.90.0-879.next
+  name: eclipse-che.v7.91.0-880.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1035,7 +1035,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Eclipse Foundation
-  version: 7.90.0-879.next
+  version: 7.91.0-880.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
@@ -7028,6 +7028,14 @@ spec:
                         - IfNotPresent
                         - Never
                       type: string
+                    maxNumberOfRunningWorkspacesPerCluster:
+                      description: |-
+                        The maximum number of concurrently running workspaces across the entire Kubernetes cluster.
+                        This applies to all users in the system. If the value is set to -1, it means there is
+                        no limit on the number of running workspaces.
+                      format: int64
+                      minimum: -1
+                      type: integer
                     maxNumberOfRunningWorkspacesPerUser:
                       description: |-
                         The maximum number of running workspaces per user.

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -6981,6 +6981,14 @@ spec:
                     - IfNotPresent
                     - Never
                     type: string
+                  maxNumberOfRunningWorkspacesPerCluster:
+                    description: |-
+                      The maximum number of concurrently running workspaces across the entire Kubernetes cluster.
+                      This applies to all users in the system. If the value is set to -1, it means there is
+                      no limit on the number of running workspaces.
+                    format: int64
+                    minimum: -1
+                    type: integer
                   maxNumberOfRunningWorkspacesPerUser:
                     description: |-
                       The maximum number of running workspaces per user.

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -7002,6 +7002,14 @@ spec:
                     - IfNotPresent
                     - Never
                     type: string
+                  maxNumberOfRunningWorkspacesPerCluster:
+                    description: |-
+                      The maximum number of concurrently running workspaces across the entire Kubernetes cluster.
+                      This applies to all users in the system. If the value is set to -1, it means there is
+                      no limit on the number of running workspaces.
+                    format: int64
+                    minimum: -1
+                    type: integer
                   maxNumberOfRunningWorkspacesPerUser:
                     description: |-
                       The maximum number of running workspaces per user.

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -6997,6 +6997,14 @@ spec:
                     - IfNotPresent
                     - Never
                     type: string
+                  maxNumberOfRunningWorkspacesPerCluster:
+                    description: |-
+                      The maximum number of concurrently running workspaces across the entire Kubernetes cluster.
+                      This applies to all users in the system. If the value is set to -1, it means there is
+                      no limit on the number of running workspaces.
+                    format: int64
+                    minimum: -1
+                    type: integer
                   maxNumberOfRunningWorkspacesPerUser:
                     description: |-
                       The maximum number of running workspaces per user.

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -7002,6 +7002,14 @@ spec:
                     - IfNotPresent
                     - Never
                     type: string
+                  maxNumberOfRunningWorkspacesPerCluster:
+                    description: |-
+                      The maximum number of concurrently running workspaces across the entire Kubernetes cluster.
+                      This applies to all users in the system. If the value is set to -1, it means there is
+                      no limit on the number of running workspaces.
+                    format: int64
+                    minimum: -1
+                    type: integer
                   maxNumberOfRunningWorkspacesPerUser:
                     description: |-
                       The maximum number of running workspaces per user.

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -6997,6 +6997,14 @@ spec:
                     - IfNotPresent
                     - Never
                     type: string
+                  maxNumberOfRunningWorkspacesPerCluster:
+                    description: |-
+                      The maximum number of concurrently running workspaces across the entire Kubernetes cluster.
+                      This applies to all users in the system. If the value is set to -1, it means there is
+                      no limit on the number of running workspaces.
+                    format: int64
+                    minimum: -1
+                    type: integer
                   maxNumberOfRunningWorkspacesPerUser:
                     description: |-
                       The maximum number of running workspaces per user.

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -6997,6 +6997,14 @@ spec:
                     - IfNotPresent
                     - Never
                     type: string
+                  maxNumberOfRunningWorkspacesPerCluster:
+                    description: |-
+                      The maximum number of concurrently running workspaces across the entire Kubernetes cluster.
+                      This applies to all users in the system. If the value is set to -1, it means there is
+                      no limit on the number of running workspaces.
+                    format: int64
+                    minimum: -1
+                    type: integer
                   maxNumberOfRunningWorkspacesPerUser:
                     description: |-
                       The maximum number of running workspaces per user.


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
feat: Introduce new CheCluster CR field `MaxNumberOfRunningWorkspacesPerCluster`

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse-che/che/issues/23081

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Prepare a patch file if needed:
```bash
cat > /tmp/cr-patch.yaml <<EOF
apiVersion: org.eclipse.che/v2
kind: CheCluster
spec: {}
EOF
```

2. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
