### PR TITLE
chore: Improve managing labels during replicating objects in users na…

### DIFF
--- a/api/v2/zz_generated.deepcopy.go
+++ b/api/v2/zz_generated.deepcopy.go
@@ -19,7 +19,7 @@ package v2
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -109,6 +109,10 @@ spec:
               value: 'false'
             - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_CONTAINERSECURITYCONTEXT
               value: '{"allowPrivilegeEscalation": true,"capabilities": {"add": ["SETGID", "SETUID"]}}'
+            - name: CHE_OPERATOR_WORKSPACES_CONFIG_CONTROLLER_LABELS_TO_REMOVE_BEFORE_SYNC_REGEXP
+              value: 'argocd[.]argoproj[.]io/.+'
+            - name: CHE_OPERATOR_WORKSPACES_CONFIG_CONTROLLER_ANNOTATIONS_TO_REMOVE_BEFORE_SYNC_REGEXP
+              value: ''
           livenessProbe:
             httpGet:
               path: /healthz

--- a/controllers/usernamespace/configmap2sync.go
+++ b/controllers/usernamespace/configmap2sync.go
@@ -44,11 +44,12 @@ func (p *configMap2Sync) newDstObject() client.Object {
 		Name:        p.cm.GetName(),
 		Annotations: p.cm.GetAnnotations(),
 		Labels: utils.MergeMaps([]map[string]string{
-			p.cm.GetLabels(),
 			{
 				dwconstants.DevWorkspaceWatchConfigMapLabel: "true",
 				dwconstants.DevWorkspaceMountLabel:          "true",
-			}}),
+			},
+			p.cm.GetLabels(),
+		}),
 	}
 
 	return dst.(client.Object)

--- a/controllers/usernamespace/secret2sync.go
+++ b/controllers/usernamespace/secret2sync.go
@@ -44,11 +44,12 @@ func (p *secret2Sync) newDstObject() client.Object {
 		Name:        p.secret.GetName(),
 		Annotations: p.secret.GetAnnotations(),
 		Labels: utils.MergeMaps([]map[string]string{
-			p.secret.GetLabels(),
 			{
 				dwconstants.DevWorkspaceWatchSecretLabel: "true",
 				dwconstants.DevWorkspaceMountLabel:       "true",
-			}}),
+			},
+			p.secret.GetLabels(),
+		}),
 	}
 
 	return dst.(client.Object)

