### PR TITLE
Backport update nonProxyHosts documentation to 7.92.x

### DIFF
--- a/api/v2/checluster_types.go
+++ b/api/v2/checluster_types.go
@@ -629,11 +629,13 @@ type Proxy struct {
 	// A list of hosts that can be reached directly, bypassing the proxy.
 	// Specify wild card domain use the following form `.<DOMAIN>`, for example:
 	//    - localhost
+	//    - 127.0.0.1
 	//    - my.host.com
 	//    - 123.42.12.32
 	// Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration,
 	// defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources.
 	// See the following page: https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html.
+	// In some proxy configurations, localhost may not translate to 127.0.0.1. Both localhost and 127.0.0.1 should be specified in this situation.
 	// +optional
 	NonProxyHosts []string `json:"nonProxyHosts,omitempty"`
 	// The secret name that contains `user` and `password` for a proxy server.

--- a/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
@@ -4379,11 +4379,13 @@ spec:
                                 A list of hosts that can be reached directly, bypassing the proxy.
                                 Specify wild card domain use the following form `.<DOMAIN>`, for example:
                                    - localhost
+                                   - 127.0.0.1
                                    - my.host.com
                                    - 123.42.12.32
                                 Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration,
                                 defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources.
                                 See the following page: https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html.
+                                In some proxy configurations, localhost may not translate to 127.0.0.1. Both localhost and 127.0.0.1 should be specified in this situation.
                               items:
                                 type: string
                               type: array

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -4343,11 +4343,13 @@ spec:
                               A list of hosts that can be reached directly, bypassing the proxy.
                               Specify wild card domain use the following form `.<DOMAIN>`, for example:
                                  - localhost
+                                 - 127.0.0.1
                                  - my.host.com
                                  - 123.42.12.32
                               Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration,
                               defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources.
                               See the following page: https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html.
+                              In some proxy configurations, localhost may not translate to 127.0.0.1. Both localhost and 127.0.0.1 should be specified in this situation.
                             items:
                               type: string
                             type: array

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -4364,11 +4364,13 @@ spec:
                               A list of hosts that can be reached directly, bypassing the proxy.
                               Specify wild card domain use the following form `.<DOMAIN>`, for example:
                                  - localhost
+                                 - 127.0.0.1
                                  - my.host.com
                                  - 123.42.12.32
                               Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration,
                               defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources.
                               See the following page: https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html.
+                              In some proxy configurations, localhost may not translate to 127.0.0.1. Both localhost and 127.0.0.1 should be specified in this situation.
                             items:
                               type: string
                             type: array

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -4359,11 +4359,13 @@ spec:
                               A list of hosts that can be reached directly, bypassing the proxy.
                               Specify wild card domain use the following form `.<DOMAIN>`, for example:
                                  - localhost
+                                 - 127.0.0.1
                                  - my.host.com
                                  - 123.42.12.32
                               Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration,
                               defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources.
                               See the following page: https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html.
+                              In some proxy configurations, localhost may not translate to 127.0.0.1. Both localhost and 127.0.0.1 should be specified in this situation.
                             items:
                               type: string
                             type: array

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -4364,11 +4364,13 @@ spec:
                               A list of hosts that can be reached directly, bypassing the proxy.
                               Specify wild card domain use the following form `.<DOMAIN>`, for example:
                                  - localhost
+                                 - 127.0.0.1
                                  - my.host.com
                                  - 123.42.12.32
                               Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration,
                               defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources.
                               See the following page: https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html.
+                              In some proxy configurations, localhost may not translate to 127.0.0.1. Both localhost and 127.0.0.1 should be specified in this situation.
                             items:
                               type: string
                             type: array

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -4359,11 +4359,13 @@ spec:
                               A list of hosts that can be reached directly, bypassing the proxy.
                               Specify wild card domain use the following form `.<DOMAIN>`, for example:
                                  - localhost
+                                 - 127.0.0.1
                                  - my.host.com
                                  - 123.42.12.32
                               Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration,
                               defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources.
                               See the following page: https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html.
+                              In some proxy configurations, localhost may not translate to 127.0.0.1. Both localhost and 127.0.0.1 should be specified in this situation.
                             items:
                               type: string
                             type: array

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -4359,11 +4359,13 @@ spec:
                               A list of hosts that can be reached directly, bypassing the proxy.
                               Specify wild card domain use the following form `.<DOMAIN>`, for example:
                                  - localhost
+                                 - 127.0.0.1
                                  - my.host.com
                                  - 123.42.12.32
                               Use only when a proxy configuration is required. The Operator respects OpenShift cluster-wide proxy configuration,
                               defining `nonProxyHosts` in a custom resource leads to merging non-proxy hosts lists from the cluster proxy configuration, and the ones defined in the custom resources.
                               See the following page: https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html.
+                              In some proxy configurations, localhost may not translate to 127.0.0.1. Both localhost and 127.0.0.1 should be specified in this situation.
                             items:
                               type: string
                             type: array


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
This PR cherry picks the commit from this PR: https://github.com/eclipse-che/che-operator/pull/1915 to the 7.92.x branch.

For https://issues.redhat.com/browse/CRW-7266

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
