### PR TITLE
feat: set default ignoredUnrecoverableEvents

### DIFF
--- a/api/v2/checluster_types.go
+++ b/api/v2/checluster_types.go
@@ -203,8 +203,9 @@ type CheClusterDevEnvironments struct {
 	// if a transient cluster issue is triggering false-positives (for example, if
 	// the cluster occasionally encounters FailedScheduling events). Events listed
 	// here will not trigger workspace failures.
+	// +kubebuilder:default:={"FailedScheduling"}
 	// +optional
-	IgnoredUnrecoverableEvents []string `json:"ignoredUnrecoverableEvents,omitempty"`
+	IgnoredUnrecoverableEvents []string `json:"ignoredUnrecoverableEvents"`
 	// AllowedSources defines the allowed sources on which workspaces can be started.
 	// +optional
 	AllowedSources *AllowedSources `json:"allowedSources,omitempty"`

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -104,7 +104,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che.v7.92.0-885.next
+  name: eclipse-che.v7.92.0-886.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1035,7 +1035,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Eclipse Foundation
-  version: 7.92.0-885.next
+  version: 7.92.0-886.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
@@ -7025,6 +7025,8 @@ spec:
                           type: object
                       type: object
                     ignoredUnrecoverableEvents:
+                      default:
+                        - FailedScheduling
                       description: |-
                         IgnoredUnrecoverableEvents defines a list of Kubernetes event names that should
                         be ignored when deciding to fail a workspace that is starting. This option should be used

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -6978,6 +6978,8 @@ spec:
                         type: object
                     type: object
                   ignoredUnrecoverableEvents:
+                    default:
+                    - FailedScheduling
                     description: |-
                       IgnoredUnrecoverableEvents defines a list of Kubernetes event names that should
                       be ignored when deciding to fail a workspace that is starting. This option should be used

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -6999,6 +6999,8 @@ spec:
                         type: object
                     type: object
                   ignoredUnrecoverableEvents:
+                    default:
+                    - FailedScheduling
                     description: |-
                       IgnoredUnrecoverableEvents defines a list of Kubernetes event names that should
                       be ignored when deciding to fail a workspace that is starting. This option should be used

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -6994,6 +6994,8 @@ spec:
                         type: object
                     type: object
                   ignoredUnrecoverableEvents:
+                    default:
+                    - FailedScheduling
                     description: |-
                       IgnoredUnrecoverableEvents defines a list of Kubernetes event names that should
                       be ignored when deciding to fail a workspace that is starting. This option should be used

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -6999,6 +6999,8 @@ spec:
                         type: object
                     type: object
                   ignoredUnrecoverableEvents:
+                    default:
+                    - FailedScheduling
                     description: |-
                       IgnoredUnrecoverableEvents defines a list of Kubernetes event names that should
                       be ignored when deciding to fail a workspace that is starting. This option should be used

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -6994,6 +6994,8 @@ spec:
                         type: object
                     type: object
                   ignoredUnrecoverableEvents:
+                    default:
+                    - FailedScheduling
                     description: |-
                       IgnoredUnrecoverableEvents defines a list of Kubernetes event names that should
                       be ignored when deciding to fail a workspace that is starting. This option should be used

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -6994,6 +6994,8 @@ spec:
                         type: object
                     type: object
                   ignoredUnrecoverableEvents:
+                    default:
+                    - FailedScheduling
                     description: |-
                       IgnoredUnrecoverableEvents defines a list of Kubernetes event names that should
                       be ignored when deciding to fail a workspace that is starting. This option should be used


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Add FailedScheduling event by default to the list of ignored unrecoverable events.

Original DWO PR (to be closed): https://github.com/devfile/devworkspace-operator/pull/1310
Related issue: https://github.com/devfile/devworkspace-operator/issues/1280
Related docs issue: https://github.com/eclipse-che/che-docs/pull/2789

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Prepare a patch file if needed:
```bash
cat > /tmp/cr-patch.yaml <<EOF
apiVersion: org.eclipse.che/v2
kind: CheCluster
spec: {}
EOF
```

2. Deploy the operator: 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

#### on Minikube
```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

### To test how FailedScheduling event will be ignored by default with these changes:
1. With operator deployed and Che server started, open Che dashboard and create a workspace with exceeding limits:
  - Create workspace from this devfile, that has already set 512 GB memory request: https://github.com/mkuznyetsov/testing-devfiles
2. The startup of workspace is expected to fail, after reaching a timeout (5 minutes), with FailedScheduling event reported in the Dashboard error message / devworkspace status.

### To test, if FailedScheduling can be configured to not be ignored (pre-PR behaviour)
1. Apply this change to Che Custom Resource:
set spec.devEnvironments.ignoredUnrecoverableEvents field to empty
2. With operator deployed and Che server started, open Che dashboard and create a workspace with exceeding limits:
  - Create workspace from this devfile, that has already set 512 GB memory request: https://github.com/mkuznyetsov/testing-devfiles
3. The startup of workspace is expected to fail as soon as FailedScheduling event is encountered, which will be shown in the Dashboard error message / devworkspace status.



[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
