### PR TITLE
CRW-9501 - Remove Tech-Preview from Jetbrains Gateway related editors.

### DIFF
--- a/editors-definitions/che-clion-server-latest.yaml
+++ b/editors-definitions/che-clion-server-latest.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains CLion (desktop)
   description: JetBrains CLion for Eclipse Che - latest
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-clion-server-next.yaml
+++ b/editors-definitions/che-clion-server-next.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains CLion (desktop)
   description: JetBrains CLion for Eclipse Che - next
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-goland-server-latest.yaml
+++ b/editors-definitions/che-goland-server-latest.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains GoLand (desktop)
   description: JetBrains GoLand dev server for Eclipse Che - latest
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-goland-server-next.yaml
+++ b/editors-definitions/che-goland-server-next.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains GoLand (desktop)
   description: JetBrains GoLand dev server for Eclipse Che - next
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-idea-server-latest.yaml
+++ b/editors-definitions/che-idea-server-latest.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains IntelliJ IDEA Ultimate (desktop)
   description: JetBrains IntelliJ IDEA Ultimate dev server for Eclipse Che - latest
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-idea-server-next.yaml
+++ b/editors-definitions/che-idea-server-next.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains IntelliJ IDEA Ultimate (desktop)
   description: JetBrains IntelliJ IDEA Ultimate dev server for Eclipse Che - next
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-phpstorm-server-latest.yaml
+++ b/editors-definitions/che-phpstorm-server-latest.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains PhpStorm (desktop)
   description: JetBrains PhpStorm for Eclipse Che - latest
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-phpstorm-server-next.yaml
+++ b/editors-definitions/che-phpstorm-server-next.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains PhpStorm (desktop)
   description: JetBrains PhpStorm for Eclipse Che - next
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-pycharm-server-latest.yaml
+++ b/editors-definitions/che-pycharm-server-latest.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains PyCharm Professional Edition (desktop)
   description: JetBrains PyCharm Professional Edition for Eclipse Che - latest
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-pycharm-server-next.yaml
+++ b/editors-definitions/che-pycharm-server-next.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains PyCharm Professional Edition (desktop)
   description: JetBrains PyCharm Professional Edition for Eclipse Che - next
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-rider-server-latest.yaml
+++ b/editors-definitions/che-rider-server-latest.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains Rider (desktop)
   description: JetBrains Rider for Eclipse Che - latest
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-rider-server-next.yaml
+++ b/editors-definitions/che-rider-server-next.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains Rider (desktop)
   description: JetBrains Rider for Eclipse Che - next
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-rubymine-server-latest.yaml
+++ b/editors-definitions/che-rubymine-server-latest.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains RubyMine (desktop)
   description: JetBrains RubyMine for Eclipse Che - latest
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-rubymine-server-next.yaml
+++ b/editors-definitions/che-rubymine-server-next.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains RubyMine (desktop)
   description: JetBrains RubyMine for Eclipse Che - next
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-webstorm-server-latest.yaml
+++ b/editors-definitions/che-webstorm-server-latest.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains WebStorm (desktop)
   description: JetBrains WebStorm for Eclipse Che - latest
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64

--- a/editors-definitions/che-webstorm-server-next.yaml
+++ b/editors-definitions/che-webstorm-server-next.yaml
@@ -16,7 +16,6 @@ metadata:
   displayName: JetBrains WebStorm (desktop)
   description: JetBrains WebStorm for Eclipse Che - next
   tags:
-    - Tech-Preview
   attributes:
     arch:
       - x86_64


### PR DESCRIPTION
This will remove the `Tech-Preview` annotation on all editor definition tiles related to the Jetbrains Gateway plugin.

**Current State**
<img width="764" height="818" alt="image" src="https://github.com/user-attachments/assets/c0445267-1bc4-47c3-826b-c58041f59390" />

CC'ing @azatsarynnyy 