### PR TITLE
doc : add note clarifying defaultContainerResources behavior and add reference link

### DIFF
--- a/api/v2/checluster_types.go
+++ b/api/v2/checluster_types.go
@@ -127,6 +127,13 @@ type CheClusterDevEnvironments struct {
 	DefaultComponents []devfile.Component `json:"defaultComponents,omitempty"`
 	// DefaultContainerResources defines the resource requirements (memory/cpu limit/request) used for
 	// container components that do not define limits or requests.
+	// Note: The actual pod container resource values exactly match the sum of:
+	// - The resource requirements configured via this field, plus
+	// - The used Editor overhead (varies from editor to editor).
+	//
+	// For more details, see:
+	// https://eclipse.dev/che/docs/stable/administration-guide/calculating-che-resource-requirements/
+	//
 	// +optional
 	DefaultContainerResources *corev1.ResourceRequirements `json:"defaultContainerResources,omitempty"`
 	// ContainerResourceCaps defines the maximum resource requirements enforced for workspace

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2026-04-15T15:08:42Z"
+    createdAt: "2026-04-20T08:28:08Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     features.operators.openshift.io/cnf: "false"
@@ -108,7 +108,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: eclipse-che.v7.117.0-973.next
+  name: eclipse-che.v7.117.0-974.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1144,7 +1144,7 @@ spec:
       name: gateway-authorization-sidecar-k8s
     - image: quay.io/che-incubator/header-rewrite-proxy:latest
       name: gateway-header-sidecar
-  version: 7.117.0-973.next
+  version: 7.117.0-974.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
@@ -16480,6 +16480,12 @@ spec:
                       description: |-
                         DefaultContainerResources defines the resource requirements (memory/cpu limit/request) used for
                         container components that do not define limits or requests.
+                        Note: The actual pod container resource values exactly match the sum of:
+                        - The resource requirements configured via this field, plus
+                        - The used Editor overhead (varies from editor to editor).
+
+                        For more details, see:
+                        https://eclipse.dev/che/docs/stable/administration-guide/calculating-che-resource-requirements/
                       properties:
                         claims:
                           description: |-

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -16398,6 +16398,12 @@ spec:
                     description: |-
                       DefaultContainerResources defines the resource requirements (memory/cpu limit/request) used for
                       container components that do not define limits or requests.
+                      Note: The actual pod container resource values exactly match the sum of:
+                      - The resource requirements configured via this field, plus
+                      - The used Editor overhead (varies from editor to editor).
+
+                      For more details, see:
+                      https://eclipse.dev/che/docs/stable/administration-guide/calculating-che-resource-requirements/
                     properties:
                       claims:
                         description: |-

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -16419,6 +16419,12 @@ spec:
                     description: |-
                       DefaultContainerResources defines the resource requirements (memory/cpu limit/request) used for
                       container components that do not define limits or requests.
+                      Note: The actual pod container resource values exactly match the sum of:
+                      - The resource requirements configured via this field, plus
+                      - The used Editor overhead (varies from editor to editor).
+
+                      For more details, see:
+                      https://eclipse.dev/che/docs/stable/administration-guide/calculating-che-resource-requirements/
                     properties:
                       claims:
                         description: |-

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -16414,6 +16414,12 @@ spec:
                     description: |-
                       DefaultContainerResources defines the resource requirements (memory/cpu limit/request) used for
                       container components that do not define limits or requests.
+                      Note: The actual pod container resource values exactly match the sum of:
+                      - The resource requirements configured via this field, plus
+                      - The used Editor overhead (varies from editor to editor).
+
+                      For more details, see:
+                      https://eclipse.dev/che/docs/stable/administration-guide/calculating-che-resource-requirements/
                     properties:
                       claims:
                         description: |-

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -16419,6 +16419,12 @@ spec:
                     description: |-
                       DefaultContainerResources defines the resource requirements (memory/cpu limit/request) used for
                       container components that do not define limits or requests.
+                      Note: The actual pod container resource values exactly match the sum of:
+                      - The resource requirements configured via this field, plus
+                      - The used Editor overhead (varies from editor to editor).
+
+                      For more details, see:
+                      https://eclipse.dev/che/docs/stable/administration-guide/calculating-che-resource-requirements/
                     properties:
                       claims:
                         description: |-

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -16414,6 +16414,12 @@ spec:
                     description: |-
                       DefaultContainerResources defines the resource requirements (memory/cpu limit/request) used for
                       container components that do not define limits or requests.
+                      Note: The actual pod container resource values exactly match the sum of:
+                      - The resource requirements configured via this field, plus
+                      - The used Editor overhead (varies from editor to editor).
+
+                      For more details, see:
+                      https://eclipse.dev/che/docs/stable/administration-guide/calculating-che-resource-requirements/
                     properties:
                       claims:
                         description: |-

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -16414,6 +16414,12 @@ spec:
                     description: |-
                       DefaultContainerResources defines the resource requirements (memory/cpu limit/request) used for
                       container components that do not define limits or requests.
+                      Note: The actual pod container resource values exactly match the sum of:
+                      - The resource requirements configured via this field, plus
+                      - The used Editor overhead (varies from editor to editor).
+
+                      For more details, see:
+                      https://eclipse.dev/che/docs/stable/administration-guide/calculating-che-resource-requirements/
                     properties:
                       claims:
                         description: |-


### PR DESCRIPTION



<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
While verifying https://issues.redhat.com/browse/CRW-9493 , this point created a lot of confusion as configured CPU/Memory resource limits were not directly reflected in the workspace pod. I performed some tests with various resource limits in CheCluster and noticed  configured limits are included in the workspace pod, it's just that additional overhead is added for Editor used:
| CheCluster CPU (limit / request) | CheCluster Memory (limit / request) | Actual Pod CPU (limit / request) | Actual Pod Memory (limit / request) | Δ CPU (limit / request) | Δ Memory (limit / request) |
|----------------------------------|-------------------------------------|----------------------------------|--------------------------------------|--------------------------|-----------------------------|
| 4 / 2                            | 500Mi / 300Mi                       | 4500m / 2030m                     | 1524Mi / 556Mi                        | +500m / +30m             | +1024Mi / +256Mi            |
| 3 / 1                            | 6Gi / 4Gi                           | 3500m / 1030m                     | 7Gi / 4352Mi                          | +500m / +30m             | +1Gi / +352Mi               |
| 2 / 1                            | 4Gi / 2Mi                           | 2500m / 1030m                     | 5Gi / 258Mi                           | +500m / +30m             | +1Gi / +256Mi               |
| 200m / 100m                      | 200Mi / 100Mi                       | 700m / 130m                       | 1224Mi / 356Mi                        | +500m / +30m             | +1024Mi / +256Mi            |


Added a note to the GoDoc for DefaultContainerResources explaining how actual resource values are calculated — as the sum of CheCluster defaults and editor overhead. Included a link to the official Che documentation https://eclipse.dev/che/docs/stable/administration-guide/calculating-che-resource-requirements/ for more details.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
It's related to https://issues.redhat.com/browse/CRW-9493


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

It's just a documentation change. 

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Development resource are up to date](https://github.com/eclipse-che/che-operator/blob/main/README.md#update-development-resources)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
