### PR TITLE
fix: Remove plugin registry pod if openVSX configured (#1913)

### DIFF
--- a/api/v2/checluster_types.go
+++ b/api/v2/checluster_types.go
@@ -1034,11 +1034,14 @@ func (c *CheCluster) IsCheFlavor() bool {
 // IsEmbeddedOpenVSXRegistryConfigured returns true if the Open VSX Registry is configured to be embedded
 // only if only the `Spec.Components.PluginRegistry.OpenVSXURL` is empty.
 func (c *CheCluster) IsEmbeddedOpenVSXRegistryConfigured() bool {
-	openVSXURL := defaults.GetPluginRegistryOpenVSXURL()
 	if c.Spec.Components.PluginRegistry.OpenVSXURL != nil {
-		openVSXURL = *c.Spec.Components.PluginRegistry.OpenVSXURL
+		return *c.Spec.Components.PluginRegistry.OpenVSXURL == ""
 	}
-	return openVSXURL == ""
+	return defaults.GetPluginRegistryOpenVSXURL() == ""
+}
+
+func (c *CheCluster) IsInternalPluginRegistryDisabled() bool {
+	return c.Spec.Components.PluginRegistry.DisableInternalRegistry || !c.IsEmbeddedOpenVSXRegistryConfigured()
 }
 
 // IsCheBeingInstalled returns true if the Che version is not set in the status.

--- a/pkg/deploy/dashboard/dashboard_deployment_test.go
+++ b/pkg/deploy/dashboard/dashboard_deployment_test.go
@@ -228,13 +228,6 @@ func TestDashboardDeploymentEnvVars(t *testing.T) {
 		t,
 		deployment.Spec.Template.Spec.Containers[0].Env,
 		corev1.EnvVar{
-			Name:  "CHE_WORKSPACE_PLUGIN__REGISTRY__INTERNAL__URL",
-			Value: "http://plugin-registry.eclipse-che.svc:8080/v3",
-		})
-	assert.Contains(
-		t,
-		deployment.Spec.Template.Spec.Containers[0].Env,
-		corev1.EnvVar{
 			Name:  "CHE_DEFAULT_SPEC_COMPONENTS_DASHBOARD_HEADERMESSAGE_TEXT",
 			Value: defaults.GetDashboardHeaderMessageText(),
 		})

--- a/pkg/deploy/dashboard/deployment_dashboard.go
+++ b/pkg/deploy/dashboard/deployment_dashboard.go
@@ -83,7 +83,7 @@ func (d *DashboardReconciler) getDashboardDeploymentSpec(ctx *chetypes.DeployCon
 			Value: fmt.Sprintf("http://%s.%s.svc:8080/api", deploy.CheServiceName, ctx.CheCluster.Namespace)},
 	)
 
-	if !ctx.CheCluster.Spec.Components.PluginRegistry.DisableInternalRegistry {
+	if !ctx.CheCluster.IsInternalPluginRegistryDisabled() {
 		envVars = append(envVars,
 			corev1.EnvVar{
 				Name:  "CHE_WORKSPACE_PLUGIN__REGISTRY__INTERNAL__URL",

--- a/pkg/deploy/gateway/gateway_test.go
+++ b/pkg/deploy/gateway/gateway_test.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/utils/pointer"
+
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 	chev2 "github.com/eclipse-che/che-operator/api/v2"
 	"github.com/eclipse-che/che-operator/pkg/common/chetypes"
@@ -170,6 +172,7 @@ func TestOauthProxyConfigUnauthorizedPaths(t *testing.T) {
 					Components: chev2.CheClusterComponents{
 						PluginRegistry: chev2.PluginRegistry{
 							DisableInternalRegistry: false,
+							OpenVSXURL:              pointer.String(""),
 						},
 					}},
 			}, nil)

--- a/pkg/deploy/gateway/oauth_proxy.go
+++ b/pkg/deploy/gateway/oauth_proxy.go
@@ -160,7 +160,7 @@ cookie_domains = "%s"
 
 func skipAuthConfig(instance *chev2.CheCluster) string {
 	var skipAuthPaths []string
-	if !instance.Spec.Components.PluginRegistry.DisableInternalRegistry {
+	if !instance.IsInternalPluginRegistryDisabled() {
 		skipAuthPaths = append(skipAuthPaths, "^/"+constants.PluginRegistryName)
 	}
 	skipAuthPaths = append(skipAuthPaths, "^/$")

--- a/pkg/deploy/pluginregistry/pluginregistry_test.go
+++ b/pkg/deploy/pluginregistry/pluginregistry_test.go
@@ -13,21 +13,39 @@
 package pluginregistry
 
 import (
+	"os"
+
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
+	chev2 "github.com/eclipse-che/che-operator/api/v2"
+	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 
 	"testing"
 )
 
-func TestPluginRegistryReconcile(t *testing.T) {
+func TestShouldDeployPluginRegistryIfOpenVSXIsEmpty(t *testing.T) {
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
 
-	ctx := test.GetDeployContext(nil, []runtime.Object{})
+	ctx := test.GetDeployContext(&chev2.CheCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eclipse-che",
+			Namespace: "eclipse-che",
+		},
+		Spec: chev2.CheClusterSpec{
+			Components: chev2.CheClusterComponents{
+				PluginRegistry: chev2.PluginRegistry{
+					OpenVSXURL: pointer.String(""),
+				},
+			},
+		},
+	}, []runtime.Object{})
 
 	pluginregistry := NewPluginRegistryReconciler()
 	_, done, err := pluginregistry.Reconcile(ctx)
@@ -38,4 +56,97 @@ func TestPluginRegistryReconcile(t *testing.T) {
 	assert.True(t, test.IsObjectExists(ctx.ClusterAPI.Client, types.NamespacedName{Name: "plugin-registry", Namespace: "eclipse-che"}, &corev1.ConfigMap{}))
 	assert.True(t, test.IsObjectExists(ctx.ClusterAPI.Client, types.NamespacedName{Name: "plugin-registry", Namespace: "eclipse-che"}, &appsv1.Deployment{}))
 	assert.NotEmpty(t, ctx.CheCluster.Status.PluginRegistryURL)
+}
+
+func TestShouldDeployPluginRegistryIfOpenVSXIsEmptyByDefault(t *testing.T) {
+	defaultOpenVSXURL := os.Getenv("CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL")
+
+	err := os.Unsetenv("CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL")
+	assert.NoError(t, err)
+
+	defer func() {
+		_ = os.Setenv("CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL", defaultOpenVSXURL)
+	}()
+
+	// re initialize defaults with new env var
+	defaults.Initialize()
+
+	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
+
+	ctx := test.GetDeployContext(&chev2.CheCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eclipse-che",
+			Namespace: "eclipse-che",
+		},
+	}, []runtime.Object{})
+
+	pluginregistry := NewPluginRegistryReconciler()
+	_, done, err := pluginregistry.Reconcile(ctx)
+	assert.True(t, done)
+	assert.Nil(t, err)
+
+	assert.True(t, test.IsObjectExists(ctx.ClusterAPI.Client, types.NamespacedName{Name: "plugin-registry", Namespace: "eclipse-che"}, &corev1.Service{}))
+	assert.True(t, test.IsObjectExists(ctx.ClusterAPI.Client, types.NamespacedName{Name: "plugin-registry", Namespace: "eclipse-che"}, &corev1.ConfigMap{}))
+	assert.True(t, test.IsObjectExists(ctx.ClusterAPI.Client, types.NamespacedName{Name: "plugin-registry", Namespace: "eclipse-che"}, &appsv1.Deployment{}))
+	assert.NotEmpty(t, ctx.CheCluster.Status.PluginRegistryURL)
+}
+
+func TestShouldNotDeployPluginRegistryIfOpenVSXConfigured(t *testing.T) {
+	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
+
+	ctx := test.GetDeployContext(&chev2.CheCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eclipse-che",
+			Namespace: "eclipse-che",
+		},
+		Spec: chev2.CheClusterSpec{
+			Components: chev2.CheClusterComponents{
+				PluginRegistry: chev2.PluginRegistry{
+					OpenVSXURL: pointer.String("https://openvsx.org"),
+				},
+			},
+		},
+	}, []runtime.Object{})
+
+	pluginregistry := NewPluginRegistryReconciler()
+	_, done, err := pluginregistry.Reconcile(ctx)
+	assert.True(t, done)
+	assert.Nil(t, err)
+
+	assert.False(t, test.IsObjectExists(ctx.ClusterAPI.Client, types.NamespacedName{Name: "plugin-registry", Namespace: "eclipse-che"}, &corev1.Service{}))
+	assert.False(t, test.IsObjectExists(ctx.ClusterAPI.Client, types.NamespacedName{Name: "plugin-registry", Namespace: "eclipse-che"}, &corev1.ConfigMap{}))
+	assert.False(t, test.IsObjectExists(ctx.ClusterAPI.Client, types.NamespacedName{Name: "plugin-registry", Namespace: "eclipse-che"}, &appsv1.Deployment{}))
+	assert.Empty(t, ctx.CheCluster.Status.PluginRegistryURL)
+}
+
+func TestShouldNotDeployPluginRegistryIfOpenVSXConfiguredByDefault(t *testing.T) {
+	defaultOpenVSXURL := os.Getenv("CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL")
+	err := os.Setenv("CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL", "https://openvsx.org")
+	assert.NoError(t, err)
+
+	defer func() {
+		_ = os.Setenv("CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL", defaultOpenVSXURL)
+	}()
+
+	// re initialize defaults with new env var
+	defaults.Initialize()
+
+	infrastructure.InitializeForTesting(infrastructure.OpenShiftv4)
+
+	ctx := test.GetDeployContext(&chev2.CheCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "eclipse-che",
+			Namespace: "eclipse-che",
+		},
+	}, []runtime.Object{})
+
+	pluginregistry := NewPluginRegistryReconciler()
+	_, done, err := pluginregistry.Reconcile(ctx)
+	assert.True(t, done)
+	assert.Nil(t, err)
+
+	assert.False(t, test.IsObjectExists(ctx.ClusterAPI.Client, types.NamespacedName{Name: "plugin-registry", Namespace: "eclipse-che"}, &corev1.Service{}))
+	assert.False(t, test.IsObjectExists(ctx.ClusterAPI.Client, types.NamespacedName{Name: "plugin-registry", Namespace: "eclipse-che"}, &corev1.ConfigMap{}))
+	assert.False(t, test.IsObjectExists(ctx.ClusterAPI.Client, types.NamespacedName{Name: "plugin-registry", Namespace: "eclipse-che"}, &appsv1.Deployment{}))
+	assert.Empty(t, ctx.CheCluster.Status.PluginRegistryURL)
 }

