### PR TITLE
chore: Improve mounting certs into users containers

### DIFF
--- a/api/v2/zz_generated.deepcopy.go
+++ b/api/v2/zz_generated.deepcopy.go
@@ -19,7 +19,7 @@ package v2
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/api/v2/zz_generated.deepcopy.go
+++ b/api/v2/zz_generated.deepcopy.go
@@ -19,7 +19,7 @@ package v2
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/controllers/usernamespace/usernamespace_controller_test.go
+++ b/controllers/usernamespace/usernamespace_controller_test.go
@@ -268,15 +268,6 @@ func TestCreatesDataInNamespace(t *testing.T) {
 		assert.Equal(t, corev1.SecretTypeOpaque, cert.Type, "Unexpected secret type")
 		assert.Equal(t, true, *cert.Immutable, "Unexpected mutability of the secret")
 
-		caCerts := corev1.ConfigMap{}
-		assert.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "che-trusted-ca-certs", Namespace: namespace.GetName()}, &caCerts))
-		assert.Equal(t, "file", caCerts.GetAnnotations()[dwconstants.DevWorkspaceMountAsAnnotation], "trusted certs should be annotated as mount as 'file'")
-		assert.Equal(t, "/public-certs", caCerts.GetAnnotations()[dwconstants.DevWorkspaceMountPathAnnotation], "trusted certs annotated as mounted to an unexpected path")
-		assert.Equal(t, "true", caCerts.GetLabels()[dwconstants.DevWorkspaceMountLabel], "trusted certs should be labeled as mounted")
-		assert.Equal(t, 2, len(caCerts.Data), "Expecting exactly 2 data entries in the trusted cert config map")
-		assert.Equal(t, "trusted cert 1", string(caCerts.Data["trusted1"]), "Unexpected trusted cert 1 value")
-		assert.Equal(t, "trusted cert 2", string(caCerts.Data["trusted2"]), "Unexpected trusted cert 2 value")
-
 		gitTlsConfig := corev1.ConfigMap{}
 		assert.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "che-git-tls-creds", Namespace: namespace.GetName()}, &gitTlsConfig))
 		assert.Equal(t, "true", gitTlsConfig.Labels[dwconstants.DevWorkspaceGitTLSLabel])

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -91,6 +91,8 @@ const (
 	CheEclipseOrgScmServerEndpoint                  = "che.eclipse.org/scm-server-endpoint"
 	CheEclipseOrgManagedAnnotationsDigest           = "che.eclipse.org/managed-annotations-digest"
 	CheEclipseOrgScmGitHubDisableSubdomainIsolation = "che.eclipse.org/scm-github-disable-subdomain-isolation"
+	OpenShiftIOOwningComponent                      = "openshift.io/owning-component"
+	ConfigOpenShiftIOInjectTrustedCaBundle          = "config.openshift.io/inject-trusted-cabundle"
 
 	// DevEnvironments
 	PerUserPVCStorageStrategy      = "per-user"

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -128,6 +128,7 @@ const (
 	WorkspacesConfig      = "workspaces-config"
 	InstallOrUpdateFailed = "InstallOrUpdateFailed"
 	FinalizerSuffix       = "finalizers.che.eclipse.org"
+	PublicCertsDir        = "/public-certs"
 
 	// DevWorkspace
 	DevWorkspaceServiceAccountName = "devworkspace-controller-serviceaccount"

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -224,9 +224,6 @@ func AddMap(a map[string]string, b map[string]string) {
 func MergeMaps(maps []map[string]string) map[string]string {
 	result := make(map[string]string)
 	for _, m := range maps {
-		//if m == nil {
-		//	continue
-		//}
 		for k, v := range m {
 			result[k] = v
 		}

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -153,7 +153,7 @@ func GetPullPolicyFromDockerImage(dockerImage string) string {
 	return "IfNotPresent"
 }
 
-func GetMap(value map[string]string, defaultValue map[string]string) map[string]string {
+func GetMapOrDefault(value map[string]string, defaultValue map[string]string) map[string]string {
 	ret := value
 	if len(value) < 1 {
 		ret = defaultValue
@@ -224,6 +224,9 @@ func AddMap(a map[string]string, b map[string]string) {
 func MergeMaps(maps []map[string]string) map[string]string {
 	result := make(map[string]string)
 	for _, m := range maps {
+		//if m == nil {
+		//	continue
+		//}
 		for k, v := range m {
 			result[k] = v
 		}

--- a/pkg/deploy/configmap.go
+++ b/pkg/deploy/configmap.go
@@ -15,8 +15,6 @@ package deploy
 import (
 	"reflect"
 
-	"github.com/eclipse-che/che-operator/pkg/common/utils"
-
 	"github.com/eclipse-che/che-operator/pkg/common/chetypes"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -53,17 +51,6 @@ func InitConfigMap(
 	}
 }
 
-// EnsureConfigMapDefaults ensures that the ConfigMap has all the required fields.
-func EnsureConfigMapDefaults(cm *corev1.ConfigMap) {
-	cm.TypeMeta = metav1.TypeMeta{
-		Kind:       "ConfigMap",
-		APIVersion: "v1",
-	}
-	cm.Data = utils.GetMap(cm.Data, map[string]string{})
-	cm.Labels = utils.GetMap(cm.Labels, map[string]string{})
-	cm.Annotations = utils.GetMap(cm.Annotations, map[string]string{})
-}
-
 func SyncConfigMapDataToCluster(
 	deployContext *chetypes.DeployContext,
 	name string,
@@ -85,12 +72,12 @@ func SyncConfigMapSpecToCluster(
 func SyncConfigMap(
 	ctx *chetypes.DeployContext,
 	cm *corev1.ConfigMap,
-	ensureLabels []string,
-	ensureAnnotations []string) (bool, error) {
+	ensuredLabels []string,
+	ensuredAnnotations []string) (bool, error) {
 
 	diffs := cmp.Options{
 		cmpopts.IgnoreFields(corev1.ConfigMap{}, "TypeMeta"),
-		GetLabelsAndAnnotationsComparator(ensureLabels, ensureAnnotations),
+		GetLabelsAndAnnotationsComparator(ensuredLabels, ensuredAnnotations),
 	}
 
 	return Sync(ctx, cm, diffs)
@@ -100,13 +87,13 @@ func SyncConfigMap(
 func SyncConfigMapIgnoreData(
 	ctx *chetypes.DeployContext,
 	cm *corev1.ConfigMap,
-	ensureLabels []string,
-	ensureAnnotations []string) (bool, error) {
+	ensuredLabels []string,
+	ensuredAnnotations []string) (bool, error) {
 
 	diffs := cmp.Options{
 		cmpopts.IgnoreFields(corev1.ConfigMap{}, "TypeMeta"),
 		cmpopts.IgnoreFields(corev1.ConfigMap{}, "Data"),
-		GetLabelsAndAnnotationsComparator(ensureLabels, ensureAnnotations),
+		GetLabelsAndAnnotationsComparator(ensuredLabels, ensuredAnnotations),
 	}
 
 	return Sync(ctx, cm, diffs)

--- a/pkg/deploy/configmap_test.go
+++ b/pkg/deploy/configmap_test.go
@@ -94,14 +94,14 @@ func TestSyncConfigMapSpecDataToCluster(t *testing.T) {
 		},
 	}
 
-	spec := GetConfigMapSpec(deployContext, "test", map[string]string{"a": "b"}, "che")
+	spec := InitConfigMap(deployContext, "test", map[string]string{"a": "b"}, "che")
 	done, err := SyncConfigMapSpecToCluster(deployContext, spec)
 	if !done || err != nil {
 		t.Fatalf("Failed to sync config map: %v", err)
 	}
 
 	// check if labels
-	spec = GetConfigMapSpec(deployContext, "test", map[string]string{"a": "b"}, "che")
+	spec = InitConfigMap(deployContext, "test", map[string]string{"a": "b"}, "che")
 	spec.ObjectMeta.Labels = map[string]string{"l": "v"}
 	_, err = SyncConfigMapSpecToCluster(deployContext, spec)
 	if err != nil {

--- a/pkg/deploy/gateway/gateway.go
+++ b/pkg/deploy/gateway/gateway.go
@@ -276,7 +276,7 @@ func GetConfigmapForGatewayConfig(
 			Namespace: deployContext.CheCluster.Namespace,
 			Labels: labels.Merge(
 				deploy.GetLabels(gatewayConfigComponentName),
-				utils.GetMap(deployContext.CheCluster.Spec.Networking.Auth.Gateway.ConfigLabels, constants.DefaultSingleHostGatewayConfigMapLabels)),
+				utils.GetMapOrDefault(deployContext.CheCluster.Spec.Networking.Auth.Gateway.ConfigLabels, constants.DefaultSingleHostGatewayConfigMapLabels)),
 		},
 		Data: map[string]string{
 			componentName + ".yml": string(gatewayConfigContent),
@@ -499,7 +499,7 @@ func getGatewayDeploymentSpec(ctx *chetypes.DeployContext) (*appsv1.Deployment, 
 }
 
 func getContainersSpec(ctx *chetypes.DeployContext) []corev1.Container {
-	configLabelsMap := utils.GetMap(ctx.CheCluster.Spec.Networking.Auth.Gateway.ConfigLabels, constants.DefaultSingleHostGatewayConfigMapLabels)
+	configLabelsMap := utils.GetMapOrDefault(ctx.CheCluster.Spec.Networking.Auth.Gateway.ConfigLabels, constants.DefaultSingleHostGatewayConfigMapLabels)
 	gatewayImage := defaults.GetGatewayImage(ctx.CheCluster)
 	configSidecarImage := defaults.GetGatewayConfigSidecarImage(ctx.CheCluster)
 	configLabels := labels.FormatLabels(configLabelsMap)

--- a/pkg/deploy/labels.go
+++ b/pkg/deploy/labels.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019-2023 Red Hat, Inc.
+// Copyright (c) 2019-2025 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -25,6 +25,19 @@ func GetLabels(component string) map[string]string {
 		constants.KubernetesComponentLabelKey: component,
 		constants.KubernetesManagedByLabelKey: GetManagedByLabel(),
 	}
+}
+
+func GetDefaultKubernetesLabelsWith(labels ...string) []string {
+	defaultK8sLabels := append(
+		[]string{
+			constants.KubernetesNameLabelKey,
+			constants.KubernetesInstanceLabelKey,
+			constants.KubernetesPartOfLabelKey,
+			constants.KubernetesComponentLabelKey,
+			constants.KubernetesManagedByLabelKey,
+		}, labels...)
+
+	return defaultK8sLabels
 }
 
 func GetManagedByLabel() string {

--- a/pkg/deploy/sync.go
+++ b/pkg/deploy/sync.go
@@ -203,17 +203,17 @@ func DeleteIgnoreIfNotFound(
 }
 
 func GetLabelsAndAnnotationsComparator(
-	ensureLabels []string,
-	ensureAnnotations []string) cmp.Option {
+	ensuredLabels []string,
+	ensuredAnnotations []string) cmp.Option {
 
 	return cmp.Comparer(func(x, y metav1.ObjectMeta) bool {
-		for _, label := range ensureLabels {
+		for _, label := range ensuredLabels {
 			if x.Labels[label] != y.Labels[label] {
 				return false
 			}
 		}
 
-		for _, annotation := range ensureAnnotations {
+		for _, annotation := range ensuredAnnotations {
 			if x.Annotations[annotation] != y.Annotations[annotation] {
 				return false
 			}

--- a/pkg/deploy/sync.go
+++ b/pkg/deploy/sync.go
@@ -202,6 +202,27 @@ func DeleteIgnoreIfNotFound(
 	return err
 }
 
+func GetLabelsAndAnnotationsComparator(
+	ensureLabels []string,
+	ensureAnnotations []string) cmp.Option {
+
+	return cmp.Comparer(func(x, y metav1.ObjectMeta) bool {
+		for _, label := range ensureLabels {
+			if x.Labels[label] != y.Labels[label] {
+				return false
+			}
+		}
+
+		for _, annotation := range ensureAnnotations {
+			if x.Annotations[annotation] != y.Annotations[annotation] {
+				return false
+			}
+		}
+
+		return true
+	})
+}
+
 // doCreate creates object.
 // Return error if object cannot be created otherwise returns nil.
 func doCreate(

--- a/pkg/deploy/tls/certificates_test.go
+++ b/pkg/deploy/tls/certificates_test.go
@@ -15,6 +15,9 @@ package tls
 import (
 	"context"
 
+	dwconstants "github.com/devfile/devworkspace-operator/pkg/constants"
+	"k8s.io/utils/pointer"
+
 	"github.com/eclipse-che/che-operator/pkg/common/constants"
 
 	"testing"
@@ -31,43 +34,127 @@ import (
 func TestSyncOpenShiftCABundleCertificates(t *testing.T) {
 	ctx := test.GetDeployContext(nil, []runtime.Object{})
 
-	certificates := NewCertificatesReconciler()
+	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
 
-	done, err := certificates.syncOpenShiftCABundleCertificates(ctx)
+	caCertsCM := &corev1.ConfigMap{}
+	err := ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
 	assert.Nil(t, err)
-	assert.True(t, done)
+	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
+	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
+	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
 
-	cm := &corev1.ConfigMap{}
-	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, cm)
+	caCertsMergedCM := &corev1.ConfigMap{}
+	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs-merged", Namespace: "eclipse-che"}, caCertsMergedCM)
 	assert.Nil(t, err)
-	assert.Equal(t, "true", cm.ObjectMeta.Labels[injectTrustedCaBundle])
-	assert.Equal(t, constants.CheEclipseOrg, cm.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
-	assert.Equal(t, constants.CheCABundle, cm.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, constants.WorkspacesConfig, caCertsMergedCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, kubernetesCABundleCertsDir, caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountPathAnnotation])
+	assert.Equal(t, "subpath", caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountAsAnnotation])
 }
 
-func TestSyncExistedOpenShiftCABundleCertificates(t *testing.T) {
-	openShiftCABundleCM := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ca-certs",
-			Namespace: "eclipse-che",
-			Labels:    map[string]string{"a": "b"},
-		},
-		Data: map[string]string{"d": "c"},
-	}
-	ctx := test.GetDeployContext(nil, []runtime.Object{openShiftCABundleCM})
+func TestSyncOnlyCustomOpenShiftCertificates(t *testing.T) {
+	ctx := test.GetDeployContext(
+		nil,
+		[]runtime.Object{
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "custom-openshift-certs-cm",
+					Namespace: "openshift-config",
+				},
+				Data: map[string]string{
+					"ca.crt": "custom-openshift-cert",
+				},
+			}})
+	ctx.CheCluster.Spec.DevEnvironments.TrustedCerts = &chev2.TrustedCerts{DisableWorkspaceCaBundleMount: pointer.Bool(true)}
+	ctx.Proxy.TrustedCAMapName = "custom-openshift-certs-cm"
 
-	certificates := NewCertificatesReconciler()
-	_, err := certificates.syncOpenShiftCABundleCertificates(ctx)
-	assert.NoError(t, err)
+	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
 
 	cm := &corev1.ConfigMap{}
-	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, cm)
-	assert.NoError(t, err)
-	assert.Equal(t, "true", cm.ObjectMeta.Labels[injectTrustedCaBundle])
+	err := ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, cm)
+	assert.Nil(t, err)
+	assert.Empty(t, cm.ObjectMeta.Labels[injectTrustedCaBundle])
 	assert.Equal(t, constants.CheEclipseOrg, cm.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
 	assert.Equal(t, constants.CheCABundle, cm.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
-	assert.Equal(t, "b", cm.ObjectMeta.Labels["a"])
-	assert.Equal(t, "c", cm.Data["d"])
+	assert.Equal(t, "custom-openshift-cert", cm.Data["ca.crt"])
+
+	caCertsMergedCM := &corev1.ConfigMap{}
+	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs-merged", Namespace: "eclipse-che"}, caCertsMergedCM)
+	assert.Nil(t, err)
+	assert.Equal(t, constants.WorkspacesConfig, caCertsMergedCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, constants.PublicCertsDir, caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountPathAnnotation])
+	assert.Equal(t, "file", caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountAsAnnotation])
+}
+
+func TestToggleDisableWorkspaceCaBundleMount(t *testing.T) {
+	// Enable workspace CA bundle mount
+	ctx := test.GetDeployContext(nil, []runtime.Object{})
+
+	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
+
+	caCertsCM := &corev1.ConfigMap{}
+	err := ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
+	assert.Nil(t, err)
+	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
+	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
+	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+
+	caCertsMergedCM := &corev1.ConfigMap{}
+	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs-merged", Namespace: "eclipse-che"}, caCertsMergedCM)
+	assert.Nil(t, err)
+	assert.Equal(t, constants.WorkspacesConfig, caCertsMergedCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, kubernetesCABundleCertsDir, caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountPathAnnotation])
+	assert.Equal(t, "subpath", caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountAsAnnotation])
+
+	// Disable workspace CA bundle mount
+	ctx.CheCluster.Spec.DevEnvironments.TrustedCerts = &chev2.TrustedCerts{DisableWorkspaceCaBundleMount: pointer.Bool(true)}
+	ctx.Proxy.TrustedCAMapName = "custom-openshift-certs-caCertsCM"
+	err = ctx.ClusterAPI.Client.Create(
+		context.TODO(),
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "custom-openshift-certs-caCertsCM",
+				Namespace: "openshift-config",
+			},
+			Data: map[string]string{
+				"ca.crt": "custom-openshift-cert",
+			},
+		})
+	assert.NoError(t, err)
+
+	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
+
+	caCertsCM = &corev1.ConfigMap{}
+	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
+	assert.Nil(t, err)
+	assert.Empty(t, caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
+	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
+	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, "custom-openshift-cert", caCertsCM.Data["ca.crt"])
+
+	caCertsMergedCM = &corev1.ConfigMap{}
+	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs-merged", Namespace: "eclipse-che"}, caCertsMergedCM)
+	assert.Nil(t, err)
+	assert.Equal(t, constants.WorkspacesConfig, caCertsMergedCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, constants.PublicCertsDir, caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountPathAnnotation])
+	assert.Equal(t, "file", caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountAsAnnotation])
+
+	// Enable workspace CA bundle mount
+	ctx.CheCluster.Spec.DevEnvironments.TrustedCerts = &chev2.TrustedCerts{DisableWorkspaceCaBundleMount: pointer.Bool(false)}
+	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
+
+	caCertsCM = &corev1.ConfigMap{}
+	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
+	assert.Nil(t, err)
+	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
+	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
+	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+
+	caCertsMergedCM = &corev1.ConfigMap{}
+	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs-merged", Namespace: "eclipse-che"}, caCertsMergedCM)
+	assert.Nil(t, err)
+	assert.Equal(t, constants.WorkspacesConfig, caCertsMergedCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, kubernetesCABundleCertsDir, caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountPathAnnotation])
+	assert.Equal(t, "subpath", caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountAsAnnotation])
 }
 
 func TestSyncKubernetesCABundleCertificates(t *testing.T) {

--- a/pkg/deploy/tls/certificates_test.go
+++ b/pkg/deploy/tls/certificates_test.go
@@ -14,6 +14,7 @@ package tls
 
 import (
 	"context"
+	"strings"
 
 	dwconstants "github.com/devfile/devworkspace-operator/pkg/constants"
 	"k8s.io/utils/pointer"
@@ -49,6 +50,37 @@ func TestSyncOpenShiftCABundleCertificates(t *testing.T) {
 	assert.Equal(t, constants.WorkspacesConfig, caCertsMergedCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
 	assert.Equal(t, kubernetesCABundleCertsDir, caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountPathAnnotation])
 	assert.Equal(t, "subpath", caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountAsAnnotation])
+	assert.Equal(t, "ca-certs#1", strings.TrimSpace(caCertsMergedCM.ObjectMeta.Annotations[cheCABundleIncludedCMRevisions]))
+	assert.Empty(t, caCertsMergedCM.Data)
+}
+
+func TestSyncEmptyOpenShiftCABundleCertificates(t *testing.T) {
+	ctx := test.GetDeployContext(nil, []runtime.Object{})
+
+	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
+
+	caCertsCM := &corev1.ConfigMap{}
+	err := ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
+	assert.NoError(t, err)
+	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
+	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
+	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+
+	// Let's pretend that OpenShift Network operator inject the CA bundle
+	caCertsCM.Data = map[string]string{"ca-bundle.crt": "openshift-ca-bundle"}
+	err = ctx.ClusterAPI.Client.Update(context.TODO(), caCertsCM)
+	assert.NoError(t, err)
+
+	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
+
+	caCertsMergedCM := &corev1.ConfigMap{}
+	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs-merged", Namespace: "eclipse-che"}, caCertsMergedCM)
+	assert.Nil(t, err)
+	assert.Equal(t, constants.WorkspacesConfig, caCertsMergedCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, kubernetesCABundleCertsDir, caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountPathAnnotation])
+	assert.Equal(t, "subpath", caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountAsAnnotation])
+	assert.Equal(t, "ca-certs#2", strings.TrimSpace(caCertsMergedCM.ObjectMeta.Annotations[cheCABundleIncludedCMRevisions]))
+	assert.Equal(t, caCertsMergedCM.Data["tls-ca-bundle.pem"], "# ConfigMap: ca-certs,  Key: ca-bundle.crt\nopenshift-ca-bundle\n\n")
 }
 
 func TestSyncOnlyCustomOpenShiftCertificates(t *testing.T) {
@@ -57,15 +89,15 @@ func TestSyncOnlyCustomOpenShiftCertificates(t *testing.T) {
 		[]runtime.Object{
 			&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "custom-openshift-certs-cm",
+					Name:      "custom-openshift-trusted-certs-cm",
 					Namespace: "openshift-config",
 				},
 				Data: map[string]string{
-					"ca.crt": "custom-openshift-cert",
+					"ca-bundle.crt": "openshift-cert",
 				},
 			}})
 	ctx.CheCluster.Spec.DevEnvironments.TrustedCerts = &chev2.TrustedCerts{DisableWorkspaceCaBundleMount: pointer.Bool(true)}
-	ctx.Proxy.TrustedCAMapName = "custom-openshift-certs-cm"
+	ctx.Proxy.TrustedCAMapName = "custom-openshift-trusted-certs-cm"
 
 	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
 
@@ -75,7 +107,7 @@ func TestSyncOnlyCustomOpenShiftCertificates(t *testing.T) {
 	assert.Empty(t, cm.ObjectMeta.Labels[injectTrustedCaBundle])
 	assert.Equal(t, constants.CheEclipseOrg, cm.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
 	assert.Equal(t, constants.CheCABundle, cm.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
-	assert.Equal(t, "custom-openshift-cert", cm.Data["ca.crt"])
+	assert.Equal(t, "openshift-cert", cm.Data["ca-bundle.crt"])
 
 	caCertsMergedCM := &corev1.ConfigMap{}
 	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs-merged", Namespace: "eclipse-che"}, caCertsMergedCM)
@@ -83,78 +115,7 @@ func TestSyncOnlyCustomOpenShiftCertificates(t *testing.T) {
 	assert.Equal(t, constants.WorkspacesConfig, caCertsMergedCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
 	assert.Equal(t, constants.PublicCertsDir, caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountPathAnnotation])
 	assert.Equal(t, "file", caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountAsAnnotation])
-}
-
-func TestToggleDisableWorkspaceCaBundleMount(t *testing.T) {
-	// Enable workspace CA bundle mount
-	ctx := test.GetDeployContext(nil, []runtime.Object{})
-
-	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
-
-	caCertsCM := &corev1.ConfigMap{}
-	err := ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
-	assert.Nil(t, err)
-	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
-	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
-	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
-
-	caCertsMergedCM := &corev1.ConfigMap{}
-	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs-merged", Namespace: "eclipse-che"}, caCertsMergedCM)
-	assert.Nil(t, err)
-	assert.Equal(t, constants.WorkspacesConfig, caCertsMergedCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
-	assert.Equal(t, kubernetesCABundleCertsDir, caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountPathAnnotation])
-	assert.Equal(t, "subpath", caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountAsAnnotation])
-
-	// Disable workspace CA bundle mount
-	ctx.CheCluster.Spec.DevEnvironments.TrustedCerts = &chev2.TrustedCerts{DisableWorkspaceCaBundleMount: pointer.Bool(true)}
-	ctx.Proxy.TrustedCAMapName = "custom-openshift-certs-caCertsCM"
-	err = ctx.ClusterAPI.Client.Create(
-		context.TODO(),
-		&corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "custom-openshift-certs-caCertsCM",
-				Namespace: "openshift-config",
-			},
-			Data: map[string]string{
-				"ca.crt": "custom-openshift-cert",
-			},
-		})
-	assert.NoError(t, err)
-
-	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
-
-	caCertsCM = &corev1.ConfigMap{}
-	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
-	assert.Nil(t, err)
-	assert.Empty(t, caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
-	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
-	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
-	assert.Equal(t, "custom-openshift-cert", caCertsCM.Data["ca.crt"])
-
-	caCertsMergedCM = &corev1.ConfigMap{}
-	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs-merged", Namespace: "eclipse-che"}, caCertsMergedCM)
-	assert.Nil(t, err)
-	assert.Equal(t, constants.WorkspacesConfig, caCertsMergedCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
-	assert.Equal(t, constants.PublicCertsDir, caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountPathAnnotation])
-	assert.Equal(t, "file", caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountAsAnnotation])
-
-	// Enable workspace CA bundle mount
-	ctx.CheCluster.Spec.DevEnvironments.TrustedCerts = &chev2.TrustedCerts{DisableWorkspaceCaBundleMount: pointer.Bool(false)}
-	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
-
-	caCertsCM = &corev1.ConfigMap{}
-	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
-	assert.Nil(t, err)
-	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
-	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
-	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
-
-	caCertsMergedCM = &corev1.ConfigMap{}
-	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs-merged", Namespace: "eclipse-che"}, caCertsMergedCM)
-	assert.Nil(t, err)
-	assert.Equal(t, constants.WorkspacesConfig, caCertsMergedCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
-	assert.Equal(t, kubernetesCABundleCertsDir, caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountPathAnnotation])
-	assert.Equal(t, "subpath", caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountAsAnnotation])
+	assert.Equal(t, caCertsMergedCM.Data["tls-ca-bundle.pem"], "# ConfigMap: ca-certs,  Key: ca-bundle.crt\nopenshift-cert\n\n")
 }
 
 func TestSyncKubernetesCABundleCertificates(t *testing.T) {
@@ -309,4 +270,99 @@ func TestSyncCheCABundleCerts(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "cert1#1 cert2#1 ", cm.ObjectMeta.Annotations["che.eclipse.org/included-configmaps"])
 	assert.Equal(t, cm.Data[kubernetesCABundleCertsFile], "# ConfigMap: cert1,  Key: a1\nb1\n\n# ConfigMap: cert2,  Key: a2\nb2\n\n")
+}
+
+func TestToggleDisableWorkspaceCaBundleMount(t *testing.T) {
+	// Enable workspace CA bundle mount
+	ctx := test.GetDeployContext(
+		nil,
+		[]runtime.Object{
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "custom-openshift-trusted-certs-cm",
+					Namespace: "openshift-config",
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": "openshift-cert",
+				},
+			}})
+	ctx.Proxy.TrustedCAMapName = "custom-openshift-trusted-certs-cm"
+	ctx.CheCluster.Spec.DevEnvironments.TrustedCerts = &chev2.TrustedCerts{DisableWorkspaceCaBundleMount: pointer.Bool(false)}
+
+	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
+
+	caCertsCM := &corev1.ConfigMap{}
+	err := ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
+	assert.Nil(t, err)
+	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
+	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
+	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+
+	// Let's pretend that OpenShift Network operator inject the CA bundle
+	caCertsCM.Data = map[string]string{"ca-bundle.crt": "openshift-ca-bundle"}
+	err = ctx.ClusterAPI.Client.Update(context.TODO(), caCertsCM)
+	assert.NoError(t, err)
+
+	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
+
+	caCertsMergedCM := &corev1.ConfigMap{}
+	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs-merged", Namespace: "eclipse-che"}, caCertsMergedCM)
+	assert.Nil(t, err)
+	assert.Equal(t, constants.WorkspacesConfig, caCertsMergedCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, kubernetesCABundleCertsDir, caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountPathAnnotation])
+	assert.Equal(t, "subpath", caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountAsAnnotation])
+	assert.Equal(t, "ca-certs#2", strings.TrimSpace(caCertsMergedCM.ObjectMeta.Annotations[cheCABundleIncludedCMRevisions]))
+	assert.Equal(t, caCertsMergedCM.Data["tls-ca-bundle.pem"], "# ConfigMap: ca-certs,  Key: ca-bundle.crt\nopenshift-ca-bundle\n\n")
+	assert.Equal(t, 1, len(caCertsMergedCM.Data))
+
+	// Disable workspace CA bundle mount
+	ctx.CheCluster.Spec.DevEnvironments.TrustedCerts = &chev2.TrustedCerts{DisableWorkspaceCaBundleMount: pointer.Bool(true)}
+
+	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
+
+	caCertsCM = &corev1.ConfigMap{}
+	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
+	assert.Nil(t, err)
+	assert.Empty(t, caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
+	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
+	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, "openshift-cert", caCertsCM.Data["ca-bundle.crt"])
+
+	caCertsMergedCM = &corev1.ConfigMap{}
+	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs-merged", Namespace: "eclipse-che"}, caCertsMergedCM)
+	assert.Nil(t, err)
+	assert.Equal(t, constants.WorkspacesConfig, caCertsMergedCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, constants.PublicCertsDir, caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountPathAnnotation])
+	assert.Equal(t, "file", caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountAsAnnotation])
+	assert.Equal(t, "ca-certs#3", strings.TrimSpace(caCertsMergedCM.ObjectMeta.Annotations[cheCABundleIncludedCMRevisions]))
+	assert.Equal(t, caCertsMergedCM.Data["tls-ca-bundle.pem"], "# ConfigMap: ca-certs,  Key: ca-bundle.crt\nopenshift-cert\n\n")
+	assert.Equal(t, 1, len(caCertsMergedCM.Data))
+
+	// Enable workspace CA bundle mount
+	ctx.CheCluster.Spec.DevEnvironments.TrustedCerts = &chev2.TrustedCerts{DisableWorkspaceCaBundleMount: pointer.Bool(false)}
+	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
+
+	caCertsCM = &corev1.ConfigMap{}
+	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
+	assert.Nil(t, err)
+	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
+	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
+	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+
+	// Let's pretend that OpenShift Network operator inject the CA bundle
+	caCertsCM.Data = map[string]string{"ca-bundle.crt": "openshift-ca-bundle-new"}
+	err = ctx.ClusterAPI.Client.Update(context.TODO(), caCertsCM)
+	assert.NoError(t, err)
+
+	test.EnsureReconcile(t, ctx, NewCertificatesReconciler().Reconcile)
+
+	caCertsMergedCM = &corev1.ConfigMap{}
+	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs-merged", Namespace: "eclipse-che"}, caCertsMergedCM)
+	assert.Nil(t, err)
+	assert.Equal(t, constants.WorkspacesConfig, caCertsMergedCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, kubernetesCABundleCertsDir, caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountPathAnnotation])
+	assert.Equal(t, "subpath", caCertsMergedCM.ObjectMeta.Annotations[dwconstants.DevWorkspaceMountAsAnnotation])
+	assert.Equal(t, "ca-certs#5", strings.TrimSpace(caCertsMergedCM.ObjectMeta.Annotations[cheCABundleIncludedCMRevisions]))
+	assert.Equal(t, caCertsMergedCM.Data["tls-ca-bundle.pem"], "# ConfigMap: ca-certs,  Key: ca-bundle.crt\nopenshift-ca-bundle-new\n\n")
+	assert.Equal(t, 1, len(caCertsMergedCM.Data))
 }

