### PR TITLE
chore: sync only custom certificate instead of whole bundle

### DIFF
--- a/pkg/common/conf/conf.go
+++ b/pkg/common/conf/conf.go
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package conf
+
+import "github.com/eclipse-che/che-operator/pkg/common/utils"
+
+var (
+	// since 7.98.0
+	// The namespace where the custom certificate ConfigMap is stored
+	// See https://docs.openshift.com/container-platform/latest/security/certificates/updating-ca-bundle.html
+	CertificatesOpenShiftConfigNamespaceName = &CheOperatorConf{
+		EnvName:      "CHE_OPERATOR_CERTIFICATES_OPENSHIFT_CONFIG_NAMESPACE_NAME",
+		defaultValue: "openshift-config",
+	}
+
+	// since 7.98.0
+	// The key name containing the custom certificate in the ConfigMap
+	// See https://docs.openshift.com/container-platform/latest/security/certificates/updating-ca-bundle.html
+	CertificatesOpenShiftCustomCertificateConfigMapKeyName = &CheOperatorConf{
+		EnvName:      "CHE_OPERATOR_CERTIFICATES_OPENSHIFT_CUSTOM_CERTIFICATE_CONFIGMAP_KEY_NAME",
+		defaultValue: "ca-bundle.crt",
+	}
+
+	// since 7.98.0
+	// Introduce a new behavior to sync only custom certificates
+	// "false" means previous behaviour when the whole OpenShift certificates bundle was synced
+	// by adding "config.openshift.io/inject-trusted-cabundle=true" label
+	// https://docs.openshift.com/container-platform/latest/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki
+	CertificatesSyncCustomOpenShiftCertificateOnly = &CheOperatorConf{
+		EnvName:      "CHE_OPERATOR_CERTIFICATES_SYNC_CUSTOM_OPENSHIFT_CERTIFICATE_ONLY",
+		defaultValue: "true",
+	}
+)
+
+type CheOperatorConf struct {
+	EnvName      string
+	defaultValue string
+}
+
+func Get(conf *CheOperatorConf) string {
+	return utils.GetEnvOrDefault(conf.EnvName, conf.defaultValue)
+}

--- a/pkg/common/utils/env.go
+++ b/pkg/common/utils/env.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019-2023 Red Hat, Inc.
+// Copyright (c) 2019-2025 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -70,7 +70,7 @@ func doGetEnvsByRegExp(regExp string, isArchitectureDependentEnvNameNeeded bool)
 	return env
 }
 
-// GetArchitectureDependentEnvName returns environment variable name dependending on architecture
+// GetArchitectureDependentEnvName returns environment variable name depending on architecture
 // by adding "_<ARCHITECTURE>" suffix. If variable is not set then the default will be return.
 func GetArchitectureDependentEnvName(name string) string {
 	archName := name + "_" + runtime.GOARCH
@@ -79,4 +79,12 @@ func GetArchitectureDependentEnvName(name string) string {
 	}
 
 	return name
+}
+
+// GetEnvOrDefault returns environment variable value or default value if variable is not set.
+func GetEnvOrDefault(name string, defaultValue string) string {
+	if value, ok := os.LookupEnv(name); ok {
+		return value
+	}
+	return defaultValue
 }

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019-2023 Red Hat, Inc.
+// Copyright (c) 2019-2025 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -13,6 +13,7 @@
 package utils
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -104,4 +105,27 @@ func TestMergeMaps(t *testing.T) {
 
 	actual := MergeMaps([]map[string]string{nil, map1, nil, map2, make(map[string]string)})
 	assert.Equal(t, expected, actual)
+}
+
+func TestGetEnvOrDefault(t *testing.T) {
+	var tests = []struct {
+		envName       string
+		envValue      string
+		defaultValue  string
+		expectedValue string
+	}{
+		{"env1", "", "default1", "default1"},
+		{"env2", "value2", "default2", "value2"},
+	}
+
+	_ = os.Setenv("env2", "value2")
+
+	defer func() {
+		_ = os.Unsetenv("env1")
+		_ = os.Unsetenv("env2")
+	}()
+
+	for _, test := range tests {
+		assert.Equal(t, test.expectedValue, GetEnvOrDefault(test.envName, test.defaultValue))
+	}
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
chore: sync only custom certificate instead of whole bundle

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-8316

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Prepare a patch file if needed:
```bash
cat > /tmp/cr-patch.yaml <<EOF
apiVersion: org.eclipse.che/v2
kind: CheCluster
spec: {}
EOF
```

2. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