--- a/controllers/usernamespace/secret2sync_test.go
+++ b/controllers/usernamespace/secret2sync_test.go
@@ -14,6 +14,7 @@ package usernamespace
 
 import (
 	"context"
+	dwconstants "github.com/devfile/devworkspace-operator/pkg/constants"
 	"sync"
 	"testing"
 
@@ -318,4 +319,150 @@ func TestSyncSecretShouldMergeLabelsAndAnnotationsOnUpdate(t *testing.T) {
 	assert.Equal(t, "new-label-value", secret.Labels["new-label"])
 	assert.Equal(t, "annotation-value-2", secret.Annotations["annotation"])
 	assert.Equal(t, "new-annotation-value", secret.Annotations["new-annotation"])
+}
+
+func TestSyncSecretShouldRespectDWOLabels(t *testing.T) {
+	deployContext := test.GetDeployContext(nil, []runtime.Object{
+		&corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      objectName,
+				Namespace: "eclipse-che",
+				Labels: map[string]string{
+					constants.KubernetesPartOfLabelKey:       constants.CheEclipseOrg,
+					constants.KubernetesComponentLabelKey:    constants.WorkspacesConfig,
+					dwconstants.DevWorkspaceWatchSecretLabel: "false",
+					dwconstants.DevWorkspaceMountLabel:       "false"},
+			},
+		}})
+
+	workspaceConfigReconciler := NewWorkspacesConfigReconciler(
+		deployContext.ClusterAPI.Client,
+		deployContext.ClusterAPI.Scheme,
+		&namespaceCache{
+			client: deployContext.ClusterAPI.Client,
+			knownNamespaces: map[string]namespaceInfo{
+				userNamespace: {
+					IsWorkspaceNamespace: true,
+					Username:             "user",
+					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
+				},
+			},
+			lock: sync.Mutex{},
+		})
+
+	// Sync Secret
+	err := workspaceConfigReconciler.syncNamespace(context.TODO(), eclipseCheNamespace, userNamespace)
+	assert.Nil(t, err)
+	assertSyncConfig(t, workspaceConfigReconciler, 2, v1SecretGKV)
+
+	// Check Secret in a user namespace is created
+	secret := &corev1.Secret{}
+	err = workspaceConfigReconciler.client.Get(context.TODO(), objectKeyInUserNs, secret)
+	assert.Nil(t, err)
+	assert.Equal(t, constants.WorkspacesConfig, secret.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, constants.CheEclipseOrg, secret.Labels[constants.KubernetesPartOfLabelKey])
+	assert.Equal(t, "false", secret.Labels[dwconstants.DevWorkspaceWatchSecretLabel])
+	assert.Equal(t, "false", secret.Labels[dwconstants.DevWorkspaceMountLabel])
+
+	// Update labels in dst Secret
+	secret = &corev1.Secret{}
+	err = workspaceConfigReconciler.client.Get(context.TODO(), objectKeyInUserNs, secret)
+	assert.Nil(t, err)
+	utils.AddMap(secret.Labels, map[string]string{
+		dwconstants.DevWorkspaceWatchSecretLabel: "true",
+		dwconstants.DevWorkspaceMountLabel:       "true",
+	})
+	err = workspaceConfigReconciler.client.Update(context.TODO(), secret)
+	assert.Nil(t, err)
+
+	// Sync Secret
+	err = workspaceConfigReconciler.syncNamespace(context.TODO(), eclipseCheNamespace, userNamespace)
+	assert.Nil(t, err)
+	assertSyncConfig(t, workspaceConfigReconciler, 2, v1SecretGKV)
+
+	// Check that destination Secret is reverted
+	secret = &corev1.Secret{}
+	err = workspaceConfigReconciler.client.Get(context.TODO(), objectKeyInUserNs, secret)
+	assert.Nil(t, err)
+	assert.Equal(t, constants.WorkspacesConfig, secret.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, constants.CheEclipseOrg, secret.Labels[constants.KubernetesPartOfLabelKey])
+	assert.Equal(t, "false", secret.Labels[dwconstants.DevWorkspaceWatchSecretLabel])
+	assert.Equal(t, "false", secret.Labels[dwconstants.DevWorkspaceMountLabel])
+
+	// Update src Secret
+	secret = &corev1.Secret{}
+	err = workspaceConfigReconciler.client.Get(context.TODO(), objectKeyInCheNs, secret)
+	assert.Nil(t, err)
+	utils.AddMap(secret.Labels, map[string]string{
+		dwconstants.DevWorkspaceWatchSecretLabel: "true",
+		dwconstants.DevWorkspaceMountLabel:       "true",
+	})
+	err = workspaceConfigReconciler.client.Update(context.TODO(), secret)
+	assert.Nil(t, err)
+
+	// Sync Secret
+	err = workspaceConfigReconciler.syncNamespace(context.TODO(), eclipseCheNamespace, userNamespace)
+	assert.Nil(t, err)
+	assertSyncConfig(t, workspaceConfigReconciler, 2, v1SecretGKV)
+
+	// Check that destination Secret is updated
+	secret = &corev1.Secret{}
+	err = workspaceConfigReconciler.client.Get(context.TODO(), objectKeyInUserNs, secret)
+	assert.Nil(t, err)
+	assert.Equal(t, constants.WorkspacesConfig, secret.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, constants.CheEclipseOrg, secret.Labels[constants.KubernetesPartOfLabelKey])
+	assert.Equal(t, "true", secret.Labels[dwconstants.DevWorkspaceWatchSecretLabel])
+	assert.Equal(t, "true", secret.Labels[dwconstants.DevWorkspaceMountLabel])
+}
+
+func TestSyncSecretShouldRemoveSomeLabels(t *testing.T) {
+	deployContext := test.GetDeployContext(nil, []runtime.Object{
+		&corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      objectName,
+				Namespace: "eclipse-che",
+				Labels: map[string]string{
+					constants.KubernetesPartOfLabelKey:    constants.CheEclipseOrg,
+					constants.KubernetesComponentLabelKey: constants.WorkspacesConfig,
+					"argocd.argoproj.io/instance":         "argocd",
+					"argocd.argoproj.io/managed-by":       "argocd"},
+			},
+		}})
+
+	workspaceConfigReconciler := NewWorkspacesConfigReconciler(
+		deployContext.ClusterAPI.Client,
+		deployContext.ClusterAPI.Scheme,
+		&namespaceCache{
+			client: deployContext.ClusterAPI.Client,
+			knownNamespaces: map[string]namespaceInfo{
+				userNamespace: {
+					IsWorkspaceNamespace: true,
+					Username:             "user",
+					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
+				},
+			},
+			lock: sync.Mutex{},
+		})
+
+	// Sync Secret
+	err := workspaceConfigReconciler.syncNamespace(context.TODO(), eclipseCheNamespace, userNamespace)
+	assert.Nil(t, err)
+	assertSyncConfig(t, workspaceConfigReconciler, 2, v1SecretGKV)
+
+	// Check Secret in a user namespace is created
+	secret := &corev1.Secret{}
+	err = workspaceConfigReconciler.client.Get(context.TODO(), objectKeyInUserNs, secret)
+	assert.Nil(t, err)
+	assert.Equal(t, constants.WorkspacesConfig, secret.Labels[constants.KubernetesComponentLabelKey])
+	assert.Equal(t, constants.CheEclipseOrg, secret.Labels[constants.KubernetesPartOfLabelKey])
+	assert.Empty(t, secret.Labels["argocd.argoproj.io/instance"])
+	assert.Empty(t, secret.Labels["argocd.argoproj.io/managed-by"])
 }


### PR DESCRIPTION
…mespaces

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Improve managing labels during replicating objects in users namespaces

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
- Respect existed `controller.devfile.io/watch-configmap`, `controller.devfile.io/watch-secret` and `controller.devfile.io/mount-to-devworkspace` labels
- Ability to remove labels/annotations before replication

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Prepare a patch file if needed:
```bash
cat > /tmp/cr-patch.yaml <<EOF
apiVersion: org.eclipse.che/v2
kind: CheCluster
spec: {}
EOF
```

2. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
