### PR TITLE
chore: Add logger to track reconcilers invocation

### DIFF
--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -104,7 +104,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/eclipse-che/che-operator
     support: Eclipse Foundation
-  name: eclipse-che.v7.94.0-888.next
+  name: eclipse-che.v7.94.0-889.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1035,7 +1035,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Eclipse Foundation
-  version: 7.94.0-888.next
+  version: 7.94.0-889.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/pkg/deploy/container-build/container_build.go
+++ b/pkg/deploy/container-build/container_build.go
@@ -47,28 +47,28 @@ func (cb *ContainerBuildReconciler) Reconcile(ctx *chetypes.DeployContext) (reco
 		// The check below to avoid NPE while CheCluster is not updated with defaults.
 		if ctx.CheCluster.IsOpenShiftSecurityContextConstraintSet() {
 			if done, err := cb.syncSCC(ctx); !done {
-				return reconcile.Result{}, false, err
+				return reconcile.Result{Requeue: true}, false, err
 			}
 
 			if done, err := cb.syncRBAC(ctx); !done {
-				return reconcile.Result{}, false, err
+				return reconcile.Result{Requeue: true}, false, err
 			}
 
 			if err := deploy.AppendFinalizer(ctx, cb.getFinalizerName()); err != nil {
-				return reconcile.Result{}, false, err
+				return reconcile.Result{Requeue: true}, false, err
 			}
 		}
 	} else {
 		if done, err := cb.removeRBAC(ctx); !done {
-			return reconcile.Result{}, false, err
+			return reconcile.Result{Requeue: true}, false, err
 		}
 
 		if done, err := cb.removeSCC(ctx); !done {
-			return reconcile.Result{}, false, err
+			return reconcile.Result{Requeue: true}, false, err
 		}
 
 		if err := deploy.DeleteFinalizer(ctx, cb.getFinalizerName()); err != nil {
-			return reconcile.Result{}, false, err
+			return reconcile.Result{Requeue: true}, false, err
 		}
 	}
 

--- a/pkg/deploy/dev-workspace-config/dev_workspace_config.go
+++ b/pkg/deploy/dev-workspace-config/dev_workspace_config.go
@@ -67,11 +67,8 @@ func (d *DevWorkspaceConfigReconciler) Reconcile(ctx *chetypes.DeployContext) (r
 		return reconcile.Result{}, false, err
 	}
 
-	if done, err := deploy.Sync(ctx, dwoc); !done {
-		return reconcile.Result{}, false, err
-	}
-
-	return reconcile.Result{}, true, nil
+	done, err := deploy.Sync(ctx, dwoc)
+	return reconcile.Result{Requeue: !done}, done, err
 }
 
 func (d *DevWorkspaceConfigReconciler) Finalize(ctx *chetypes.DeployContext) bool {

--- a/pkg/deploy/reconcile_manager.go
+++ b/pkg/deploy/reconcile_manager.go
@@ -74,7 +74,7 @@ func (manager *ReconcileManager) ReconcileAll(ctx *chetypes.DeployContext) (reco
 		result, done, err := reconciler.Reconcile(ctx)
 
 		if manager.operationLogger != nil {
-			manager.operationLogger.Printf("Reconciler [%s] done: %t, err: %v", reconcilerName, done, err)
+			manager.operationLogger.Printf("Reconciler [%s] done: %t", reconcilerName, done)
 		}
 
 		if err != nil {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
* Add logger to track reconcilers invocation
* Force reconcile when devworkspaceoperatorconfig is updated

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse-che/che/issues/23167

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Prepare a patch file if needed:
```bash
cat > /tmp/cr-patch.yaml <<EOF
apiVersion: org.eclipse.che/v2
kind: CheCluster
spec: {}
EOF
```

2. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
