### PR TITLE
chore: Enable persistent home by default

### DIFF
--- a/api/v2/checluster_types.go
+++ b/api/v2/checluster_types.go
@@ -47,7 +47,7 @@ type CheClusterSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Development environments"
-	// +kubebuilder:default:={storage: {pvcStrategy: per-user}, defaultNamespace: {template: <username>-che, autoProvision: true}, secondsOfInactivityBeforeIdling:1800, secondsOfRunBeforeIdling:-1, startTimeoutSeconds:300, maxNumberOfWorkspacesPerUser:-1, disableContainerRunCapabilities:true}
+	// +kubebuilder:default:={storage: {pvcStrategy: per-user}, defaultNamespace: {template: <username>-che, autoProvision: true}, secondsOfInactivityBeforeIdling:1800, secondsOfRunBeforeIdling:-1, startTimeoutSeconds:300, maxNumberOfWorkspacesPerUser:-1, disableContainerRunCapabilities:true, persistUserHome: {enabled: true}}
 	DevEnvironments CheClusterDevEnvironments `json:"devEnvironments"`
 	// Che components configuration.
 	// +optional
@@ -89,6 +89,7 @@ type CheClusterDevEnvironments struct {
 	// PersistUserHome defines configuration options for persisting the
 	// user home directory in workspaces.
 	// +optional
+	// +kubebuilder:default:={enabled: true}
 	PersistUserHome *PersistentHomeConfig `json:"persistUserHome,omitempty"`
 	// Default plug-ins applied to DevWorkspaces.
 	// +optional
@@ -563,7 +564,8 @@ type PersistentHomeConfig struct {
 	// Determines whether the user home directory in workspaces should persist between
 	// workspace shutdown and startup.
 	// Must be used with the 'per-user' or 'per-workspace' PVC strategy in order to take effect.
-	// Disabled by default.
+	// +optional
+	// +kubebuilder:default:=true
 	Enabled *bool `json:"enabled,omitempty"`
 	// Determines whether the init container that initializes the persistent home directory should be disabled.
 	// When the `/home/user` directory is persisted, the init container is used to initialize the directory before

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2026-04-13T08:40:46Z"
+    createdAt: "2026-04-15T15:08:42Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     features.operators.openshift.io/cnf: "false"
@@ -108,7 +108,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: eclipse-che.v7.117.0-972.next
+  name: eclipse-che.v7.117.0-973.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1144,7 +1144,7 @@ spec:
       name: gateway-authorization-sidecar-k8s
     - image: quay.io/che-incubator/header-rewrite-proxy:latest
       name: gateway-header-sidecar
-  version: 7.117.0-972.next
+  version: 7.117.0-973.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
@@ -14715,6 +14715,8 @@ spec:
                       template: <username>-che
                     disableContainerRunCapabilities: true
                     maxNumberOfWorkspacesPerUser: -1
+                    persistUserHome:
+                      enabled: true
                     secondsOfInactivityBeforeIdling: 1800
                     secondsOfRunBeforeIdling: -1
                     startTimeoutSeconds: 300
@@ -18744,6 +18746,8 @@ spec:
                         the workspace pods.
                       type: object
                     persistUserHome:
+                      default:
+                        enabled: true
                       description: |-
                         PersistUserHome defines configuration options for persisting the
                         user home directory in workspaces.
@@ -18758,11 +18762,11 @@ spec:
                             The init container is enabled by default.
                           type: boolean
                         enabled:
+                          default: true
                           description: |-
                             Determines whether the user home directory in workspaces should persist between
                             workspace shutdown and startup.
                             Must be used with the 'per-user' or 'per-workspace' PVC strategy in order to take effect.
-                            Disabled by default.
                           type: boolean
                       type: object
                     podSchedulerName:

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -14637,6 +14637,8 @@ spec:
                     template: <username>-che
                   disableContainerRunCapabilities: true
                   maxNumberOfWorkspacesPerUser: -1
+                  persistUserHome:
+                    enabled: true
                   secondsOfInactivityBeforeIdling: 1800
                   secondsOfRunBeforeIdling: -1
                   startTimeoutSeconds: 300
@@ -18660,6 +18662,8 @@ spec:
                       workspace pods.
                     type: object
                   persistUserHome:
+                    default:
+                      enabled: true
                     description: |-
                       PersistUserHome defines configuration options for persisting the
                       user home directory in workspaces.
@@ -18674,11 +18678,11 @@ spec:
                           The init container is enabled by default.
                         type: boolean
                       enabled:
+                        default: true
                         description: |-
                           Determines whether the user home directory in workspaces should persist between
                           workspace shutdown and startup.
                           Must be used with the 'per-user' or 'per-workspace' PVC strategy in order to take effect.
-                          Disabled by default.
                         type: boolean
                     type: object
                   podSchedulerName:

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -14658,6 +14658,8 @@ spec:
                     template: <username>-che
                   disableContainerRunCapabilities: true
                   maxNumberOfWorkspacesPerUser: -1
+                  persistUserHome:
+                    enabled: true
                   secondsOfInactivityBeforeIdling: 1800
                   secondsOfRunBeforeIdling: -1
                   startTimeoutSeconds: 300
@@ -18681,6 +18683,8 @@ spec:
                       workspace pods.
                     type: object
                   persistUserHome:
+                    default:
+                      enabled: true
                     description: |-
                       PersistUserHome defines configuration options for persisting the
                       user home directory in workspaces.
@@ -18695,11 +18699,11 @@ spec:
                           The init container is enabled by default.
                         type: boolean
                       enabled:
+                        default: true
                         description: |-
                           Determines whether the user home directory in workspaces should persist between
                           workspace shutdown and startup.
                           Must be used with the 'per-user' or 'per-workspace' PVC strategy in order to take effect.
-                          Disabled by default.
                         type: boolean
                     type: object
                   podSchedulerName:

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -14653,6 +14653,8 @@ spec:
                     template: <username>-che
                   disableContainerRunCapabilities: true
                   maxNumberOfWorkspacesPerUser: -1
+                  persistUserHome:
+                    enabled: true
                   secondsOfInactivityBeforeIdling: 1800
                   secondsOfRunBeforeIdling: -1
                   startTimeoutSeconds: 300
@@ -18676,6 +18678,8 @@ spec:
                       workspace pods.
                     type: object
                   persistUserHome:
+                    default:
+                      enabled: true
                     description: |-
                       PersistUserHome defines configuration options for persisting the
                       user home directory in workspaces.
@@ -18690,11 +18694,11 @@ spec:
                           The init container is enabled by default.
                         type: boolean
                       enabled:
+                        default: true
                         description: |-
                           Determines whether the user home directory in workspaces should persist between
                           workspace shutdown and startup.
                           Must be used with the 'per-user' or 'per-workspace' PVC strategy in order to take effect.
-                          Disabled by default.
                         type: boolean
                     type: object
                   podSchedulerName:

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -14658,6 +14658,8 @@ spec:
                     template: <username>-che
                   disableContainerRunCapabilities: true
                   maxNumberOfWorkspacesPerUser: -1
+                  persistUserHome:
+                    enabled: true
                   secondsOfInactivityBeforeIdling: 1800
                   secondsOfRunBeforeIdling: -1
                   startTimeoutSeconds: 300
@@ -18681,6 +18683,8 @@ spec:
                       workspace pods.
                     type: object
                   persistUserHome:
+                    default:
+                      enabled: true
                     description: |-
                       PersistUserHome defines configuration options for persisting the
                       user home directory in workspaces.
@@ -18695,11 +18699,11 @@ spec:
                           The init container is enabled by default.
                         type: boolean
                       enabled:
+                        default: true
                         description: |-
                           Determines whether the user home directory in workspaces should persist between
                           workspace shutdown and startup.
                           Must be used with the 'per-user' or 'per-workspace' PVC strategy in order to take effect.
-                          Disabled by default.
                         type: boolean
                     type: object
                   podSchedulerName:

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -14653,6 +14653,8 @@ spec:
                     template: <username>-che
                   disableContainerRunCapabilities: true
                   maxNumberOfWorkspacesPerUser: -1
+                  persistUserHome:
+                    enabled: true
                   secondsOfInactivityBeforeIdling: 1800
                   secondsOfRunBeforeIdling: -1
                   startTimeoutSeconds: 300
@@ -18676,6 +18678,8 @@ spec:
                       workspace pods.
                     type: object
                   persistUserHome:
+                    default:
+                      enabled: true
                     description: |-
                       PersistUserHome defines configuration options for persisting the
                       user home directory in workspaces.
@@ -18690,11 +18694,11 @@ spec:
                           The init container is enabled by default.
                         type: boolean
                       enabled:
+                        default: true
                         description: |-
                           Determines whether the user home directory in workspaces should persist between
                           workspace shutdown and startup.
                           Must be used with the 'per-user' or 'per-workspace' PVC strategy in order to take effect.
-                          Disabled by default.
                         type: boolean
                     type: object
                   podSchedulerName:

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -14653,6 +14653,8 @@ spec:
                     template: <username>-che
                   disableContainerRunCapabilities: true
                   maxNumberOfWorkspacesPerUser: -1
+                  persistUserHome:
+                    enabled: true
                   secondsOfInactivityBeforeIdling: 1800
                   secondsOfRunBeforeIdling: -1
                   startTimeoutSeconds: 300
@@ -18676,6 +18678,8 @@ spec:
                       workspace pods.
                     type: object
                   persistUserHome:
+                    default:
+                      enabled: true
                     description: |-
                       PersistUserHome defines configuration options for persisting the
                       user home directory in workspaces.
@@ -18690,11 +18694,11 @@ spec:
                           The init container is enabled by default.
                         type: boolean
                       enabled:
+                        default: true
                         description: |-
                           Determines whether the user home directory in workspaces should persist between
                           workspace shutdown and startup.
                           Must be used with the 'per-user' or 'per-workspace' PVC strategy in order to take effect.
-                          Disabled by default.
                         type: boolean
                     type: object
                   podSchedulerName:


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Enable persistent home by default

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://redhat.atlassian.net/browse/CRW-10655

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh
```

or

```bash
build/scripts/docker-run.sh /bin/bash -c "
  oc login \
    --token=<...> \
    --server=<...> \
    --insecure-skip-tls-verify=true && \
  build/scripts/olm/test-catalog-from-sources.sh
"
```

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh
```

2. Check that `spec.devEnvironments.persistUserHome.enabled=true`

#### Common Test Scenarios
- [ ] Deploy Eclipse Che
- [ ] Start an empty workspace
- [ ] Open terminal and build/run an image
- [ ] Stop a workspace
- [ ] Check operator logs for reconciliation errors or infinite reconciliation loops

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