--- a/pkg/deploy/tls/certificates_test.go
+++ b/pkg/deploy/tls/certificates_test.go
@@ -40,7 +40,7 @@ func TestSyncOpenShiftCABundleCertificates(t *testing.T) {
 	caCertsCM := &corev1.ConfigMap{}
 	err := ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
 	assert.Nil(t, err)
-	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
+	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[constants.ConfigOpenShiftIOInjectTrustedCaBundle])
 	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
 	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
 
@@ -62,7 +62,7 @@ func TestSyncEmptyOpenShiftCABundleCertificates(t *testing.T) {
 	caCertsCM := &corev1.ConfigMap{}
 	err := ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
 	assert.NoError(t, err)
-	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
+	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[constants.ConfigOpenShiftIOInjectTrustedCaBundle])
 	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
 	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
 
@@ -104,7 +104,7 @@ func TestSyncOnlyCustomOpenShiftCertificates(t *testing.T) {
 	cm := &corev1.ConfigMap{}
 	err := ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, cm)
 	assert.Nil(t, err)
-	assert.Empty(t, cm.ObjectMeta.Labels[injectTrustedCaBundle])
+	assert.Empty(t, cm.ObjectMeta.Labels[constants.ConfigOpenShiftIOInjectTrustedCaBundle])
 	assert.Equal(t, constants.CheEclipseOrg, cm.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
 	assert.Equal(t, constants.CheCABundle, cm.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
 	assert.Equal(t, "openshift-cert", cm.Data["ca-bundle.crt"])
@@ -294,7 +294,7 @@ func TestToggleDisableWorkspaceCaBundleMount(t *testing.T) {
 	caCertsCM := &corev1.ConfigMap{}
 	err := ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
 	assert.Nil(t, err)
-	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
+	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[constants.ConfigOpenShiftIOInjectTrustedCaBundle])
 	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
 	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
 
@@ -323,7 +323,7 @@ func TestToggleDisableWorkspaceCaBundleMount(t *testing.T) {
 	caCertsCM = &corev1.ConfigMap{}
 	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
 	assert.Nil(t, err)
-	assert.Empty(t, caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
+	assert.Empty(t, caCertsCM.ObjectMeta.Labels[constants.ConfigOpenShiftIOInjectTrustedCaBundle])
 	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
 	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
 	assert.Equal(t, "openshift-cert", caCertsCM.Data["ca-bundle.crt"])
@@ -345,7 +345,7 @@ func TestToggleDisableWorkspaceCaBundleMount(t *testing.T) {
 	caCertsCM = &corev1.ConfigMap{}
 	err = ctx.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: "ca-certs", Namespace: "eclipse-che"}, caCertsCM)
 	assert.Nil(t, err)
-	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[injectTrustedCaBundle])
+	assert.Equal(t, "true", caCertsCM.ObjectMeta.Labels[constants.ConfigOpenShiftIOInjectTrustedCaBundle])
 	assert.Equal(t, constants.CheEclipseOrg, caCertsCM.ObjectMeta.Labels[constants.KubernetesPartOfLabelKey])
 	assert.Equal(t, constants.CheCABundle, caCertsCM.ObjectMeta.Labels[constants.KubernetesComponentLabelKey])
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
1. Removing the `che-trusted-ca-certs` ConfigMap from user namespaces. These ConfigMaps were used to mount certificates into the /public-certs directory.
2.  The `ca-certs-merged` ConfigMap is created in the user namespace and is merged either into the `/public-certs` directory or `/etc/pki/ca-trust/extracted/pem`, depending on the value of `spec.devEnvironments.trustedCerts.disableWorkspaceCaBundleMount`

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-8316

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Deploy a next Eclipse Che version 
```sh
chectl update next
chectl server:deploy -p openshift 
```

2. Login Eclipse Che (open dashboard)

3. Observe a size of two ConfigMaps in a user namespace (pretty big)
```sh
~ oc get configmaps -n <..> ca-certs-merged -o json | jq '.data."tls-ca-bundle.pem" | length'
238783
~ oc get configmaps -n <..> che-trusted-ca-certs -o json | jq '.data."tls-ca-bundle.pem" | length'
~ 238783
```

5. Update Eclipse Che with a new changes
```sh
chectl server:update --che-operator-image=quay.io/abazko/operator:CRW-8316
```
6.  Wait until operator completes reconciliation

7. Check that  `che-trusted-ca-certs` doesn't exist in a user namespace
```sh
~ oc get configmaps -n <..> che-trusted-ca-certs 
configmaps "che-trusted-ca-certs" not found
```

8. Start an empty workspace

9. Ensure there is no anymore `/public-certs` directory mounted
```sh
oc exec -n <user_namespace> <workspace_pod> -c universal-developer-image -- ls /public-certs
```

10. Ensure that `tls-ca-bundle.pem` file is a new file in the directory
```sh
oc exec -n <user_namespace> <workspace_pod> -c universal-developer-image -- ls /etc/pki/ca-trust/extracted/pem -l
```

11. Check it content, ensure it contains content from `kube-root-ca.crt`, `self-signed-certificate` and `ca-certs` ConfigMaps
```sh
oc exec -n <user_namespace> <workspace_pod> -c universal-developer-image -- cat /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem | less
```
12. Stop a user workspace

13. Add custom certificate into OpenShift following the doc:
https://docs.openshift.com/container-platform/4.17/security/certificates/updating-ca-bundle.html#ca-bundle-replacing_updating-ca-bundle

14. After a while start a user workspace again

15. Recheck step 11, ensure `tls-ca-bundle.pem` contains recently added certificate from step 13

16. Disable workspace mounting certs
```sh
oc patch checluster eclipse-che -n eclipse-che --patch '{"spec": {"devEnvironments": {"trustedCerts": {"disableWorkspaceCaBundleMount": true}}}}' --type=merge
```

17. Wait workspace is restarted

18. Step 10 is not correct anymore, all files have the same creation date

19. The size of `ca-certs-merged` is pretty small:
```sh
~ oc get configmaps -n <..> ca-certs-merged -o json | jq '.data."tls-ca-bundle.pem" | length'
10986
```

20. Check the content of `tls-ca-bundle.pem` in `/public-certs` dir. Ensure it contains content from `kube-root-ca.crt`, `self-signed-certificate` and `ca-certs` ConfigMaps
```sh
oc exec -n <user_namespace> <workspace-pod> -c universal-developer-image -- cat /public-certs/tls-ca-bundle.pem
```

21. Ensure that `ca-certs` ConfigMap contains only certs from step 3
```sh
oc get configmaps -n eclipse-che ca-certs -o yaml
```

22. Do any editor tests

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
