### PR TITLE
Use endpoint-specific service for discoverable endpoints

### DIFF
--- a/controllers/devworkspace/solver/che_routing.go
+++ b/controllers/devworkspace/solver/che_routing.go
@@ -344,7 +344,9 @@ func (c *CheRoutingSolver) getGatewayConfigsAndFillRoutingObjects(cheCluster *ch
 	if infraExposer, err := c.getInfraSpecificExposer(cheCluster, routing, objs, endpointStrategy); err != nil {
 		return nil, err
 	} else {
-		if workspaceConfig := exposeAllEndpoints(cheCluster, routing, objs, infraExposer, endpointStrategy); workspaceConfig != nil {
+		if workspaceConfig, err := exposeAllEndpoints(cheCluster, routing, objs, infraExposer, endpointStrategy); err != nil {
+			return nil, err
+		} else if workspaceConfig != nil {
 			configs = append(configs, *workspaceConfig)
 		}
 	}
@@ -485,26 +487,27 @@ func getServiceForEndpoint(objs *solvers.RoutingObjects, endpoint dwo.Endpoint) 
 }
 
 // Returns the appropriate service to use when exposing an endpoint.
+// If the appropriate service could not be found in the given routing objects, an error is returned.
+//
 // Endpoints with the "discoverable" attribute set have their own service that should be used.
 // Endpoints that do not set the "discoverable" attribute should use the common service associated with the workspace.
-func determineEndpointService(objs *solvers.RoutingObjects, endpoint dwo.Endpoint, commonService *corev1.Service) *corev1.Service {
+func determineEndpointService(objs *solvers.RoutingObjects, endpoint dwo.Endpoint, commonService *corev1.Service) (*corev1.Service, error) {
 	if endpoint.Attributes.GetBoolean(string(dwo.DiscoverableAttribute), nil) {
 		endpointService := getServiceForEndpoint(objs, endpoint)
 		if endpointService == nil {
-			return endpointService
-		} else {
-			logger.Error(fmt.Errorf("could not find endpoint-specfic service for endpoint '%s'", endpoint.Name), "Using common service instead.")
+			return nil, fmt.Errorf("could not find endpoint-specfic service for endpoint '%s'", endpoint.Name)
 		}
+		return endpointService, nil
 	}
-	return commonService
+	return commonService, nil
 }
 
-func exposeAllEndpoints(cheCluster *chev2.CheCluster, routing *dwo.DevWorkspaceRouting, objs *solvers.RoutingObjects, ingressExpose func(*EndpointInfo), endpointStrategy EndpointStrategy) *corev1.ConfigMap {
+func exposeAllEndpoints(cheCluster *chev2.CheCluster, routing *dwo.DevWorkspaceRouting, objs *solvers.RoutingObjects, ingressExpose func(*EndpointInfo), endpointStrategy EndpointStrategy) (*corev1.ConfigMap, error) {
 	wsRouteConfig := gateway.CreateEmptyTraefikConfig()
 
 	commonService := getCommonService(objs, routing.Spec.DevWorkspaceId)
 	if commonService == nil {
-		return nil
+		return nil, fmt.Errorf("could not find the common service for workspace '%s'", routing.Spec.DevWorkspaceId)
 	}
 
 	order := 1
@@ -532,7 +535,10 @@ func exposeAllEndpoints(cheCluster *chev2.CheCluster, routing *dwo.DevWorkspaceR
 			if e.Attributes.GetString(urlRewriteSupportedEndpointAttributeName, nil) == "true" {
 				addEndpointToTraefikConfig(componentName, e, wsRouteConfig, cheCluster, routing, endpointStrategy)
 			} else {
-				service := determineEndpointService(objs, e, commonService)
+				service, err := determineEndpointService(objs, e, commonService)
+				if err != nil {
+					return nil, err
+				}
 				ingressExpose(&EndpointInfo{
 					order:         order,
 					componentName: componentName,
@@ -550,6 +556,7 @@ func exposeAllEndpoints(cheCluster *chev2.CheCluster, routing *dwo.DevWorkspaceR
 	contents, err := yaml.Marshal(wsRouteConfig)
 	if err != nil {
 		logger.Error(err, "can't serialize traefik config")
+		return nil, err
 	}
 
 	wsConfigMap := &corev1.ConfigMap{
@@ -581,7 +588,7 @@ providers:
 log:
   level: "INFO"`, wsGatewayPort)
 
-	return wsConfigMap
+	return wsConfigMap, nil
 }
 
 func containPort(service *corev1.Service, port int32) bool {

--- a/controllers/devworkspace/solver/che_routing.go
+++ b/controllers/devworkspace/solver/che_routing.go
@@ -565,7 +565,7 @@ func getCommonService(objs *solvers.RoutingObjects, dwId string) *corev1.Service
 	return nil
 }
 
-func getServiceForEndpoint(objs *solvers.RoutingObjects, endpoint dwo.Endpoint) *corev1.Service {
+func getEndpointService(objs *solvers.RoutingObjects, endpoint dwo.Endpoint) *corev1.Service {
 	endpointServiceName := common.EndpointName(endpoint.Name)
 	for _, svc := range objs.Services {
 		if svc.Name == endpointServiceName {
@@ -580,9 +580,9 @@ func getServiceForEndpoint(objs *solvers.RoutingObjects, endpoint dwo.Endpoint) 
 //
 // Endpoints with the "discoverable" attribute set have their own service that should be used.
 // Endpoints that do not set the "discoverable" attribute should use the common service associated with the workspace.
-func getEndpointService(objs *solvers.RoutingObjects, endpoint dwo.Endpoint, commonService *corev1.Service) (*corev1.Service, error) {
+func determineEndpointService(objs *solvers.RoutingObjects, endpoint dwo.Endpoint, commonService *corev1.Service) (*corev1.Service, error) {
 	if endpoint.Attributes.GetBoolean(string(dwo.DiscoverableAttribute), nil) {
-		endpointService := getServiceForEndpoint(objs, endpoint)
+		endpointService := getEndpointService(objs, endpoint)
 		if endpointService == nil {
 			return nil, fmt.Errorf("could not find endpoint-specfic service for endpoint '%s'", endpoint.Name)
 		}


### PR DESCRIPTION
### What does this PR do?
When using the `discoverable` attribute on a devfile endpoint, a service is created for that specific endpoint that's associated with the route/ingress. However, the current behaviour of the Che Router always associates an endpoint with the workspace's common service, rather than any endpoint-specific service. 

This PR fixes this behaviour, by ensuring the correct service is provided for each endpoint's route/ingress.

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse-che/che/issues/23061


### How to test this PR?
1. Install Che using the changes from this PR by running:
 - On OpenShift: `./build/scripts/olm/test-catalog-from-sources.sh `
 - On Minikube: `./build/scripts/minikube-tests/test-operator-from-sources.sh`
 - Alternatively, I've built a Che-Operator image from this PR and pushed it to `quay.io/aobuchow/che-operator:endpoint-service`.
2. Once Che is installed, create a workspace using a devfile that has an endpoint with the discoverable attribute. For convenience, you can use my reproducer [devfile](https://github.com/AObuchow/python-minikube-test/tree/main).
```YAML
# Example endpoint with discoverable attribute
- exposure: public
  targetPort: 8080
  name: https-python
  protocol: http
  secure: true
  attributes:
    discoverable: true
```

4. In your workspace, start up a web server that uses the discoverable endpoint. Using my reproducer devfile, this can be accomplished by running the `pip-install-requirements` then `run-app` devfile tasks from the CheCode UI. When the endpoint notification pops up, click "Open in New Tab".
5. The web server should be available on the route provided. With my reproducer devfile, you'll see a page with `Hello World!`

For comparison, here's a [comment](https://github.com/eclipse-che/che/issues/23061#issuecomment-2259253935) displaying the behaviour without the changes from this PR applied.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
