### PR TITLE
chore: add mkuznyetsov as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @SDawley @tolusha @ibuziuk 
+* @SDawley @tolusha @ibuziuk @mkuznyetsov


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
chore: add mkuznyetsov as codeowner