### PR TITLE
chore: Configure maxResponseBodySize for traefik

### DIFF
--- a/pkg/deploy/gateway/traefik_config.go
+++ b/pkg/deploy/gateway/traefik_config.go
@@ -62,9 +62,10 @@ type TraefikConfigStripPrefix struct {
 }
 
 type TraefikConfigForwardAuth struct {
-	Address            string            `json:"address"`
-	TrustForwardHeader bool              `json:"trustForwardHeader"`
-	TLS                *TraefikConfigTLS `json:"tls,omitempty"`
+	Address             string            `json:"address"`
+	TrustForwardHeader  bool              `json:"trustForwardHeader"`
+	TLS                 *TraefikConfigTLS `json:"tls,omitempty"`
+	MaxResponseBodySize *int              `json:"maxResponseBodySize,omitempty"`
 }
 
 type TraefikConfigErrors struct {

--- a/pkg/deploy/gateway/traefik_config_util.go
+++ b/pkg/deploy/gateway/traefik_config_util.go
@@ -12,6 +12,8 @@
 
 package gateway
 
+import "k8s.io/utils/pointer"
+
 const (
 	StripPrefixMiddlewareSuffix   = "-strip-prefix"
 	HeaderRewriteMiddlewareSuffix = "-header-rewrite"
@@ -88,8 +90,9 @@ func (cfg *TraefikConfig) AddOpenShiftTokenCheck(componentName string) {
 	cfg.HTTP.Routers[componentName].Middlewares = append(cfg.HTTP.Routers[componentName].Middlewares, middlewareName)
 	cfg.HTTP.Middlewares[middlewareName] = &TraefikConfigMiddleware{
 		ForwardAuth: &TraefikConfigForwardAuth{
-			Address:            "https://kubernetes.default.svc/apis/user.openshift.io/v1/users/~",
-			TrustForwardHeader: true,
+			Address:             "https://kubernetes.default.svc/apis/user.openshift.io/v1/users/~",
+			TrustForwardHeader:  true,
+			MaxResponseBodySize: pointer.Int(1048576),
 			TLS: &TraefikConfigTLS{
 				InsecureSkipVerify: true,
 			},
@@ -102,7 +105,8 @@ func (cfg *TraefikConfig) AddAuth(componentName string, authAddress string) {
 	cfg.HTTP.Routers[componentName].Middlewares = append(cfg.HTTP.Routers[componentName].Middlewares, middlewareName)
 	cfg.HTTP.Middlewares[middlewareName] = &TraefikConfigMiddleware{
 		ForwardAuth: &TraefikConfigForwardAuth{
-			Address: authAddress,
+			Address:             authAddress,
+			MaxResponseBodySize: pointer.Int(1048576),
 		},
 	}
 }

--- a/pkg/deploy/gateway/traefik_config_util.go
+++ b/pkg/deploy/gateway/traefik_config_util.go
@@ -92,7 +92,7 @@ func (cfg *TraefikConfig) AddOpenShiftTokenCheck(componentName string) {
 		ForwardAuth: &TraefikConfigForwardAuth{
 			Address:             "https://kubernetes.default.svc/apis/user.openshift.io/v1/users/~",
 			TrustForwardHeader:  true,
-			MaxResponseBodySize: pointer.Int(1048576),
+			MaxResponseBodySize: pointer.Int(16384), // 16KB
 			TLS: &TraefikConfigTLS{
 				InsecureSkipVerify: true,
 			},
@@ -106,7 +106,7 @@ func (cfg *TraefikConfig) AddAuth(componentName string, authAddress string) {
 	cfg.HTTP.Middlewares[middlewareName] = &TraefikConfigMiddleware{
 		ForwardAuth: &TraefikConfigForwardAuth{
 			Address:             authAddress,
-			MaxResponseBodySize: pointer.Int(1048576),
+			MaxResponseBodySize: pointer.Int(16384), // 16KB
 		},
 	}
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Configure maxResponseBodySize for traefik

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse-che/che/issues/23807

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh
```

or

```bash
build/scripts/docker-run.sh /bin/bash -c "
  oc login \
    --token=<...> \
    --server=<...> \
    --insecure-skip-tls-verify=true && \
  build/scripts/olm/test-catalog-from-sources.sh
"
```

2. 

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh
```

#### Common Test Scenarios
- [x] Deploy Eclipse Che
- [x] Start an empty workspace
- [ ] Open terminal and build/run an image
- [ ] Stop a workspace
- [x] Check operator logs for reconciliation errors or infinite reconciliation loops

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
