### PR TITLE
chore: sync dev-workspace-container-build CRB on every reconcile loop

### DIFF
--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -133,6 +133,8 @@ const (
 	PublicCertsDir        = "/public-certs"
 
 	// DevWorkspace
+	DevWorkspaceControllerName     = "devworkspace-controller"
+	DevWorkspaceOperatorName       = "devworkspace-operator"
 	DevWorkspaceServiceAccountName = "devworkspace-controller-serviceaccount"
 	DefaultContainerBuildSccName   = "container-build"
 )

--- a/pkg/deploy/container-build/container_build_test.go
+++ b/pkg/deploy/container-build/container_build_test.go
@@ -33,17 +33,24 @@ import (
 )
 
 func TestContainerBuildReconciler(t *testing.T) {
-	dwSA := &corev1.ServiceAccount{
+	dwPod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "ServiceAccount",
+			Kind:       "Pod",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.DevWorkspaceServiceAccountName,
+			Name:      "devworkspace-controller",
 			Namespace: "eclipse-che",
+			Labels: map[string]string{
+				constants.KubernetesNameLabelKey:   constants.DevWorkspaceControllerName,
+				constants.KubernetesPartOfLabelKey: constants.DevWorkspaceOperatorName,
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: constants.DevWorkspaceServiceAccountName,
 		},
 	}
-	ctx := test.GetDeployContext(nil, []runtime.Object{dwSA})
+	ctx := test.GetDeployContext(nil, []runtime.Object{dwPod})
 	containerBuildReconciler := NewContainerBuildReconciler()
 
 	_, done, err := containerBuildReconciler.Reconcile(ctx)
@@ -83,18 +90,25 @@ func TestContainerBuildReconciler(t *testing.T) {
 }
 
 func TestSyncAndRemoveRBAC(t *testing.T) {
-	dwSA := &corev1.ServiceAccount{
+	dwPod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "ServiceAccount",
+			Kind:       "Pod",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.DevWorkspaceServiceAccountName,
+			Name:      "devworkspace-controller",
 			Namespace: "eclipse-che",
+			Labels: map[string]string{
+				constants.KubernetesNameLabelKey:   constants.DevWorkspaceControllerName,
+				constants.KubernetesPartOfLabelKey: constants.DevWorkspaceOperatorName,
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: constants.DevWorkspaceServiceAccountName,
 		},
 	}
-	ctx := test.GetDeployContext(nil, []runtime.Object{dwSA})
-	ctx.CheCluster.Spec.DevEnvironments.DisableContainerBuildCapabilities = pointer.BoolPtr(false)
+	ctx := test.GetDeployContext(nil, []runtime.Object{dwPod})
+	ctx.CheCluster.Spec.DevEnvironments.DisableContainerBuildCapabilities = pointer.Bool(false)
 	ctx.CheCluster.Spec.DevEnvironments.ContainerBuildConfiguration = &chev2.ContainerBuildConfiguration{OpenShiftSecurityContextConstraint: "scc"}
 
 	containerBuildReconciler := NewContainerBuildReconciler()
@@ -118,7 +132,7 @@ func TestSyncAndRemoveRBAC(t *testing.T) {
 
 func TestSyncAndRemoveSCC(t *testing.T) {
 	ctx := test.GetDeployContext(nil, []runtime.Object{})
-	ctx.CheCluster.Spec.DevEnvironments.DisableContainerBuildCapabilities = pointer.BoolPtr(false)
+	ctx.CheCluster.Spec.DevEnvironments.DisableContainerBuildCapabilities = pointer.Bool(false)
 	ctx.CheCluster.Spec.DevEnvironments.ContainerBuildConfiguration = &chev2.ContainerBuildConfiguration{OpenShiftSecurityContextConstraint: "scc"}
 
 	containerBuildReconciler := NewContainerBuildReconciler()


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
snc dev-workspace-container-build CRB on every reconcile loop

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse-che/che/issues/23400

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Prepare a patch file if needed:
```bash
cat > /tmp/cr-patch.yaml <<EOF
apiVersion: org.eclipse.che/v2
kind: CheCluster
spec: {}
EOF
```

2. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh --cr-patch-yaml /tmp/cr-patch.yaml
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