--- a/pkg/deploy/server/server_configmap.go
+++ b/pkg/deploy/server/server_configmap.go
@@ -142,7 +142,7 @@ func (s *CheServerReconciler) getCheConfigMapData(ctx *chetypes.DeployContext) (
 	cheAPI := "https://" + ctx.CheHost + "/api"
 	var pluginRegistryInternalURL string
 
-	if !ctx.CheCluster.Spec.Components.PluginRegistry.DisableInternalRegistry {
+	if !ctx.CheCluster.IsInternalPluginRegistryDisabled() {
 		pluginRegistryInternalURL = fmt.Sprintf("http://%s.%s.svc:8080/v3", constants.PluginRegistryName, ctx.CheCluster.Namespace)
 	}
 

--- a/pkg/deploy/server/server_configmap_test.go
+++ b/pkg/deploy/server/server_configmap_test.go
@@ -15,6 +15,8 @@ package server
 import (
 	"testing"
 
+	"k8s.io/utils/pointer"
+
 	"github.com/devfile/devworkspace-operator/pkg/infrastructure"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
 	"github.com/stretchr/testify/assert"
@@ -348,6 +350,14 @@ func TestShouldSetUpCorrectlyPluginRegistryURL(t *testing.T) {
 			cheCluster: &chev2.CheCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "eclipse-che",
+				},
+				Spec: chev2.CheClusterSpec{
+					Components: chev2.CheClusterComponents{
+						PluginRegistry: chev2.PluginRegistry{
+							DisableInternalRegistry: false,
+							OpenVSXURL:              pointer.String(""),
+						},
+					},
 				},
 				Status: chev2.CheClusterStatus{
 					PluginRegistryURL: "internal-plugin-registry",


### PR DESCRIPTION
* fix: Remove plugin registry pod if openVSX configured

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Remove plugin registry pod if openVSX configured

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-7473

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Prepare a patch file if needed:
```bash
cat > /tmp/cr-patch.yaml <<EOF
apiVersion: org.eclipse.che/v2
kind: CheCluster
spec: {}
EOF
```

2. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
