### PR TITLE
chore: use udi9 as the default development image instead of udi8

### DIFF
--- a/build/scripts/docker-run.sh
+++ b/build/scripts/docker-run.sh
@@ -29,8 +29,9 @@ init() {
 build() {
   printf "%bBuilding image %b${IMAGE_NAME}${NC}..." "${BOLD}" "${BLUE}"
   if docker build -t ${IMAGE_NAME} > docker-build-log 2>&1  -<<EOF
-  FROM golang:1.19.13-bullseye
-  RUN apt update && apt install python3-pip skopeo jq rsync unzip -y && pip install yq && \
+  FROM golang:1.23-bookworm
+  RUN apt update && apt install python3-pip skopeo jq rsync unzip -y && \
+    pip install --break-system-packages yq && \
     curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     go install golang.org/x/tools/cmd/goimports@latest && \

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -108,7 +108,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: eclipse-che.v7.102.0-905.next
+  name: eclipse-che.v7.103.0-906.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -955,7 +955,7 @@ spec:
                         value: che-incubator/che-code/latest
                       - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS
                         value: '[{"name": "universal-developer-image", "container":
-                          {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]'
+                          {"image": "quay.io/devfile/universal-developer-image:ubi9-latest"}}]'
                       - name: CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL
                         value: https://open-vsx.org
                       - name: CHE_DEFAULT_SPEC_COMPONENTS_DEVFILEREGISTRY_EXTERNAL_DEVFILE_REGISTRIES
@@ -1080,7 +1080,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: Eclipse Foundation
-  version: 7.102.0-905.next
+  version: 7.103.0-906.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -100,7 +100,7 @@ spec:
             - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR
               value: che-incubator/che-code/latest
             - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS
-              value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]'
+              value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi9-latest"}}]'
             - name: CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL
               value: https://open-vsx.org
             - name: CHE_DEFAULT_SPEC_COMPONENTS_DEVFILEREGISTRY_EXTERNAL_DEVFILE_REGISTRIES

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -9181,7 +9181,7 @@ spec:
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR
           value: che-incubator/che-code/latest
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS
-          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]'
+          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi9-latest"}}]'
         - name: CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL
           value: https://open-vsx.org
         - name: CHE_DEFAULT_SPEC_COMPONENTS_DEVFILEREGISTRY_EXTERNAL_DEVFILE_REGISTRIES

--- a/deploy/deployment/kubernetes/objects/che-operator.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/che-operator.Deployment.yaml
@@ -94,7 +94,7 @@ spec:
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR
           value: che-incubator/che-code/latest
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS
-          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]'
+          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi9-latest"}}]'
         - name: CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL
           value: https://open-vsx.org
         - name: CHE_DEFAULT_SPEC_COMPONENTS_DEVFILEREGISTRY_EXTERNAL_DEVFILE_REGISTRIES

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -9183,7 +9183,7 @@ spec:
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR
           value: che-incubator/che-code/latest
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS
-          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]'
+          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi9-latest"}}]'
         - name: CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL
           value: https://open-vsx.org
         - name: CHE_DEFAULT_SPEC_COMPONENTS_DEVFILEREGISTRY_EXTERNAL_DEVFILE_REGISTRIES

--- a/deploy/deployment/openshift/objects/che-operator.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/che-operator.Deployment.yaml
@@ -94,7 +94,7 @@ spec:
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR
           value: che-incubator/che-code/latest
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS
-          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]'
+          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi9-latest"}}]'
         - name: CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL
           value: https://open-vsx.org
         - name: CHE_DEFAULT_SPEC_COMPONENTS_DEVFILEREGISTRY_EXTERNAL_DEVFILE_REGISTRIES

--- a/helmcharts/next/templates/che-operator.Deployment.yaml
+++ b/helmcharts/next/templates/che-operator.Deployment.yaml
@@ -94,7 +94,7 @@ spec:
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTEDITOR
           value: che-incubator/che-code/latest
         - name: CHE_DEFAULT_SPEC_DEVENVIRONMENTS_DEFAULTCOMPONENTS
-          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi8-latest"}}]'
+          value: '[{"name": "universal-developer-image", "container": {"image": "quay.io/devfile/universal-developer-image:ubi9-latest"}}]'
         - name: CHE_DEFAULT_SPEC_COMPONENTS_PLUGINREGISTRY_OPENVSXURL
           value: https://open-vsx.org
         - name: CHE_DEFAULT_SPEC_COMPONENTS_DEVFILEREGISTRY_EXTERNAL_DEVFILE_REGISTRIES


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
This PR updates the default universal developer image used by Eclipse Che to ubi9-latest, replacing the deprecated ubi8-latest. It also includes improvements and  compatibility fixes `docker-run` script 


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse-che/che/issues/23321

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Go into the branch with current changes.
2. `minikube start --disk-size=50000mb --memory=8192 --cpus=4`
3. `make gen-chectl-tmpl TEMPLATES=/tmp/templates`
4. `chectl server:deploy   -p minikube   --che-operator-image=quay.io/rh-ee-mszuc/che-operator:ubi9-update   --templates=/tmp/templates`
5. Open the Che dashboard, create an empty workspace, and verify that it is using the ubi9 image
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
