### PR TITLE
feat: automatic detection and configuration of OpenShift's external OIDC authentication

### DIFF
--- a/api/v2/checluster_types.go
+++ b/api/v2/checluster_types.go
@@ -615,11 +615,11 @@ type Auth struct {
 	// For OpenShift with built-in OAuth, this is the name of the `OAuthClient` resource used to set up identity federation.
 	// +optional
 	OAuthClientName string `json:"oAuthClientName,omitempty"`
-	// Defines the OAuth client secret.
-	// It can either be a plain text secret value or the name of a Kubernetes secret
-	// containing a key `oAuthSecret` with the secret value. The Kubernetes secret must exist in the same namespace
-	// as the `CheCluster` resource and have the label `app.kubernetes.io/part-of=che.eclipse.org`.
-	// For OpenShift with built-in OAuth, this is the secret set in the `OAuthClient` resource used to set up identity federation.
+	// For OIDC, this is the client secret issued by the Identity Provider for the configured OIDC client.
+	// For OpenShift with built-in OAuth, this is the secret configured in the OAuthClient for OpenShift OAuth integration.
+	// The value can either be a plain text secret value (deprecated) or the name of a Kubernetes secret
+	// that contains the secret value under the `oAuthSecret` key. The Kubernetes secret must exist in the same namespace
+	// as the `CheCluster` resource namespace and must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
 	// +optional
 	OAuthSecret string `json:"oAuthSecret,omitempty"`
 	// Defines the scope requested from the OIDC provider.

--- a/api/v2/zz_generated.deepcopy.go
+++ b/api/v2/zz_generated.deepcopy.go
@@ -19,7 +19,7 @@ package v2
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/api/v2/zz_generated.deepcopy.go
+++ b/api/v2/zz_generated.deepcopy.go
@@ -19,7 +19,7 @@ package v2
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2026-05-25T12:34:54Z"
+    createdAt: "2026-05-25T15:13:44Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     features.operators.openshift.io/cnf: "false"
@@ -108,7 +108,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: eclipse-che.v7.119.0-987.next
+  name: eclipse-che.v7.119.0-988.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1153,7 +1153,7 @@ spec:
       name: gateway-authorization-sidecar
     - image: quay.io/che-incubator/header-rewrite-proxy:latest
       name: gateway-header-sidecar
-  version: 7.119.0-987.next
+  version: 7.119.0-988.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2026-05-25T15:13:44Z"
+    createdAt: "2026-05-26T12:11:24Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     features.operators.openshift.io/cnf: "false"
@@ -108,7 +108,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: eclipse-che.v7.119.0-988.next
+  name: eclipse-che.v7.119.0-989.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1153,7 +1153,7 @@ spec:
       name: gateway-authorization-sidecar
     - image: quay.io/che-incubator/header-rewrite-proxy:latest
       name: gateway-header-sidecar
-  version: 7.119.0-988.next
+  version: 7.119.0-989.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2026-05-21T07:42:52Z"
+    createdAt: "2026-05-25T10:34:54Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     features.operators.openshift.io/cnf: "false"
@@ -772,6 +772,7 @@ spec:
                 - cluster
               resources:
                 - proxies
+                - authentications
               verbs:
                 - get
             - apiGroups:

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2026-05-25T10:34:54Z"
+    createdAt: "2026-05-25T12:34:54Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     features.operators.openshift.io/cnf: "false"
@@ -108,7 +108,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: eclipse-che.v7.118.0-986.next
+  name: eclipse-che.v7.119.0-987.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1153,7 +1153,7 @@ spec:
       name: gateway-authorization-sidecar
     - image: quay.io/che-incubator/header-rewrite-proxy:latest
       name: gateway-header-sidecar
-  version: 7.118.0-986.next
+  version: 7.119.0-987.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
@@ -22749,11 +22749,11 @@ spec:
                           type: string
                         oAuthSecret:
                           description: |-
-                            Defines the OAuth client secret.
-                            It can either be a plain text secret value or the name of a Kubernetes secret
-                            containing a key `oAuthSecret` with the secret value. The Kubernetes secret must exist in the same namespace
-                            as the `CheCluster` resource and have the label `app.kubernetes.io/part-of=che.eclipse.org`.
-                            For OpenShift with built-in OAuth, this is the secret set in the `OAuthClient` resource used to set up identity federation.
+                            For OIDC, this is the client secret issued by the Identity Provider for the configured OIDC client.
+                            For OpenShift with built-in OAuth, this is the secret configured in the OAuthClient for OpenShift OAuth integration.
+                            The value can either be a plain text secret value (deprecated) or the name of a Kubernetes secret
+                            that contains the secret value under the `oAuthSecret` key. The Kubernetes secret must exist in the same namespace
+                            as the `CheCluster` resource namespace and must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                           type: string
                       type: object
                     domain:

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -22650,11 +22650,11 @@ spec:
                         type: string
                       oAuthSecret:
                         description: |-
-                          Defines the OAuth client secret.
-                          It can either be a plain text secret value or the name of a Kubernetes secret
-                          containing a key `oAuthSecret` with the secret value. The Kubernetes secret must exist in the same namespace
-                          as the `CheCluster` resource and have the label `app.kubernetes.io/part-of=che.eclipse.org`.
-                          For OpenShift with built-in OAuth, this is the secret set in the `OAuthClient` resource used to set up identity federation.
+                          For OIDC, this is the client secret issued by the Identity Provider for the configured OIDC client.
+                          For OpenShift with built-in OAuth, this is the secret configured in the OAuthClient for OpenShift OAuth integration.
+                          The value can either be a plain text secret value (deprecated) or the name of a Kubernetes secret
+                          that contains the secret value under the `oAuthSecret` key. The Kubernetes secret must exist in the same namespace
+                          as the `CheCluster` resource namespace and must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                     type: object
                   domain:

--- a/config/rbac/cluster_role.yaml
+++ b/config/rbac/cluster_role.yaml
@@ -247,6 +247,7 @@ rules:
       - config.openshift.io
     resources:
       - proxies
+      - authentications
     resourceNames:
       - cluster
     verbs:

--- a/controllers/che/authentication.go
+++ b/controllers/che/authentication.go
@@ -1,0 +1,254 @@
+//
+// Copyright (c) 2019-2026 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package che
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/eclipse-che/che-operator/pkg/common/chetypes"
+	"github.com/eclipse-che/che-operator/pkg/common/constants"
+	"github.com/eclipse-che/che-operator/pkg/common/diffs"
+	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8sclient "github.com/eclipse-che/che-operator/pkg/common/k8s-client"
+	"github.com/eclipse-che/che-operator/pkg/deploy"
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	// OpenShift external OIDC authentication constants.
+	// See: https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/authentication_and_authorization/external-auth
+	openshiftConfigNamespace = "openshift-config"
+	issuerCAKey              = "ca-bundle.crt"
+
+	openShiftNamespaceOIDCClientSecretKey = "clientSecret"
+	cheNamespaceOIDCClientSecretKey       = "oAuthSecret"
+
+	oidcIssuerCAConfigMapName = "oidc-issuer-ca"
+)
+
+// ResolveOIDCAuthentication builds an Authentication config from the CheCluster spec,
+// falling back to the OpenShift cluster Authentication resource for any unset fields.
+func ResolveOIDCAuthentication(ctx *chetypes.DeployContext) (*chetypes.OIDCAuthentication, error) {
+	authentication := &chetypes.OIDCAuthentication{
+		UsernameClaim:  ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_OIDC_USERNAME__CLAIM"],
+		UsernamePrefix: ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_OIDC_USERNAME__PREFIX"],
+		GroupsClaim:    ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_OIDC_GROUPS__CLAIM"],
+		GroupsPrefix:   ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_OIDC_GROUPS__PREFIX"],
+		IssuerURL:      ctx.CheCluster.Spec.Networking.Auth.IdentityProviderURL,
+		OIDCClientId:   ctx.CheCluster.Spec.Networking.Auth.OAuthClientName,
+	}
+
+	if ctx.CheCluster.Spec.Networking.Auth.OAuthSecret != "" {
+		oidcClientSecret, err := resolveOIDCClientSecret(ctx.CheCluster.Spec.Networking.Auth.OAuthSecret, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve OIDC client secret: %w", err)
+		}
+		authentication.OIDCClientSecret = oidcClientSecret
+	}
+
+	if infrastructure.IsOpenShiftWithoutOAuth() {
+		clusterAuthentication := &configv1.Authentication{}
+		err := ctx.ClusterAPI.NonCachingClient.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, clusterAuthentication)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch authentication config: %w", err)
+		}
+
+		if clusterAuthentication.Spec.Type != configv1.AuthenticationTypeOIDC {
+			return nil, fmt.Errorf("authentication type is not OIDC")
+		}
+
+		if len(clusterAuthentication.Spec.OIDCProviders) != 1 {
+			return nil, fmt.Errorf("ambiguous OIDC providers")
+		}
+
+		oidcProvider := clusterAuthentication.Spec.OIDCProviders[0]
+
+		if authentication.IssuerURL == "" {
+			authentication.IssuerURL = oidcProvider.Issuer.URL
+
+			// Sync issuer CA
+			if oidcProvider.Issuer.CertificateAuthority.Name != "" {
+				err = syncIssuerCASecret(
+					oidcProvider.Issuer.CertificateAuthority.Name,
+					openshiftConfigNamespace,
+					ctx,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("failed to sync issuer CA: %w", err)
+				}
+			}
+		}
+
+		if authentication.UsernameClaim == "" {
+			authentication.UsernameClaim = oidcProvider.ClaimMappings.Username.Claim
+		}
+
+		if authentication.UsernamePrefix == "" {
+			if oidcProvider.ClaimMappings.Username.Prefix != nil {
+				if oidcProvider.ClaimMappings.Username.PrefixPolicy == configv1.NoOpinion {
+					// NoOpinion (default): prefix with issuerURL unless claim is "email"
+					if authentication.UsernameClaim != "email" {
+						authentication.UsernamePrefix = fmt.Sprintf("%s#", authentication.IssuerURL)
+					}
+				} else {
+					authentication.UsernamePrefix = oidcProvider.ClaimMappings.Username.Prefix.PrefixString
+				}
+			}
+		}
+
+		if authentication.GroupsClaim == "" {
+			authentication.GroupsClaim = oidcProvider.ClaimMappings.Groups.Claim
+		}
+
+		if authentication.GroupsPrefix == "" {
+			authentication.GroupsPrefix = oidcProvider.ClaimMappings.Groups.Prefix
+		}
+
+		if authentication.OIDCClientId == "" {
+			// Reuse the console's OIDC client credentials when no explicit client is configured.
+			for _, oidcClient := range oidcProvider.OIDCClients {
+				if oidcClient.ComponentName == "openshift-console" {
+					authentication.OIDCClientId = oidcClient.ClientID
+
+					if oidcClient.ClientSecret.Name != "" {
+						oidcClientSecret, err := readOIDCClientSecretFromOpenShiftNamespace(oidcClient.ClientSecret.Name, ctx)
+						if err != nil {
+							return nil, fmt.Errorf("failed to read OIDC client secret: %w", err)
+						}
+						authentication.OIDCClientSecret = oidcClientSecret
+					}
+
+					break
+				}
+			}
+
+			if authentication.OIDCClientId == "" {
+				return nil, fmt.Errorf("failed to find `openshift-console` OIDC client")
+			}
+		}
+	}
+
+	return authentication, nil
+}
+
+func readOIDCClientSecretFromOpenShiftNamespace(oidcClientSecretName string, ctx *chetypes.DeployContext) ([]byte, error) {
+	secret := &corev1.Secret{}
+
+	// Use client instead of wrapper in order to catch all errors including NotFound
+	err := ctx.ClusterAPI.NonCachingClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      oidcClientSecretName,
+			Namespace: openshiftConfigNamespace,
+		},
+		secret,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	value, ok := secret.Data[openShiftNamespaceOIDCClientSecretKey]
+	if !ok {
+		return nil, fmt.Errorf("no client secret found")
+	}
+
+	return value, nil
+}
+
+func resolveOIDCClientSecret(oidcClientSecret string, ctx *chetypes.DeployContext) ([]byte, error) {
+	secret := &corev1.Secret{}
+
+	// treat as Secret name first
+	exists, err := ctx.ClusterAPI.ClientWrapper.GetIgnoreNotFound(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      oidcClientSecret,
+			Namespace: ctx.CheCluster.Namespace,
+		},
+		secret,
+	)
+	if err != nil {
+		return nil, err
+	} else if exists {
+		value, ok := secret.Data[cheNamespaceOIDCClientSecretKey]
+		if !ok {
+			return nil, fmt.Errorf("failed to fetch OIDC client secret: no client secret found")
+		}
+
+		return value, nil
+	}
+
+	// Backward compatibility: treat OIDCClientSecretName as a literal secret value, not a reference.
+	return []byte(oidcClientSecret), nil
+}
+
+func syncIssuerCASecret(
+	issuerCASecretName string,
+	issuerCASecretNamespace string,
+	ctx *chetypes.DeployContext,
+) error {
+	sourceIssuerCASecret := &corev1.Secret{}
+
+	// Fetch from a foreign namespace (e.g. openshift-config), use client instead of wrapper
+	// in order to catch all errors including NotFound
+	err := ctx.ClusterAPI.NonCachingClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      issuerCASecretName,
+			Namespace: issuerCASecretNamespace,
+		},
+		sourceIssuerCASecret,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Labeled as CheCABundle so it gets merged into `ca-certs-merged` and mounted to all components.
+	oidcIssuerCACM := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oidcIssuerCAConfigMapName,
+			Namespace: ctx.CheCluster.Namespace,
+			Labels:    deploy.GetLabels(constants.CheCABundle),
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": string(sourceIssuerCASecret.Data[issuerCAKey]),
+		},
+	}
+
+	err = controllerutil.SetControllerReference(ctx.CheCluster, oidcIssuerCACM, ctx.ClusterAPI.Scheme)
+	if err != nil {
+		return err
+	}
+
+	err = ctx.ClusterAPI.ClientWrapper.Sync(
+		context.TODO(),
+		oidcIssuerCACM,
+		&k8sclient.SyncOptions{
+			DiffOpts: diffs.ConfigMapEnsureLabels,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/controllers/che/authentication.go
+++ b/controllers/che/authentication.go
@@ -17,16 +17,10 @@ import (
 	"fmt"
 
 	"github.com/eclipse-che/che-operator/pkg/common/chetypes"
-	"github.com/eclipse-che/che-operator/pkg/common/constants"
-	"github.com/eclipse-che/che-operator/pkg/common/diffs"
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
-	k8sclient "github.com/eclipse-che/che-operator/pkg/common/k8s-client"
-	"github.com/eclipse-che/che-operator/pkg/deploy"
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -37,8 +31,6 @@ const (
 
 	openShiftNamespaceOIDCClientSecretKey = "clientSecret"
 	cheNamespaceOIDCClientSecretKey       = "oAuthSecret"
-
-	oidcIssuerCAConfigMapName = "oidc-issuer-ca"
 )
 
 // ResolveOIDCAuthentication builds an Authentication config from the CheCluster spec,
@@ -61,7 +53,7 @@ func ResolveOIDCAuthentication(ctx *chetypes.DeployContext) (*chetypes.OIDCAuthe
 		authentication.OIDCClientSecret = oidcClientSecret
 	}
 
-	if infrastructure.IsOpenShiftWithoutOAuth() {
+	if infrastructure.IsOpenShiftExternalAuth() {
 		clusterAuthentication := &configv1.Authentication{}
 		err := ctx.ClusterAPI.NonCachingClient.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, clusterAuthentication)
 		if err != nil {
@@ -72,8 +64,12 @@ func ResolveOIDCAuthentication(ctx *chetypes.DeployContext) (*chetypes.OIDCAuthe
 			return nil, fmt.Errorf("authentication type is not OIDC")
 		}
 
+		if len(clusterAuthentication.Spec.OIDCProviders) == 0 {
+			return nil, fmt.Errorf("no OIDC providers configured")
+		}
+
 		if len(clusterAuthentication.Spec.OIDCProviders) != 1 {
-			return nil, fmt.Errorf("ambiguous OIDC providers")
+			return nil, fmt.Errorf("multiple OIDC providers configured, expected exactly one")
 		}
 
 		oidcProvider := clusterAuthentication.Spec.OIDCProviders[0]
@@ -83,7 +79,7 @@ func ResolveOIDCAuthentication(ctx *chetypes.DeployContext) (*chetypes.OIDCAuthe
 
 			// Sync issuer CA
 			if oidcProvider.Issuer.CertificateAuthority.Name != "" {
-				err = syncIssuerCASecret(
+				issuerCA, err := readIssuerCASecret(
 					oidcProvider.Issuer.CertificateAuthority.Name,
 					openshiftConfigNamespace,
 					ctx,
@@ -91,6 +87,7 @@ func ResolveOIDCAuthentication(ctx *chetypes.DeployContext) (*chetypes.OIDCAuthe
 				if err != nil {
 					return nil, fmt.Errorf("failed to sync issuer CA: %w", err)
 				}
+				authentication.IssuerCA = issuerCA
 			}
 		}
 
@@ -99,14 +96,16 @@ func ResolveOIDCAuthentication(ctx *chetypes.DeployContext) (*chetypes.OIDCAuthe
 		}
 
 		if authentication.UsernamePrefix == "" {
-			if oidcProvider.ClaimMappings.Username.Prefix != nil {
-				if oidcProvider.ClaimMappings.Username.PrefixPolicy == configv1.NoOpinion {
-					// NoOpinion (default): prefix with issuerURL unless claim is "email"
+			if authentication.UsernamePrefix == "" {
+				switch oidcProvider.ClaimMappings.Username.PrefixPolicy {
+				case configv1.NoOpinion:
 					if authentication.UsernameClaim != "email" {
 						authentication.UsernamePrefix = fmt.Sprintf("%s#", authentication.IssuerURL)
 					}
-				} else {
-					authentication.UsernamePrefix = oidcProvider.ClaimMappings.Username.Prefix.PrefixString
+				case configv1.Prefix:
+					if oidcProvider.ClaimMappings.Username.Prefix != nil {
+						authentication.UsernamePrefix = oidcProvider.ClaimMappings.Username.Prefix.PrefixString
+					}
 				}
 			}
 		}
@@ -197,58 +196,24 @@ func resolveOIDCClientSecret(oidcClientSecret string, ctx *chetypes.DeployContex
 	return []byte(oidcClientSecret), nil
 }
 
-func syncIssuerCASecret(
+func readIssuerCASecret(
 	issuerCASecretName string,
 	issuerCASecretNamespace string,
 	ctx *chetypes.DeployContext,
-) error {
-	sourceIssuerCASecret := &corev1.Secret{}
+) (string, error) {
+	secret := &corev1.Secret{}
 
-	// Fetch from a foreign namespace (e.g. openshift-config), use client instead of wrapper
-	// in order to catch all errors including NotFound
 	err := ctx.ClusterAPI.NonCachingClient.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      issuerCASecretName,
 			Namespace: issuerCASecretNamespace,
 		},
-		sourceIssuerCASecret,
+		secret,
 	)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	// Labeled as CheCABundle so it gets merged into `ca-certs-merged` and mounted to all components.
-	oidcIssuerCACM := &corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ConfigMap",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      oidcIssuerCAConfigMapName,
-			Namespace: ctx.CheCluster.Namespace,
-			Labels:    deploy.GetLabels(constants.CheCABundle),
-		},
-		Data: map[string]string{
-			"ca-bundle.crt": string(sourceIssuerCASecret.Data[issuerCAKey]),
-		},
-	}
-
-	err = controllerutil.SetControllerReference(ctx.CheCluster, oidcIssuerCACM, ctx.ClusterAPI.Scheme)
-	if err != nil {
-		return err
-	}
-
-	err = ctx.ClusterAPI.ClientWrapper.Sync(
-		context.TODO(),
-		oidcIssuerCACM,
-		&k8sclient.SyncOptions{
-			DiffOpts: diffs.ConfigMapEnsureLabels,
-		},
-	)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return string(secret.Data[issuerCAKey]), nil
 }

--- a/controllers/che/authentication.go
+++ b/controllers/che/authentication.go
@@ -79,7 +79,7 @@ func ResolveOIDCAuthentication(ctx *chetypes.DeployContext) (*chetypes.OIDCAuthe
 
 			// Sync issuer CA
 			if oidcProvider.Issuer.CertificateAuthority.Name != "" {
-				issuerCA, err := readIssuerCASecret(
+				issuerCA, err := readIssuerCA(
 					oidcProvider.Issuer.CertificateAuthority.Name,
 					openshiftConfigNamespace,
 					ctx,
@@ -121,7 +121,7 @@ func ResolveOIDCAuthentication(ctx *chetypes.DeployContext) (*chetypes.OIDCAuthe
 		if authentication.OIDCClientId == "" {
 			// Reuse the console's OIDC client credentials when no explicit client is configured.
 			for _, oidcClient := range oidcProvider.OIDCClients {
-				if oidcClient.ComponentName == "openshift-console" {
+				if oidcClient.ComponentName == "console" {
 					authentication.OIDCClientId = oidcClient.ClientID
 
 					if oidcClient.ClientSecret.Name != "" {
@@ -196,24 +196,24 @@ func resolveOIDCClientSecret(oidcClientSecret string, ctx *chetypes.DeployContex
 	return []byte(oidcClientSecret), nil
 }
 
-func readIssuerCASecret(
-	issuerCASecretName string,
-	issuerCASecretNamespace string,
+func readIssuerCA(
+	issuerCAConfigMapName string,
+	issuerCAConfigMapNamespace string,
 	ctx *chetypes.DeployContext,
 ) (string, error) {
-	secret := &corev1.Secret{}
+	cm := &corev1.ConfigMap{}
 
 	err := ctx.ClusterAPI.NonCachingClient.Get(
 		context.TODO(),
 		types.NamespacedName{
-			Name:      issuerCASecretName,
-			Namespace: issuerCASecretNamespace,
+			Name:      issuerCAConfigMapName,
+			Namespace: issuerCAConfigMapNamespace,
 		},
-		secret,
+		cm,
 	)
 	if err != nil {
 		return "", err
 	}
 
-	return string(secret.Data[issuerCAKey]), nil
+	return cm.Data[issuerCAKey], nil
 }

--- a/controllers/che/authentication.go
+++ b/controllers/che/authentication.go
@@ -98,14 +98,14 @@ func ResolveAuthentication(ctx *chetypes.DeployContext) (*chetypes.Authenticatio
 		if authentication.GroupsClaim == "" {
 			authentication.GroupsClaim = oidcProvider.ClaimMappings.Groups.Claim
 		}
-		if authentication.GroupsPrefix == "" {
+		if authentication.GroupsClaim != "" && authentication.GroupsPrefix == "" {
 			authentication.GroupsPrefix = oidcProvider.ClaimMappings.Groups.Prefix
 		}
 
 		if authentication.UsernameClaim == "" {
 			authentication.UsernameClaim = oidcProvider.ClaimMappings.Username.Claim
 		}
-		if authentication.UsernamePrefix == "" {
+		if authentication.UsernameClaim != "" && authentication.UsernamePrefix == "" {
 			switch oidcProvider.ClaimMappings.Username.PrefixPolicy {
 			case configv1.NoOpinion:
 				// See `NoOpinion` description

--- a/controllers/che/authentication.go
+++ b/controllers/che/authentication.go
@@ -22,7 +22,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -79,10 +78,13 @@ func ResolveAuthentication(ctx *chetypes.DeployContext) (*chetypes.Authenticatio
 
 		oidcProvider := clusterAuthentication.Spec.OIDCProviders[0]
 
-		// issuer URL and certificate authority
+		// issuer URL
 		if authentication.IssuerURL == "" {
 			authentication.IssuerURL = oidcProvider.Issuer.URL
+		}
 
+		// issuer certificate authority
+		if authentication.IssuerURL == oidcProvider.Issuer.URL {
 			if oidcProvider.Issuer.CertificateAuthority.Name != "" {
 				issuerCA, err := readIssuerCA(oidcProvider.Issuer.CertificateAuthority.Name, ctx)
 				if err != nil {
@@ -159,25 +161,25 @@ func resolveClientSecretInOpenShiftConfigNamespace(secretName string, ctx *chety
 }
 
 func resolveOAuthSecretInCheNamespace(ctx *chetypes.DeployContext) ([]byte, error) {
-	secrets, err := ctx.ClusterAPI.ClientWrapper.List(
+	secret := &corev1.Secret{}
+	exists, err := ctx.ClusterAPI.ClientWrapper.GetIgnoreNotFound(
 		context.TODO(),
-		&corev1.SecretList{},
-		&client.ListOptions{Namespace: ctx.CheCluster.Namespace},
+		types.NamespacedName{
+			Name:      ctx.CheCluster.Spec.Networking.Auth.OAuthSecret,
+			Namespace: ctx.CheCluster.Namespace,
+		},
+		secret,
 	)
 	if err != nil {
 		return nil, err
 	}
-
-	for _, obj := range secrets {
-		secret := obj.(*corev1.Secret)
-		if secret.Name == ctx.CheCluster.Spec.Networking.Auth.OAuthSecret {
-			value, ok := secret.Data["oAuthSecret"]
-			if ok {
-				return value, nil
-			}
-
-			return nil, fmt.Errorf("client secret not found in: %s", ctx.CheCluster.Spec.Networking.Auth.OAuthSecret)
+	if exists {
+		value, ok := secret.Data["oAuthSecret"]
+		if ok {
+			return value, nil
 		}
+
+		return nil, fmt.Errorf("client secret not found in: %s", ctx.CheCluster.Spec.Networking.Auth.OAuthSecret)
 	}
 
 	// Backward compatibility: treat as a literal secret value, not a reference.

--- a/controllers/che/authentication.go
+++ b/controllers/che/authentication.go
@@ -15,12 +15,14 @@ package che
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/eclipse-che/che-operator/pkg/common/chetypes"
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -28,29 +30,32 @@ const (
 	// See: https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/authentication_and_authorization/external-auth
 	openshiftConfigNamespace = "openshift-config"
 	issuerCAKey              = "ca-bundle.crt"
-
-	openShiftNamespaceOIDCClientSecretKey = "clientSecret"
-	cheNamespaceOIDCClientSecretKey       = "oAuthSecret"
+	oidcClientSecretKey      = "clientSecret"
 )
 
-// ResolveOIDCAuthentication builds an Authentication config from the CheCluster spec,
+// ResolveAuthentication builds an Authentication config from the CheCluster spec,
 // falling back to the OpenShift cluster Authentication resource for any unset fields.
-func ResolveOIDCAuthentication(ctx *chetypes.DeployContext) (*chetypes.OIDCAuthentication, error) {
-	authentication := &chetypes.OIDCAuthentication{
+func ResolveAuthentication(ctx *chetypes.DeployContext) (*chetypes.Authentication, error) {
+	authentication := &chetypes.Authentication{
 		UsernameClaim:  ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_OIDC_USERNAME__CLAIM"],
 		UsernamePrefix: ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_OIDC_USERNAME__PREFIX"],
 		GroupsClaim:    ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_OIDC_GROUPS__CLAIM"],
 		GroupsPrefix:   ctx.CheCluster.Spec.Components.CheServer.ExtraProperties["CHE_OIDC_GROUPS__PREFIX"],
 		IssuerURL:      ctx.CheCluster.Spec.Networking.Auth.IdentityProviderURL,
-		OIDCClientId:   ctx.CheCluster.Spec.Networking.Auth.OAuthClientName,
+		// OIDC client ID must be explicitly defined; the openshift-console client
+		// cannot be reused because it has a different callback URL.
+		ClientId: ctx.CheCluster.Spec.Networking.Auth.OAuthClientName,
 	}
 
+	// must be outside main `if` condition
 	if ctx.CheCluster.Spec.Networking.Auth.OAuthSecret != "" {
-		oidcClientSecret, err := resolveOIDCClientSecret(ctx.CheCluster.Spec.Networking.Auth.OAuthSecret, ctx)
+		// `OAuthSecret` can be a Kubernetes Secret name in CheCluster namespace
+		// or a literal value; resolve accordingly.
+		clientSecret, err := resolveOAuthSecretInCheNamespace(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve OIDC client secret: %w", err)
+			return nil, fmt.Errorf("failed to resolve secret: %w", err)
 		}
-		authentication.OIDCClientSecret = oidcClientSecret
+		authentication.ClientSecret = clientSecret
 	}
 
 	if infrastructure.IsOpenShiftExternalAuth() {
@@ -74,70 +79,59 @@ func ResolveOIDCAuthentication(ctx *chetypes.DeployContext) (*chetypes.OIDCAuthe
 
 		oidcProvider := clusterAuthentication.Spec.OIDCProviders[0]
 
+		// issuer URL and certificate authority
 		if authentication.IssuerURL == "" {
 			authentication.IssuerURL = oidcProvider.Issuer.URL
 
-			// Sync issuer CA
 			if oidcProvider.Issuer.CertificateAuthority.Name != "" {
-				issuerCA, err := readIssuerCA(
-					oidcProvider.Issuer.CertificateAuthority.Name,
-					openshiftConfigNamespace,
-					ctx,
-				)
+				issuerCA, err := readIssuerCA(oidcProvider.Issuer.CertificateAuthority.Name, ctx)
 				if err != nil {
-					return nil, fmt.Errorf("failed to sync issuer CA: %w", err)
+					return nil, fmt.Errorf("failed to read issuer CA: %w", err)
 				}
 				authentication.IssuerCA = issuerCA
 			}
 		}
 
-		if authentication.UsernameClaim == "" {
-			authentication.UsernameClaim = oidcProvider.ClaimMappings.Username.Claim
-		}
-
-		if authentication.UsernamePrefix == "" {
-			if authentication.UsernamePrefix == "" {
-				switch oidcProvider.ClaimMappings.Username.PrefixPolicy {
-				case configv1.NoOpinion:
-					if authentication.UsernameClaim != "email" {
-						authentication.UsernamePrefix = fmt.Sprintf("%s#", authentication.IssuerURL)
-					}
-				case configv1.Prefix:
-					if oidcProvider.ClaimMappings.Username.Prefix != nil {
-						authentication.UsernamePrefix = oidcProvider.ClaimMappings.Username.Prefix.PrefixString
-					}
-				}
-			}
-		}
-
+		// username/groups claim mappings
 		if authentication.GroupsClaim == "" {
 			authentication.GroupsClaim = oidcProvider.ClaimMappings.Groups.Claim
 		}
-
 		if authentication.GroupsPrefix == "" {
 			authentication.GroupsPrefix = oidcProvider.ClaimMappings.Groups.Prefix
 		}
 
-		if authentication.OIDCClientId == "" {
-			// Reuse the console's OIDC client credentials when no explicit client is configured.
-			for _, oidcClient := range oidcProvider.OIDCClients {
-				if oidcClient.ComponentName == "console" {
-					authentication.OIDCClientId = oidcClient.ClientID
-
-					if oidcClient.ClientSecret.Name != "" {
-						oidcClientSecret, err := readOIDCClientSecretFromOpenShiftNamespace(oidcClient.ClientSecret.Name, ctx)
-						if err != nil {
-							return nil, fmt.Errorf("failed to read OIDC client secret: %w", err)
-						}
-						authentication.OIDCClientSecret = oidcClientSecret
-					}
-
-					break
+		if authentication.UsernameClaim == "" {
+			authentication.UsernameClaim = oidcProvider.ClaimMappings.Username.Claim
+		}
+		if authentication.UsernamePrefix == "" {
+			switch oidcProvider.ClaimMappings.Username.PrefixPolicy {
+			case configv1.NoOpinion:
+				// See `NoOpinion` description
+				if authentication.UsernameClaim != "email" {
+					authentication.UsernamePrefix = fmt.Sprintf("%s#", authentication.IssuerURL)
+				}
+			case configv1.Prefix:
+				if oidcProvider.ClaimMappings.Username.Prefix != nil {
+					authentication.UsernamePrefix = oidcProvider.ClaimMappings.Username.Prefix.PrefixString
 				}
 			}
+		}
 
-			if authentication.OIDCClientId == "" {
-				return nil, fmt.Errorf("failed to find `openshift-console` OIDC client")
+		// client secret
+		if len(authentication.ClientSecret) == 0 {
+			idx := slices.IndexFunc(oidcProvider.OIDCClients, func(config configv1.OIDCClientConfig) bool {
+				return config.ClientID == authentication.ClientId
+			})
+
+			if idx != -1 {
+				oidcClient := oidcProvider.OIDCClients[idx]
+				if oidcClient.ClientSecret.Name != "" {
+					clientSecret, err := resolveClientSecretInOpenShiftConfigNamespace(oidcClient.ClientSecret.Name, ctx)
+					if err != nil {
+						return nil, fmt.Errorf("failed to read client secret: %w", err)
+					}
+					authentication.ClientSecret = clientSecret
+				}
 			}
 		}
 	}
@@ -145,75 +139,66 @@ func ResolveOIDCAuthentication(ctx *chetypes.DeployContext) (*chetypes.OIDCAuthe
 	return authentication, nil
 }
 
-func readOIDCClientSecretFromOpenShiftNamespace(oidcClientSecretName string, ctx *chetypes.DeployContext) ([]byte, error) {
+func resolveClientSecretInOpenShiftConfigNamespace(secretName string, ctx *chetypes.DeployContext) ([]byte, error) {
 	secret := &corev1.Secret{}
-
-	// Use client instead of wrapper in order to catch all errors including NotFound
 	err := ctx.ClusterAPI.NonCachingClient.Get(
 		context.TODO(),
-		types.NamespacedName{
-			Name:      oidcClientSecretName,
-			Namespace: openshiftConfigNamespace,
-		},
+		types.NamespacedName{Name: secretName, Namespace: openshiftConfigNamespace},
 		secret,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	value, ok := secret.Data[openShiftNamespaceOIDCClientSecretKey]
-	if !ok {
-		return nil, fmt.Errorf("no client secret found")
-	}
-
-	return value, nil
-}
-
-func resolveOIDCClientSecret(oidcClientSecret string, ctx *chetypes.DeployContext) ([]byte, error) {
-	secret := &corev1.Secret{}
-
-	// treat as Secret name first
-	exists, err := ctx.ClusterAPI.ClientWrapper.GetIgnoreNotFound(
-		context.TODO(),
-		types.NamespacedName{
-			Name:      oidcClientSecret,
-			Namespace: ctx.CheCluster.Namespace,
-		},
-		secret,
-	)
-	if err != nil {
-		return nil, err
-	} else if exists {
-		value, ok := secret.Data[cheNamespaceOIDCClientSecretKey]
-		if !ok {
-			return nil, fmt.Errorf("failed to fetch OIDC client secret: no client secret found")
-		}
-
+	value, ok := secret.Data[oidcClientSecretKey]
+	if ok {
 		return value, nil
 	}
 
-	// Backward compatibility: treat OIDCClientSecretName as a literal secret value, not a reference.
-	return []byte(oidcClientSecret), nil
+	return nil, fmt.Errorf("client secret not found in: %s", secretName)
 }
 
-func readIssuerCA(
-	issuerCAConfigMapName string,
-	issuerCAConfigMapNamespace string,
-	ctx *chetypes.DeployContext,
-) (string, error) {
-	cm := &corev1.ConfigMap{}
+func resolveOAuthSecretInCheNamespace(ctx *chetypes.DeployContext) ([]byte, error) {
+	secrets, err := ctx.ClusterAPI.ClientWrapper.List(
+		context.TODO(),
+		&corev1.SecretList{},
+		&client.ListOptions{Namespace: ctx.CheCluster.Namespace},
+	)
+	if err != nil {
+		return nil, err
+	}
 
+	for _, obj := range secrets {
+		secret := obj.(*corev1.Secret)
+		if secret.Name == ctx.CheCluster.Spec.Networking.Auth.OAuthSecret {
+			value, ok := secret.Data["oAuthSecret"]
+			if ok {
+				return value, nil
+			}
+
+			return nil, fmt.Errorf("client secret not found in: %s", ctx.CheCluster.Spec.Networking.Auth.OAuthSecret)
+		}
+	}
+
+	// Backward compatibility: treat as a literal secret value, not a reference.
+	return []byte(ctx.CheCluster.Spec.Networking.Auth.OAuthSecret), nil
+}
+
+func readIssuerCA(cmName string, ctx *chetypes.DeployContext) (string, error) {
+	cm := &corev1.ConfigMap{}
 	err := ctx.ClusterAPI.NonCachingClient.Get(
 		context.TODO(),
-		types.NamespacedName{
-			Name:      issuerCAConfigMapName,
-			Namespace: issuerCAConfigMapNamespace,
-		},
+		types.NamespacedName{Name: cmName, Namespace: openshiftConfigNamespace},
 		cm,
 	)
 	if err != nil {
 		return "", err
 	}
 
-	return cm.Data[issuerCAKey], nil
+	ca, ok := cm.Data[issuerCAKey]
+	if !ok {
+		return "", fmt.Errorf("issuer CA not found in the ConfigMap %s", cmName)
+	}
+
+	return ca, nil
 }

--- a/controllers/che/authentication_test.go
+++ b/controllers/che/authentication_test.go
@@ -97,13 +97,21 @@ func TestResolveOIDCAuthentication(t *testing.T) {
 			},
 		},
 		{
-			name:         "OpenShift without OAuth, fields resolved from cluster Authentication",
+			name:         "OpenShift without OAuth, claim mappings resolved from cluster Authentication",
 			isOpenShift:  true,
 			oAuthEnabled: false,
 			cheCluster: &chev2.CheCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "eclipse-che",
 					Namespace: "eclipse-che",
+				},
+				Spec: chev2.CheClusterSpec{
+					Networking: chev2.CheClusterSpecNetworking{
+						Auth: chev2.Auth{
+							IdentityProviderURL: "https://oidc.example.com",
+							OAuthClientName:     "che-client",
+						},
+					},
 				},
 			},
 			initObjects: []client.Object{
@@ -134,11 +142,11 @@ func TestResolveOIDCAuthentication(t *testing.T) {
 								},
 								OIDCClients: []configv1.OIDCClientConfig{
 									{
-										ComponentName:      "openshift-console",
+										ComponentName:      "console",
 										ComponentNamespace: "openshift-console",
-										ClientID:           "console-client-id",
+										ClientID:           "che-client",
 										ClientSecret: configv1.SecretNameReference{
-											Name: "console-secret",
+											Name: "che-secret",
 										},
 									},
 								},
@@ -148,18 +156,18 @@ func TestResolveOIDCAuthentication(t *testing.T) {
 				},
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "console-secret",
+						Name:      "che-secret",
 						Namespace: "openshift-config",
 					},
 					Data: map[string][]byte{
-						"clientSecret": []byte("console-secret-value"),
+						"clientSecret": []byte("che-secret-value"),
 					},
 				},
 			},
 			expectedAuth: &oidcAuthResult{
 				IssuerURL:        "https://oidc.example.com",
-				OIDCClientId:     "console-client-id",
-				OIDCClientSecret: "console-secret-value",
+				OIDCClientId:     "che-client",
+				OIDCClientSecret: "che-secret-value",
 				UsernameClaim:    "sub",
 				UsernamePrefix:   "oidc-user:",
 				GroupsClaim:      "groups",
@@ -212,7 +220,7 @@ func TestResolveOIDCAuthentication(t *testing.T) {
 				WithObjects(tc.initObjects...).
 				Build()
 
-			auth, err := ResolveOIDCAuthentication(ctx)
+			auth, err := ResolveAuthentication(ctx)
 
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
@@ -220,8 +228,8 @@ func TestResolveOIDCAuthentication(t *testing.T) {
 
 			got := &oidcAuthResult{
 				IssuerURL:        auth.IssuerURL,
-				OIDCClientId:     auth.OIDCClientId,
-				OIDCClientSecret: string(auth.OIDCClientSecret),
+				OIDCClientId:     auth.ClientId,
+				OIDCClientSecret: string(auth.ClientSecret),
 				UsernameClaim:    auth.UsernameClaim,
 				UsernamePrefix:   auth.UsernamePrefix,
 				GroupsClaim:      auth.GroupsClaim,

--- a/controllers/che/authentication_test.go
+++ b/controllers/che/authentication_test.go
@@ -27,6 +27,7 @@ import (
 
 type oidcAuthResult struct {
 	IssuerURL        string
+	IssuerCA         string
 	OIDCClientId     string
 	OIDCClientSecret string
 	UsernameClaim    string
@@ -111,8 +112,7 @@ func TestResolveOIDCAuthentication(t *testing.T) {
 				Spec: chev2.CheClusterSpec{
 					Networking: chev2.CheClusterSpecNetworking{
 						Auth: chev2.Auth{
-							IdentityProviderURL: "https://oidc.example.com",
-							OAuthClientName:     "che-client",
+							OAuthClientName: "che-client",
 						},
 					},
 				},
@@ -202,6 +202,282 @@ func TestResolveOIDCAuthentication(t *testing.T) {
 				OIDCClientSecret: "literal-secret-value",
 			},
 		},
+		{
+			name:         "OpenShift: IssuerCA not resolved when issuer URLs differ",
+			isOpenShift:  true,
+			oAuthEnabled: false,
+			cheCluster: &chev2.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "eclipse-che",
+					Namespace: "eclipse-che",
+				},
+				Spec: chev2.CheClusterSpec{
+					Networking: chev2.CheClusterSpecNetworking{
+						Auth: chev2.Auth{
+							IdentityProviderURL: "https://custom-oidc.example.com",
+							OAuthClientName:     "che-client",
+						},
+					},
+				},
+			},
+			initObjects: []client.Object{
+				&configv1.Authentication{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Spec: configv1.AuthenticationSpec{
+						Type: configv1.AuthenticationTypeOIDC,
+						OIDCProviders: []configv1.OIDCProvider{
+							{
+								Name: "my-oidc",
+								Issuer: configv1.TokenIssuer{
+									URL:                  "https://cluster-oidc.example.com",
+									CertificateAuthority: configv1.ConfigMapNameReference{Name: "issuer-ca"},
+								},
+							},
+						},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "issuer-ca",
+						Namespace: "openshift-config",
+					},
+					Data: map[string]string{
+						"ca-bundle.crt": "should-not-be-used",
+					},
+				},
+			},
+			expectedAuth: &oidcAuthResult{
+				IssuerURL:    "https://custom-oidc.example.com",
+				OIDCClientId: "che-client",
+				IssuerCA:     "",
+			},
+		},
+		{
+			name:         "OpenShift: UsernamePrefix with NoOpinion policy and claim is email",
+			isOpenShift:  true,
+			oAuthEnabled: false,
+			cheCluster: &chev2.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "eclipse-che",
+					Namespace: "eclipse-che",
+				},
+				Spec: chev2.CheClusterSpec{
+					Networking: chev2.CheClusterSpecNetworking{
+						Auth: chev2.Auth{
+							IdentityProviderURL: "https://oidc.example.com",
+							OAuthClientName:     "che-client",
+						},
+					},
+				},
+			},
+			initObjects: []client.Object{
+				&configv1.Authentication{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Spec: configv1.AuthenticationSpec{
+						Type: configv1.AuthenticationTypeOIDC,
+						OIDCProviders: []configv1.OIDCProvider{
+							{
+								Name: "my-oidc",
+								Issuer: configv1.TokenIssuer{
+									URL: "https://oidc.example.com",
+								},
+								ClaimMappings: configv1.TokenClaimMappings{
+									Username: configv1.UsernameClaimMapping{
+										Claim:        "email",
+										PrefixPolicy: configv1.NoOpinion,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedAuth: &oidcAuthResult{
+				IssuerURL:     "https://oidc.example.com",
+				OIDCClientId:  "che-client",
+				UsernameClaim: "email",
+			},
+		},
+		{
+			name:         "OpenShift: UsernamePrefix with NoOpinion policy and claim is not email",
+			isOpenShift:  true,
+			oAuthEnabled: false,
+			cheCluster: &chev2.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "eclipse-che",
+					Namespace: "eclipse-che",
+				},
+				Spec: chev2.CheClusterSpec{
+					Networking: chev2.CheClusterSpecNetworking{
+						Auth: chev2.Auth{
+							IdentityProviderURL: "https://oidc.example.com",
+							OAuthClientName:     "che-client",
+						},
+					},
+				},
+			},
+			initObjects: []client.Object{
+				&configv1.Authentication{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Spec: configv1.AuthenticationSpec{
+						Type: configv1.AuthenticationTypeOIDC,
+						OIDCProviders: []configv1.OIDCProvider{
+							{
+								Name: "my-oidc",
+								Issuer: configv1.TokenIssuer{
+									URL: "https://oidc.example.com",
+								},
+								ClaimMappings: configv1.TokenClaimMappings{
+									Username: configv1.UsernameClaimMapping{
+										Claim:        "sub",
+										PrefixPolicy: configv1.NoOpinion,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedAuth: &oidcAuthResult{
+				IssuerURL:      "https://oidc.example.com",
+				OIDCClientId:   "che-client",
+				UsernameClaim:  "sub",
+				UsernamePrefix: "https://oidc.example.com#",
+			},
+		},
+		{
+			name:         "OpenShift: Client secret not resolved when no OIDCClient matches ClientID",
+			isOpenShift:  true,
+			oAuthEnabled: false,
+			cheCluster: &chev2.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "eclipse-che",
+					Namespace: "eclipse-che",
+				},
+				Spec: chev2.CheClusterSpec{
+					Networking: chev2.CheClusterSpecNetworking{
+						Auth: chev2.Auth{
+							IdentityProviderURL: "https://oidc.example.com",
+							OAuthClientName:     "che-client",
+						},
+					},
+				},
+			},
+			initObjects: []client.Object{
+				&configv1.Authentication{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Spec: configv1.AuthenticationSpec{
+						Type: configv1.AuthenticationTypeOIDC,
+						OIDCProviders: []configv1.OIDCProvider{
+							{
+								Name: "my-oidc",
+								Issuer: configv1.TokenIssuer{
+									URL: "https://oidc.example.com",
+								},
+								OIDCClients: []configv1.OIDCClientConfig{
+									{
+										ClientID: "other-client",
+										ClientSecret: configv1.SecretNameReference{
+											Name: "other-secret",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedAuth: &oidcAuthResult{
+				IssuerURL:        "https://oidc.example.com",
+				OIDCClientId:     "che-client",
+				OIDCClientSecret: "",
+			},
+		},
+		{
+			name:         "OpenShift: CheCluster fields take precedence over cluster Authentication",
+			isOpenShift:  true,
+			oAuthEnabled: false,
+			cheCluster: &chev2.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "eclipse-che",
+					Namespace: "eclipse-che",
+				},
+				Spec: chev2.CheClusterSpec{
+					Networking: chev2.CheClusterSpecNetworking{
+						Auth: chev2.Auth{
+							IdentityProviderURL: "https://custom-oidc.example.com",
+							OAuthClientName:     "che-client",
+							OAuthSecret:         "che-override-secret",
+						},
+					},
+					Components: chev2.CheClusterComponents{
+						CheServer: chev2.CheServer{
+							ExtraProperties: map[string]string{
+								"CHE_OIDC_USERNAME__CLAIM":  "custom_user",
+								"CHE_OIDC_USERNAME__PREFIX": "custom-prefix:",
+								"CHE_OIDC_GROUPS__CLAIM":    "custom_groups",
+								"CHE_OIDC_GROUPS__PREFIX":   "custom-group:",
+							},
+						},
+					},
+				},
+			},
+			initObjects: []client.Object{
+				&configv1.Authentication{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Spec: configv1.AuthenticationSpec{
+						Type: configv1.AuthenticationTypeOIDC,
+						OIDCProviders: []configv1.OIDCProvider{
+							{
+								Name: "my-oidc",
+								Issuer: configv1.TokenIssuer{
+									URL: "https://cluster-oidc.example.com",
+								},
+								ClaimMappings: configv1.TokenClaimMappings{
+									Username: configv1.UsernameClaimMapping{
+										Claim:        "sub",
+										Prefix:       &configv1.UsernamePrefix{PrefixString: "cluster:"},
+										PrefixPolicy: configv1.Prefix,
+									},
+									Groups: configv1.PrefixedClaimMapping{
+										TokenClaimMapping: configv1.TokenClaimMapping{
+											Claim: "groups",
+										},
+										Prefix: "cluster-group:",
+									},
+								},
+								OIDCClients: []configv1.OIDCClientConfig{
+									{
+										ClientID: "che-client",
+										ClientSecret: configv1.SecretNameReference{
+											Name: "cluster-secret",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cluster-secret",
+						Namespace: "openshift-config",
+					},
+					Data: map[string][]byte{
+						"clientSecret": []byte("cluster-secret-value"),
+					},
+				},
+			},
+			expectedAuth: &oidcAuthResult{
+				IssuerURL:        "https://custom-oidc.example.com",
+				OIDCClientId:     "che-client",
+				OIDCClientSecret: "che-override-secret",
+				UsernameClaim:    "custom_user",
+				UsernamePrefix:   "custom-prefix:",
+				GroupsClaim:      "custom_groups",
+				GroupsPrefix:     "custom-group:",
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -231,6 +507,7 @@ func TestResolveOIDCAuthentication(t *testing.T) {
 
 			got := &oidcAuthResult{
 				IssuerURL:        auth.IssuerURL,
+				IssuerCA:         auth.IssuerCA,
 				OIDCClientId:     auth.ClientId,
 				OIDCClientSecret: string(auth.ClientSecret),
 				UsernameClaim:    auth.UsernameClaim,

--- a/controllers/che/authentication_test.go
+++ b/controllers/che/authentication_test.go
@@ -1,0 +1,244 @@
+//
+// Copyright (c) 2019-2026 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package che
+
+import (
+	"strings"
+	"testing"
+
+	chev2 "github.com/eclipse-che/che-operator/api/v2"
+	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	"github.com/eclipse-che/che-operator/pkg/common/test"
+	"github.com/google/go-cmp/cmp"
+	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type oidcAuthResult struct {
+	IssuerURL        string
+	OIDCClientId     string
+	OIDCClientSecret string
+	UsernameClaim    string
+	UsernamePrefix   string
+	GroupsClaim      string
+	GroupsPrefix     string
+}
+
+func TestResolveOIDCAuthentication(t *testing.T) {
+	type testCase struct {
+		name           string
+		isOpenShift    bool
+		oAuthEnabled   bool
+		cheCluster     *chev2.CheCluster
+		initObjects    []client.Object
+		expectedAuth   *oidcAuthResult
+		expectedErrMsg string
+	}
+
+	testCases := []testCase{
+		{
+			name:         "All fields from CheCluster spec on Kubernetes",
+			isOpenShift:  false,
+			oAuthEnabled: false,
+			cheCluster: &chev2.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "eclipse-che",
+					Namespace: "eclipse-che",
+				},
+				Spec: chev2.CheClusterSpec{
+					Networking: chev2.CheClusterSpecNetworking{
+						Auth: chev2.Auth{
+							IdentityProviderURL: "https://keycloak.example.com",
+							OAuthClientName:     "che-client",
+							OAuthSecret:         "my-secret",
+						},
+					},
+					Components: chev2.CheClusterComponents{
+						CheServer: chev2.CheServer{
+							ExtraProperties: map[string]string{
+								"CHE_OIDC_USERNAME__CLAIM":  "preferred_username",
+								"CHE_OIDC_USERNAME__PREFIX": "che:",
+								"CHE_OIDC_GROUPS__CLAIM":    "groups",
+								"CHE_OIDC_GROUPS__PREFIX":   "che-group:",
+							},
+						},
+					},
+				},
+			},
+			initObjects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-secret",
+						Namespace: "eclipse-che",
+					},
+					Data: map[string][]byte{
+						"oAuthSecret": []byte("secret-value"),
+					},
+				},
+			},
+			expectedAuth: &oidcAuthResult{
+				IssuerURL:        "https://keycloak.example.com",
+				OIDCClientId:     "che-client",
+				OIDCClientSecret: "secret-value",
+				UsernameClaim:    "preferred_username",
+				UsernamePrefix:   "che:",
+				GroupsClaim:      "groups",
+				GroupsPrefix:     "che-group:",
+			},
+		},
+		{
+			name:         "OpenShift without OAuth, fields resolved from cluster Authentication",
+			isOpenShift:  true,
+			oAuthEnabled: false,
+			cheCluster: &chev2.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "eclipse-che",
+					Namespace: "eclipse-che",
+				},
+			},
+			initObjects: []client.Object{
+				&configv1.Authentication{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: configv1.AuthenticationSpec{
+						Type: configv1.AuthenticationTypeOIDC,
+						OIDCProviders: []configv1.OIDCProvider{
+							{
+								Name: "my-oidc",
+								Issuer: configv1.TokenIssuer{
+									URL: "https://oidc.example.com",
+								},
+								ClaimMappings: configv1.TokenClaimMappings{
+									Username: configv1.UsernameClaimMapping{
+										Claim:        "sub",
+										Prefix:       &configv1.UsernamePrefix{PrefixString: "oidc-user:"},
+										PrefixPolicy: configv1.Prefix,
+									},
+									Groups: configv1.PrefixedClaimMapping{
+										TokenClaimMapping: configv1.TokenClaimMapping{
+											Claim: "groups",
+										},
+										Prefix: "oidc:",
+									},
+								},
+								OIDCClients: []configv1.OIDCClientConfig{
+									{
+										ComponentName:      "openshift-console",
+										ComponentNamespace: "openshift-console",
+										ClientID:           "console-client-id",
+										ClientSecret: configv1.SecretNameReference{
+											Name: "console-secret",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "console-secret",
+						Namespace: "openshift-config",
+					},
+					Data: map[string][]byte{
+						"clientSecret": []byte("console-secret-value"),
+					},
+				},
+			},
+			expectedAuth: &oidcAuthResult{
+				IssuerURL:        "https://oidc.example.com",
+				OIDCClientId:     "console-client-id",
+				OIDCClientSecret: "console-secret-value",
+				UsernameClaim:    "sub",
+				UsernamePrefix:   "oidc-user:",
+				GroupsClaim:      "groups",
+				GroupsPrefix:     "oidc:",
+			},
+		},
+		{
+			name:         "Backward compatibility: OAuthSecret treated as literal value when secret not found",
+			isOpenShift:  false,
+			oAuthEnabled: false,
+			cheCluster: &chev2.CheCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "eclipse-che",
+					Namespace: "eclipse-che",
+				},
+				Spec: chev2.CheClusterSpec{
+					Networking: chev2.CheClusterSpecNetworking{
+						Auth: chev2.Auth{
+							IdentityProviderURL: "https://keycloak.example.com",
+							OAuthClientName:     "che-client",
+							OAuthSecret:         "literal-secret-value",
+						},
+					},
+				},
+			},
+			expectedAuth: &oidcAuthResult{
+				IssuerURL:        "https://keycloak.example.com",
+				OIDCClientId:     "che-client",
+				OIDCClientSecret: "literal-secret-value",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.isOpenShift {
+				infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)
+				infrastructure.SetOpenShiftOAuthEnabledForTesting(tc.oAuthEnabled)
+			} else {
+				infrastructure.InitializeForTesting(infrastructure.Kubernetes)
+			}
+			defer infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)
+
+			ctx := test.NewCtxBuilder().
+				WithCheCluster(tc.cheCluster).
+				WithObjects(tc.initObjects...).
+				Build()
+
+			auth, err := ResolveOIDCAuthentication(ctx)
+
+			if tc.expectedErrMsg != "" {
+				if err == nil {
+					t.Fatalf("Expected error containing %q, got nil", tc.expectedErrMsg)
+				}
+				if !strings.Contains(err.Error(), tc.expectedErrMsg) {
+					t.Fatalf("Expected error containing %q, got %q", tc.expectedErrMsg, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			got := &oidcAuthResult{
+				IssuerURL:        auth.IssuerURL,
+				OIDCClientId:     auth.OIDCClientId,
+				OIDCClientSecret: string(auth.OIDCClientSecret),
+				UsernameClaim:    auth.UsernameClaim,
+				UsernamePrefix:   auth.UsernamePrefix,
+				GroupsClaim:      auth.GroupsClaim,
+				GroupsPrefix:     auth.GroupsPrefix,
+			}
+
+			if diff := cmp.Diff(tc.expectedAuth, got); diff != "" {
+				t.Errorf("Authentication result mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/controllers/che/authentication_test.go
+++ b/controllers/che/authentication_test.go
@@ -80,6 +80,9 @@ func TestResolveOIDCAuthentication(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-secret",
 						Namespace: "eclipse-che",
+						Labels: map[string]string{
+							"app.kubernetes.io/part-of": "eclipse-che",
+						},
 					},
 					Data: map[string][]byte{
 						"oAuthSecret": []byte("secret-value"),

--- a/controllers/che/authentication_test.go
+++ b/controllers/che/authentication_test.go
@@ -13,7 +13,6 @@
 package che
 
 import (
-	"strings"
 	"testing"
 
 	chev2 "github.com/eclipse-che/che-operator/api/v2"
@@ -38,13 +37,12 @@ type oidcAuthResult struct {
 
 func TestResolveOIDCAuthentication(t *testing.T) {
 	type testCase struct {
-		name           string
-		isOpenShift    bool
-		oAuthEnabled   bool
-		cheCluster     *chev2.CheCluster
-		initObjects    []client.Object
-		expectedAuth   *oidcAuthResult
-		expectedErrMsg string
+		name         string
+		isOpenShift  bool
+		oAuthEnabled bool
+		cheCluster   *chev2.CheCluster
+		initObjects  []client.Object
+		expectedAuth *oidcAuthResult
 	}
 
 	testCases := []testCase{
@@ -203,7 +201,11 @@ func TestResolveOIDCAuthentication(t *testing.T) {
 			} else {
 				infrastructure.InitializeForTesting(infrastructure.Kubernetes)
 			}
-			defer infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)
+
+			defer func() {
+				infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)
+				infrastructure.SetOpenShiftOAuthEnabledForTesting(true)
+			}()
 
 			ctx := test.NewCtxBuilder().
 				WithCheCluster(tc.cheCluster).
@@ -211,16 +213,6 @@ func TestResolveOIDCAuthentication(t *testing.T) {
 				Build()
 
 			auth, err := ResolveOIDCAuthentication(ctx)
-
-			if tc.expectedErrMsg != "" {
-				if err == nil {
-					t.Fatalf("Expected error containing %q, got nil", tc.expectedErrMsg)
-				}
-				if !strings.Contains(err.Error(), tc.expectedErrMsg) {
-					t.Fatalf("Expected error containing %q, got %q", tc.expectedErrMsg, err.Error())
-				}
-				return
-			}
 
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)

--- a/controllers/che/checluster_controller.go
+++ b/controllers/che/checluster_controller.go
@@ -245,6 +245,7 @@ func (r *CheClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	oidcAuthentication, err := ResolveOIDCAuthentication(deployContext)
 	if err != nil {
+		r.Log.Error(err, "Error on resolving OIDC authentication")
 		return ctrl.Result{}, err
 	}
 	deployContext.OIDCAuthentication = oidcAuthentication

--- a/controllers/che/checluster_controller.go
+++ b/controllers/che/checluster_controller.go
@@ -235,7 +235,7 @@ func (r *CheClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		CheCluster: checluster,
 	}
 
-	// Read proxy configuration
+	// Resolve proxy configuration
 	proxy, err := GetProxyConfiguration(deployContext)
 	if err != nil {
 		r.Log.Error(err, "Error on reading proxy configuration")
@@ -243,12 +243,13 @@ func (r *CheClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	deployContext.Proxy = proxy
 
-	oidcAuthentication, err := ResolveOIDCAuthentication(deployContext)
+	// Resolve authentication configuration
+	authentication, err := ResolveAuthentication(deployContext)
 	if err != nil {
-		r.Log.Error(err, "Error on resolving OIDC authentication")
+		r.Log.Error(err, "Error on resolving authentication")
 		return ctrl.Result{}, err
 	}
-	deployContext.OIDCAuthentication = oidcAuthentication
+	deployContext.Authentication = authentication
 
 	// Detect whether self-signed certificate is used
 	isSelfSignedCertificate, err := tls.IsSelfSignedCertificateUsed(deployContext)

--- a/controllers/che/checluster_controller.go
+++ b/controllers/che/checluster_controller.go
@@ -243,6 +243,12 @@ func (r *CheClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	deployContext.Proxy = proxy
 
+	oidcAuthentication, err := ResolveOIDCAuthentication(deployContext)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	deployContext.OIDCAuthentication = oidcAuthentication
+
 	// Detect whether self-signed certificate is used
 	isSelfSignedCertificate, err := tls.IsSelfSignedCertificateUsed(deployContext)
 	if err != nil {

--- a/controllers/usernamespace/usernamespace_controller.go
+++ b/controllers/usernamespace/usernamespace_controller.go
@@ -433,7 +433,7 @@ func (r *CheUserNamespaceReconciler) reconcileUserSettings(
 		Data: data,
 	}
 
-	_, err := deploy.Sync(deployContext, cm, diffs.ConfigMapAllLabels)
+	_, err := deploy.Sync(deployContext, cm, diffs.ConfigMapEnsureLabels)
 	return err
 }
 
@@ -487,7 +487,7 @@ func (r *CheUserNamespaceReconciler) reconcileGitTlsCertificate(ctx context.Cont
 		target.Data["host"] = gitCert.Data[constants.GitSelfSignedCertsConfigMapGitHostKey]
 	}
 
-	_, err := deploy.Sync(deployContext, &target, diffs.ConfigMapAllLabels)
+	_, err := deploy.Sync(deployContext, &target, diffs.ConfigMapEnsureLabels)
 	return err
 }
 

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -23045,6 +23045,7 @@ rules:
   - cluster
   resources:
   - proxies
+  - authentications
   verbs:
   - get
 - apiGroups:

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -22671,11 +22671,11 @@ spec:
                         type: string
                       oAuthSecret:
                         description: |-
-                          Defines the OAuth client secret.
-                          It can either be a plain text secret value or the name of a Kubernetes secret
-                          containing a key `oAuthSecret` with the secret value. The Kubernetes secret must exist in the same namespace
-                          as the `CheCluster` resource and have the label `app.kubernetes.io/part-of=che.eclipse.org`.
-                          For OpenShift with built-in OAuth, this is the secret set in the `OAuthClient` resource used to set up identity federation.
+                          For OIDC, this is the client secret issued by the Identity Provider for the configured OIDC client.
+                          For OpenShift with built-in OAuth, this is the secret configured in the OAuthClient for OpenShift OAuth integration.
+                          The value can either be a plain text secret value (deprecated) or the name of a Kubernetes secret
+                          that contains the secret value under the `oAuthSecret` key. The Kubernetes secret must exist in the same namespace
+                          as the `CheCluster` resource namespace and must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                     type: object
                   domain:

--- a/deploy/deployment/kubernetes/objects/che-operator.ClusterRole.yaml
+++ b/deploy/deployment/kubernetes/objects/che-operator.ClusterRole.yaml
@@ -249,6 +249,7 @@ rules:
   - cluster
   resources:
   - proxies
+  - authentications
   verbs:
   - get
 - apiGroups:

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -22666,11 +22666,11 @@ spec:
                         type: string
                       oAuthSecret:
                         description: |-
-                          Defines the OAuth client secret.
-                          It can either be a plain text secret value or the name of a Kubernetes secret
-                          containing a key `oAuthSecret` with the secret value. The Kubernetes secret must exist in the same namespace
-                          as the `CheCluster` resource and have the label `app.kubernetes.io/part-of=che.eclipse.org`.
-                          For OpenShift with built-in OAuth, this is the secret set in the `OAuthClient` resource used to set up identity federation.
+                          For OIDC, this is the client secret issued by the Identity Provider for the configured OIDC client.
+                          For OpenShift with built-in OAuth, this is the secret configured in the OAuthClient for OpenShift OAuth integration.
+                          The value can either be a plain text secret value (deprecated) or the name of a Kubernetes secret
+                          that contains the secret value under the `oAuthSecret` key. The Kubernetes secret must exist in the same namespace
+                          as the `CheCluster` resource namespace and must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                     type: object
                   domain:

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -23045,6 +23045,7 @@ rules:
   - cluster
   resources:
   - proxies
+  - authentications
   verbs:
   - get
 - apiGroups:

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -22671,11 +22671,11 @@ spec:
                         type: string
                       oAuthSecret:
                         description: |-
-                          Defines the OAuth client secret.
-                          It can either be a plain text secret value or the name of a Kubernetes secret
-                          containing a key `oAuthSecret` with the secret value. The Kubernetes secret must exist in the same namespace
-                          as the `CheCluster` resource and have the label `app.kubernetes.io/part-of=che.eclipse.org`.
-                          For OpenShift with built-in OAuth, this is the secret set in the `OAuthClient` resource used to set up identity federation.
+                          For OIDC, this is the client secret issued by the Identity Provider for the configured OIDC client.
+                          For OpenShift with built-in OAuth, this is the secret configured in the OAuthClient for OpenShift OAuth integration.
+                          The value can either be a plain text secret value (deprecated) or the name of a Kubernetes secret
+                          that contains the secret value under the `oAuthSecret` key. The Kubernetes secret must exist in the same namespace
+                          as the `CheCluster` resource namespace and must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                     type: object
                   domain:

--- a/deploy/deployment/openshift/objects/che-operator.ClusterRole.yaml
+++ b/deploy/deployment/openshift/objects/che-operator.ClusterRole.yaml
@@ -249,6 +249,7 @@ rules:
   - cluster
   resources:
   - proxies
+  - authentications
   verbs:
   - get
 - apiGroups:

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -22666,11 +22666,11 @@ spec:
                         type: string
                       oAuthSecret:
                         description: |-
-                          Defines the OAuth client secret.
-                          It can either be a plain text secret value or the name of a Kubernetes secret
-                          containing a key `oAuthSecret` with the secret value. The Kubernetes secret must exist in the same namespace
-                          as the `CheCluster` resource and have the label `app.kubernetes.io/part-of=che.eclipse.org`.
-                          For OpenShift with built-in OAuth, this is the secret set in the `OAuthClient` resource used to set up identity federation.
+                          For OIDC, this is the client secret issued by the Identity Provider for the configured OIDC client.
+                          For OpenShift with built-in OAuth, this is the secret configured in the OAuthClient for OpenShift OAuth integration.
+                          The value can either be a plain text secret value (deprecated) or the name of a Kubernetes secret
+                          that contains the secret value under the `oAuthSecret` key. The Kubernetes secret must exist in the same namespace
+                          as the `CheCluster` resource namespace and must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                     type: object
                   domain:

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -22666,11 +22666,11 @@ spec:
                         type: string
                       oAuthSecret:
                         description: |-
-                          Defines the OAuth client secret.
-                          It can either be a plain text secret value or the name of a Kubernetes secret
-                          containing a key `oAuthSecret` with the secret value. The Kubernetes secret must exist in the same namespace
-                          as the `CheCluster` resource and have the label `app.kubernetes.io/part-of=che.eclipse.org`.
-                          For OpenShift with built-in OAuth, this is the secret set in the `OAuthClient` resource used to set up identity federation.
+                          For OIDC, this is the client secret issued by the Identity Provider for the configured OIDC client.
+                          For OpenShift with built-in OAuth, this is the secret configured in the OAuthClient for OpenShift OAuth integration.
+                          The value can either be a plain text secret value (deprecated) or the name of a Kubernetes secret
+                          that contains the secret value under the `oAuthSecret` key. The Kubernetes secret must exist in the same namespace
+                          as the `CheCluster` resource namespace and must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
                         type: string
                     type: object
                   domain:

--- a/helmcharts/next/templates/che-operator.ClusterRole.yaml
+++ b/helmcharts/next/templates/che-operator.ClusterRole.yaml
@@ -249,6 +249,7 @@ rules:
   - cluster
   resources:
   - proxies
+  - authentications
   verbs:
   - get
 - apiGroups:

--- a/pkg/common/chetypes/types.go
+++ b/pkg/common/chetypes/types.go
@@ -46,6 +46,7 @@ type OIDCAuthentication struct {
 	UsernamePrefix string
 
 	IssuerURL string
+	IssuerCA  string
 
 	OIDCClientId     string
 	OIDCClientSecret []byte

--- a/pkg/common/chetypes/types.go
+++ b/pkg/common/chetypes/types.go
@@ -24,7 +24,7 @@ type DeployContext struct {
 	CheCluster              *chev2.CheCluster
 	ClusterAPI              ClusterAPI
 	Proxy                   *Proxy
-	OIDCAuthentication      *OIDCAuthentication
+	Authentication          *Authentication
 	IsSelfSignedCertificate bool
 	CheHost                 string
 	DwoNamespace            string
@@ -39,7 +39,7 @@ type ClusterAPI struct {
 	NonCachingClientWrapper *k8sclient.K8sClientWrapper
 }
 
-type OIDCAuthentication struct {
+type Authentication struct {
 	GroupsClaim    string
 	GroupsPrefix   string
 	UsernameClaim  string
@@ -48,8 +48,8 @@ type OIDCAuthentication struct {
 	IssuerURL string
 	IssuerCA  string
 
-	OIDCClientId     string
-	OIDCClientSecret []byte
+	ClientId     string
+	ClientSecret []byte
 }
 
 type Proxy struct {

--- a/pkg/common/chetypes/types.go
+++ b/pkg/common/chetypes/types.go
@@ -24,6 +24,7 @@ type DeployContext struct {
 	CheCluster              *chev2.CheCluster
 	ClusterAPI              ClusterAPI
 	Proxy                   *Proxy
+	OIDCAuthentication      *OIDCAuthentication
 	IsSelfSignedCertificate bool
 	CheHost                 string
 	DwoNamespace            string
@@ -36,6 +37,18 @@ type ClusterAPI struct {
 	Scheme                  *runtime.Scheme
 	ClientWrapper           *k8sclient.K8sClientWrapper
 	NonCachingClientWrapper *k8sclient.K8sClientWrapper
+}
+
+type OIDCAuthentication struct {
+	GroupsClaim    string
+	GroupsPrefix   string
+	UsernameClaim  string
+	UsernamePrefix string
+
+	IssuerURL string
+
+	OIDCClientId     string
+	OIDCClientSecret []byte
 }
 
 type Proxy struct {

--- a/pkg/common/diffs/diffs.go
+++ b/pkg/common/diffs/diffs.go
@@ -44,7 +44,7 @@ var SecurityContextConstraints = cmp.Options{
 	cmpopts.IgnoreFields(securityv1.SecurityContextConstraints{}, "TypeMeta", "ObjectMeta", "Priority"),
 }
 
-var ConfigMapAllLabels = cmp.Options{
+var ConfigMapEnsureLabels = cmp.Options{
 	cmpopts.IgnoreFields(corev1.ConfigMap{}, "TypeMeta"),
 	cmp.Comparer(func(x, y metav1.ObjectMeta) bool {
 		return maps.Equal(x.Labels, y.Labels)

--- a/pkg/common/diffs/diffs_test.go
+++ b/pkg/common/diffs/diffs_test.go
@@ -34,7 +34,7 @@ func TestConfigMap(t *testing.T) {
 		{
 			srcCm:   &corev1.ConfigMap{},
 			dstCm:   &corev1.ConfigMap{},
-			diffs:   ConfigMapAllLabels,
+			diffs:   ConfigMapEnsureLabels,
 			isEqual: true,
 		},
 		{
@@ -45,7 +45,7 @@ func TestConfigMap(t *testing.T) {
 				},
 			},
 			dstCm:   &corev1.ConfigMap{},
-			diffs:   ConfigMapAllLabels,
+			diffs:   ConfigMapEnsureLabels,
 			isEqual: true,
 		},
 	}

--- a/pkg/common/infrastructure/cluster.go
+++ b/pkg/common/infrastructure/cluster.go
@@ -68,7 +68,7 @@ func IsOpenShiftOAuthEnabled() bool {
 	return isOpenShiftOAuthEnabled
 }
 
-func IsOpenShiftWithoutOAuth() bool {
+func IsOpenShiftExternalAuth() bool {
 	initializeIfNeeded()
 	return IsOpenShift() && !IsOpenShiftOAuthEnabled()
 }

--- a/pkg/common/infrastructure/cluster.go
+++ b/pkg/common/infrastructure/cluster.go
@@ -52,15 +52,17 @@ func GetOperatorNamespace() (string, error) {
 		nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 		if err == nil {
 			operatorNamespace = strings.TrimSpace(string(nsBytes))
+			return operatorNamespace, nil
 		}
 
 		// for the purpose of local run
 		namespace, ok := os.LookupEnv("WATCH_NAMESPACE")
-		if !ok {
-			return "", fmt.Errorf("WATCH_NAMESPACE environment variable not set")
+		if ok {
+			operatorNamespace = namespace
+			return operatorNamespace, nil
 		}
 
-		operatorNamespace = namespace
+		return "", fmt.Errorf("operator namespace is not set")
 	}
 
 	return operatorNamespace, nil

--- a/pkg/common/infrastructure/cluster.go
+++ b/pkg/common/infrastructure/cluster.go
@@ -68,6 +68,11 @@ func IsOpenShiftOAuthEnabled() bool {
 	return isOpenShiftOAuthEnabled
 }
 
+func IsOpenShiftWithoutOAuth() bool {
+	initializeIfNeeded()
+	return IsOpenShift() && !IsOpenShiftOAuthEnabled()
+}
+
 func IsLeaderElectionEnabled() bool {
 	initializeIfNeeded()
 	return isLeaderElectionEnabled
@@ -81,6 +86,10 @@ func IsKubernetesImagePullerEnabled() bool {
 func IsServiceMonitorEnabled() bool {
 	initializeIfNeeded()
 	return isServiceMonitorEnabled
+}
+
+func SetOpenShiftOAuthEnabledForTesting(enabled bool) {
+	isOpenShiftOAuthEnabled = enabled
 }
 
 func InitializeForTesting(desiredInfrastructure Type) {

--- a/pkg/common/infrastructure/cluster.go
+++ b/pkg/common/infrastructure/cluster.go
@@ -13,6 +13,7 @@
 package infrastructure
 
 import (
+	"fmt"
 	"os"
 	"slices"
 	"strings"
@@ -49,10 +50,16 @@ var (
 func GetOperatorNamespace() (string, error) {
 	if operatorNamespace == "" {
 		nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-		if err != nil {
-			return "", err
+		if err == nil {
+			operatorNamespace = strings.TrimSpace(string(nsBytes))
 		}
-		operatorNamespace = strings.TrimSpace(string(nsBytes))
+
+		namespace, ok := os.LookupEnv("WATCH_NAMESPACE")
+		if !ok {
+			return "", fmt.Errorf("WATCH_NAMESPACE environment variable not set")
+		}
+
+		return namespace, nil
 	}
 
 	return operatorNamespace, nil

--- a/pkg/common/infrastructure/cluster.go
+++ b/pkg/common/infrastructure/cluster.go
@@ -54,12 +54,13 @@ func GetOperatorNamespace() (string, error) {
 			operatorNamespace = strings.TrimSpace(string(nsBytes))
 		}
 
+		// for the purpose of local run
 		namespace, ok := os.LookupEnv("WATCH_NAMESPACE")
 		if !ok {
 			return "", fmt.Errorf("WATCH_NAMESPACE environment variable not set")
 		}
 
-		return namespace, nil
+		operatorNamespace = namespace
 	}
 
 	return operatorNamespace, nil

--- a/pkg/common/test/deploy_context.go
+++ b/pkg/common/test/deploy_context.go
@@ -74,8 +74,9 @@ func (f *DeployContextBuild) Build() *chetypes.DeployContext {
 			ClientWrapper:           k8s_client.NewK8sClient(fakeClient, scheme),
 			NonCachingClientWrapper: k8s_client.NewK8sClient(fakeClient, scheme),
 		},
-		Proxy:        &chetypes.Proxy{},
-		DwoNamespace: "devworkspace-controller",
+		Proxy:              &chetypes.Proxy{},
+		OIDCAuthentication: &chetypes.OIDCAuthentication{},
+		DwoNamespace:       "devworkspace-controller",
 	}
 
 	if f.cheCluster != nil {

--- a/pkg/common/test/deploy_context.go
+++ b/pkg/common/test/deploy_context.go
@@ -74,9 +74,9 @@ func (f *DeployContextBuild) Build() *chetypes.DeployContext {
 			ClientWrapper:           k8s_client.NewK8sClient(fakeClient, scheme),
 			NonCachingClientWrapper: k8s_client.NewK8sClient(fakeClient, scheme),
 		},
-		Proxy:              &chetypes.Proxy{},
-		OIDCAuthentication: &chetypes.OIDCAuthentication{},
-		DwoNamespace:       "devworkspace-controller",
+		Proxy:          &chetypes.Proxy{},
+		Authentication: buildAuthentication(f.cheCluster),
+		DwoNamespace:   "devworkspace-controller",
 	}
 
 	if f.cheCluster != nil {
@@ -84,6 +84,21 @@ func (f *DeployContextBuild) Build() *chetypes.DeployContext {
 	}
 
 	return ctx
+}
+
+func buildAuthentication(cheCluster *chev2.CheCluster) *chetypes.Authentication {
+	if cheCluster == nil {
+		return &chetypes.Authentication{}
+	}
+	return &chetypes.Authentication{
+		IssuerURL:      cheCluster.Spec.Networking.Auth.IdentityProviderURL,
+		ClientId:       cheCluster.Spec.Networking.Auth.OAuthClientName,
+		ClientSecret:   []byte(cheCluster.Spec.Networking.Auth.OAuthSecret),
+		UsernameClaim:  cheCluster.Spec.Components.CheServer.ExtraProperties["CHE_OIDC_USERNAME__CLAIM"],
+		UsernamePrefix: cheCluster.Spec.Components.CheServer.ExtraProperties["CHE_OIDC_USERNAME__PREFIX"],
+		GroupsClaim:    cheCluster.Spec.Components.CheServer.ExtraProperties["CHE_OIDC_GROUPS__CLAIM"],
+		GroupsPrefix:   cheCluster.Spec.Components.CheServer.ExtraProperties["CHE_OIDC_GROUPS__PREFIX"],
+	}
 }
 
 func getDefaultCheCluster() *chev2.CheCluster {

--- a/pkg/common/test/test-client/test_client.go
+++ b/pkg/common/test/test-client/test_client.go
@@ -90,7 +90,7 @@ func getScheme() *runtime.Scheme {
 	scheme.AddKnownTypes(controllerv1alpha1.GroupVersion, &controllerv1alpha1.DevWorkspaceOperatorConfig{}, &controllerv1alpha1.DevWorkspaceOperatorConfigList{})
 	scheme.AddKnownTypes(controllerv1alpha1.GroupVersion, &controllerv1alpha1.DevWorkspaceRouting{}, &controllerv1alpha1.DevWorkspaceRoutingList{})
 	scheme.AddKnownTypes(oauthv1.GroupVersion, &oauthv1.OAuthClient{}, &oauthv1.OAuthClientList{})
-	scheme.AddKnownTypes(configv1.GroupVersion, &configv1.Proxy{}, &configv1.Console{})
+	scheme.AddKnownTypes(configv1.GroupVersion, &configv1.Proxy{}, &configv1.Console{}, &configv1.Authentication{}, &configv1.AuthenticationList{})
 	scheme.AddKnownTypes(templatev1.GroupVersion, &templatev1.Template{}, &templatev1.TemplateList{})
 	scheme.AddKnownTypes(routev1.GroupVersion, &routev1.Route{}, &routev1.RouteList{})
 	scheme.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Secret{}, &corev1.SecretList{})

--- a/pkg/deploy/editors-definitions/editors_definitions.go
+++ b/pkg/deploy/editors-definitions/editors_definitions.go
@@ -162,5 +162,5 @@ func syncEditorDefinitions(ctx *chetypes.DeployContext, editorDefinitions map[st
 		cm.Data[fileName] = string(content)
 	}
 
-	return deploy.Sync(ctx, cm, diffs.ConfigMapAllLabels)
+	return deploy.Sync(ctx, cm, diffs.ConfigMapEnsureLabels)
 }

--- a/pkg/deploy/expose/expose.go
+++ b/pkg/deploy/expose/expose.go
@@ -76,7 +76,7 @@ func exposeWithGateway(deployContext *chetypes.DeployContext,
 	if err != nil {
 		return "", false, err
 	}
-	done, err = deploy.Sync(deployContext, &cfg, diffs.ConfigMapAllLabels)
+	done, err = deploy.Sync(deployContext, &cfg, diffs.ConfigMapEnsureLabels)
 	if !done {
 		if err != nil {
 			logrus.Error(err)

--- a/pkg/deploy/gateway/oauth_proxy.go
+++ b/pkg/deploy/gateway/oauth_proxy.go
@@ -97,26 +97,6 @@ skip_provider_button = false
 		skipAuthConfig(ctx.CheCluster))
 }
 
-func getSecretValue(ctx *chetypes.DeployContext) string {
-	secret := &corev1.Secret{}
-	exists, _ := deploy.GetNamespacedObject(ctx, ctx.CheCluster.Spec.Networking.Auth.OAuthSecret, secret)
-	if !exists {
-		// Kubernetes secret provided name not found. Assuming oAuthSecret provided is the actual secret.
-		return ctx.CheCluster.Spec.Networking.Auth.OAuthSecret
-	}
-
-	// Retrieve the value associated with the key "oAuthSecret"
-	value, found := secret.Data["oAuthSecret"]
-	if !found {
-		// Key 'oAuthSecret' not found. Assuming oAuthSecret provided is the actual secret.
-		return ctx.CheCluster.Spec.Networking.Auth.OAuthSecret
-	}
-
-	// Convert the byte slice to a string
-	secretValue := string(value)
-	return secretValue
-}
-
 func kubernetesOauthProxyConfig(ctx *chetypes.DeployContext, cookieSecret string) string {
 	return fmt.Sprintf(`
 proxy_prefix = "/oauth"
@@ -144,9 +124,9 @@ cookie_domains = "%s"
 %s
 `, GatewayServicePort,
 		ctx.CheHost,
-		ctx.CheCluster.Spec.Networking.Auth.IdentityProviderURL,
-		ctx.CheCluster.Spec.Networking.Auth.OAuthClientName,
-		getSecretValue(ctx),
+		ctx.OIDCAuthentication.IssuerURL,
+		ctx.OIDCAuthentication.OIDCClientId,
+		string(ctx.OIDCAuthentication.OIDCClientSecret),
 		cookieSecret,
 		cookieExpireAsString(ctx.CheCluster),
 		utils.Whitelist(ctx.CheHost),

--- a/pkg/deploy/gateway/oauth_proxy.go
+++ b/pkg/deploy/gateway/oauth_proxy.go
@@ -124,9 +124,9 @@ cookie_domains = "%s"
 %s
 `, GatewayServicePort,
 		ctx.CheHost,
-		ctx.OIDCAuthentication.IssuerURL,
-		ctx.OIDCAuthentication.OIDCClientId,
-		string(ctx.OIDCAuthentication.OIDCClientSecret),
+		ctx.Authentication.IssuerURL,
+		ctx.Authentication.ClientId,
+		string(ctx.Authentication.ClientSecret),
 		cookieSecret,
 		cookieExpireAsString(ctx.CheCluster),
 		utils.Whitelist(ctx.CheHost),

--- a/pkg/deploy/gateway/oauth_proxy_test.go
+++ b/pkg/deploy/gateway/oauth_proxy_test.go
@@ -18,12 +18,9 @@ import (
 	"k8s.io/utils/pointer"
 
 	chev2 "github.com/eclipse-che/che-operator/api/v2"
-	"github.com/eclipse-che/che-operator/pkg/common/constants"
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCookieExpireForOpenShiftOauthProxyConfig(t *testing.T) {
@@ -62,125 +59,6 @@ func TestCookieExpireKubernetesOauthProxyConfig(t *testing.T) {
 
 	config := kubernetesOauthProxyConfig(ctx, "")
 	assert.Contains(t, config, "cookie_expire = \"1h1m5s\"")
-}
-
-func TestKubernetesOauthProxySecretSecretFoundWithKey(t *testing.T) {
-	ctx := test.NewCtxBuilder().WithCheCluster(&chev2.CheCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "eclipse-che",
-		},
-		Spec: chev2.CheClusterSpec{
-			Networking: chev2.CheClusterSpecNetworking{
-				Auth: chev2.Auth{
-					OAuthSecret: "my-secret",
-				},
-			}},
-	}).WithObjects(&corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-secret",
-			Namespace: "eclipse-che",
-			Labels:    map[string]string{constants.KubernetesPartOfLabelKey: constants.CheEclipseOrg},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{"oAuthSecret": []byte("my")},
-	},
-	).Build()
-
-	ctx.CheHost = "che-site.che-domain.com"
-	infrastructure.InitializeForTesting(infrastructure.Kubernetes)
-
-	config := kubernetesOauthProxyConfig(ctx, "blabol")
-	assert.Contains(t, config, "client_secret = \"my\"")
-}
-
-func TestKubernetesOauthProxySecretSecretFoundWithWrongKey(t *testing.T) {
-	ctx := test.NewCtxBuilder().WithCheCluster(&chev2.CheCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "eclipse-che",
-		},
-		Spec: chev2.CheClusterSpec{
-			Networking: chev2.CheClusterSpecNetworking{
-				Auth: chev2.Auth{
-					OAuthSecret: "my-secret",
-				},
-			}},
-	}).WithObjects(&corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-secret",
-			Namespace: "eclipse-che",
-			Labels:    map[string]string{constants.KubernetesPartOfLabelKey: constants.CheEclipseOrg},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{"keyIsNotoAuthSecret": []byte("my")},
-	}).Build()
-
-	ctx.CheHost = "che-site.che-domain.com"
-	infrastructure.InitializeForTesting(infrastructure.Kubernetes)
-
-	config := kubernetesOauthProxyConfig(ctx, "blabol")
-	//expect interpret as literal secret
-	assert.Contains(t, config, "client_secret = \"my-secret\"")
-}
-
-func TestKubernetesOauthProxySecretSecretFoundWithWrongSecretName(t *testing.T) {
-	ctx := test.NewCtxBuilder().WithCheCluster(&chev2.CheCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "eclipse-che",
-		},
-		Spec: chev2.CheClusterSpec{
-			Networking: chev2.CheClusterSpecNetworking{
-				Auth: chev2.Auth{
-					OAuthSecret: "wrong-secret-name",
-				},
-			}},
-	}).WithObjects(&corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-secret",
-			Namespace: "eclipse-che",
-			Labels:    map[string]string{constants.KubernetesPartOfLabelKey: constants.CheEclipseOrg},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{"oAuthSecret": []byte("my")},
-	}).Build()
-	ctx.CheHost = "che-site.che-domain.com"
-	infrastructure.InitializeForTesting(infrastructure.Kubernetes)
-
-	config := kubernetesOauthProxyConfig(ctx, "blabol")
-	//expect interpret as literal secret
-	assert.Contains(t, config, "client_secret = \"wrong-secret-name\"")
-}
-
-func TestKubernetesOauthProxySecretLegacyPlaintextSecretName(t *testing.T) {
-	ctx := test.NewCtxBuilder().WithCheCluster(&chev2.CheCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "eclipse-che",
-		},
-		Spec: chev2.CheClusterSpec{
-			Networking: chev2.CheClusterSpecNetworking{
-				Auth: chev2.Auth{
-					OAuthSecret: "abcdefPlainTextSecret",
-				},
-			},
-		},
-	}).Build()
-	ctx.CheHost = "che-site.che-domain.com"
-	infrastructure.InitializeForTesting(infrastructure.Kubernetes)
-
-	config := kubernetesOauthProxyConfig(ctx, "blabol")
-	//expect interpret as literal secret
-	assert.Contains(t, config, "client_secret = \"abcdefPlainTextSecret\"")
 }
 
 func TestKubernetesOauthProxyConfig(t *testing.T) {

--- a/pkg/deploy/identity-provider/identity_provider_reconciler.go
+++ b/pkg/deploy/identity-provider/identity_provider_reconciler.go
@@ -74,10 +74,10 @@ func syncOAuthClient(ctx *chetypes.DeployContext) (bool, error) {
 
 	if oauthClient != nil {
 		oauthClientName = oauthClient.Name
-		oauthSecret = utils.GetValue(ctx.CheCluster.Spec.Networking.Auth.OAuthSecret, oauthClient.Secret)
+		oauthSecret = utils.GetValue(string(ctx.Authentication.ClientSecret), oauthClient.Secret)
 	} else {
 		oauthClientName = GetOAuthClientName(ctx)
-		oauthSecret = utils.GetValue(ctx.CheCluster.Spec.Networking.Auth.OAuthSecret, utils.GeneratePassword(12))
+		oauthSecret = utils.GetValue(string(ctx.Authentication.ClientSecret), utils.GeneratePassword(12))
 	}
 
 	redirectURIs := []string{"https://" + ctx.CheHost + "/oauth/callback"}

--- a/pkg/deploy/identity-provider/identity_provider_util.go
+++ b/pkg/deploy/identity-provider/identity_provider_util.go
@@ -15,6 +15,7 @@ package identityprovider
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/chetypes"
 	"github.com/eclipse-che/che-operator/pkg/common/constants"
+	"github.com/eclipse-che/che-operator/pkg/common/utils"
 	"github.com/eclipse-che/che-operator/pkg/deploy"
 	oauth "github.com/openshift/api/oauth/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,9 +59,5 @@ func GetOAuthClient(ctx *chetypes.DeployContext) (*oauth.OAuthClient, error) {
 }
 
 func GetOAuthClientName(ctx *chetypes.DeployContext) string {
-	if ctx.CheCluster.Spec.Networking.Auth.OAuthClientName != "" {
-		return ctx.CheCluster.Spec.Networking.Auth.OAuthClientName
-	}
-
-	return ctx.CheCluster.Namespace + "-client"
+	return utils.GetValue(ctx.Authentication.ClientId, ctx.CheCluster.Namespace+"-client")
 }

--- a/pkg/deploy/pluginregistry/pluginregistry.go
+++ b/pkg/deploy/pluginregistry/pluginregistry.go
@@ -117,7 +117,7 @@ func (p *PluginRegistryReconciler) syncConfigMap(ctx *chetypes.DeployContext) (b
 		Data: data,
 	}
 
-	return deploy.Sync(ctx, cm, diffs.ConfigMapAllLabels)
+	return deploy.Sync(ctx, cm, diffs.ConfigMapEnsureLabels)
 }
 
 func (p *PluginRegistryReconciler) ExposeEndpoint(ctx *chetypes.DeployContext) (string, bool, error) {

--- a/pkg/deploy/server/server_configmap.go
+++ b/pkg/deploy/server/server_configmap.go
@@ -152,7 +152,7 @@ func (s *CheServerReconciler) getConfigMapData(ctx *chetypes.DeployContext) (che
 		CheLogLevel:                         cheLogLevel,
 		CheMetricsEnabled:                   cheMetricsEnabled,
 		CheInfrastructure:                   cheInfrastructure,
-		CheOIDCAuthServerUrl:                ctx.OIDCAuthentication.IssuerURL,
+		CheOIDCAuthServerUrl:                ctx.Authentication.IssuerURL,
 		NamespaceDefault:                    namespaceDefault,
 		NamespaceCreationAllowed:            namespaceCreationAllowed,
 		KubernetesLabels:                    kubernetesLabels,
@@ -313,8 +313,8 @@ func (s *CheServerReconciler) updateServerEndpointsEnv(ctx *chetypes.DeployConte
 }
 
 func (s *CheServerReconciler) updateOIDCClaimMappings(ctx *chetypes.DeployContext, cheEnv map[string]string) {
-	cheEnv["CHE_OIDC_GROUPS__CLAIM"] = ctx.OIDCAuthentication.GroupsClaim
-	cheEnv["CHE_OIDC_GROUPS__PREFIX"] = ctx.OIDCAuthentication.GroupsPrefix
-	cheEnv["CHE_OIDC_USERNAME__CLAIM"] = ctx.OIDCAuthentication.UsernameClaim
-	cheEnv["CHE_OIDC_USERNAME__PREFIX"] = ctx.OIDCAuthentication.UsernamePrefix
+	cheEnv["CHE_OIDC_GROUPS__CLAIM"] = ctx.Authentication.GroupsClaim
+	cheEnv["CHE_OIDC_GROUPS__PREFIX"] = ctx.Authentication.GroupsPrefix
+	cheEnv["CHE_OIDC_USERNAME__CLAIM"] = ctx.Authentication.UsernameClaim
+	cheEnv["CHE_OIDC_USERNAME__PREFIX"] = ctx.Authentication.UsernamePrefix
 }

--- a/pkg/deploy/server/server_configmap.go
+++ b/pkg/deploy/server/server_configmap.go
@@ -192,7 +192,7 @@ func (s *CheServerReconciler) getConfigMapData(ctx *chetypes.DeployContext) (che
 		return nil, err
 	}
 
-	if infrastructure.IsOpenShiftWithoutOAuth() {
+	if infrastructure.IsOpenShiftExternalAuth() {
 		s.updateOIDCClaimMappings(ctx, cheEnv)
 	}
 

--- a/pkg/deploy/server/server_configmap.go
+++ b/pkg/deploy/server/server_configmap.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 type CheConfigMap struct {
@@ -73,6 +74,10 @@ func (s *CheServerReconciler) syncConfigMap(ctx *chetypes.DeployContext) (bool, 
 			Labels:    deploy.GetLabels(getComponentName()),
 		},
 		Data: data,
+	}
+
+	if err := controllerutil.SetControllerReference(ctx.CheCluster, cm, ctx.ClusterAPI.Scheme); err != nil {
+		return false, err
 	}
 
 	err = ctx.ClusterAPI.ClientWrapper.Sync(

--- a/pkg/deploy/server/server_configmap.go
+++ b/pkg/deploy/server/server_configmap.go
@@ -152,7 +152,7 @@ func (s *CheServerReconciler) getConfigMapData(ctx *chetypes.DeployContext) (che
 		CheLogLevel:                         cheLogLevel,
 		CheMetricsEnabled:                   cheMetricsEnabled,
 		CheInfrastructure:                   cheInfrastructure,
-		CheOIDCAuthServerUrl:                ctx.CheCluster.Spec.Networking.Auth.IdentityProviderURL,
+		CheOIDCAuthServerUrl:                ctx.OIDCAuthentication.IssuerURL,
 		NamespaceDefault:                    namespaceDefault,
 		NamespaceCreationAllowed:            namespaceCreationAllowed,
 		KubernetesLabels:                    kubernetesLabels,

--- a/pkg/deploy/server/server_configmap.go
+++ b/pkg/deploy/server/server_configmap.go
@@ -78,7 +78,7 @@ func (s *CheServerReconciler) syncConfigMap(ctx *chetypes.DeployContext) (bool, 
 	err = ctx.ClusterAPI.ClientWrapper.Sync(
 		context.TODO(),
 		cm,
-		&k8sclient.SyncOptions{DiffOpts: diffs.ConfigMapAllLabels},
+		&k8sclient.SyncOptions{DiffOpts: diffs.ConfigMapEnsureLabels},
 	)
 
 	return err == nil, err
@@ -190,6 +190,10 @@ func (s *CheServerReconciler) getConfigMapData(ctx *chetypes.DeployContext) (che
 	// Update `CHE_INTEGRATION_<...>_SERVER__ENDPOINTS`
 	if err := s.updateServerEndpointsEnv(ctx, cheEnv); err != nil {
 		return nil, err
+	}
+
+	if infrastructure.IsOpenShiftWithoutOAuth() {
+		s.updateOIDCClaimMappings(ctx, cheEnv)
 	}
 
 	return cheEnv, nil
@@ -306,4 +310,11 @@ func (s *CheServerReconciler) updateServerEndpointsEnv(ctx *chetypes.DeployConte
 	}
 
 	return nil
+}
+
+func (s *CheServerReconciler) updateOIDCClaimMappings(ctx *chetypes.DeployContext, cheEnv map[string]string) {
+	cheEnv["CHE_OIDC_GROUPS__CLAIM"] = ctx.OIDCAuthentication.GroupsClaim
+	cheEnv["CHE_OIDC_GROUPS__PREFIX"] = ctx.OIDCAuthentication.GroupsPrefix
+	cheEnv["CHE_OIDC_USERNAME__CLAIM"] = ctx.OIDCAuthentication.UsernameClaim
+	cheEnv["CHE_OIDC_USERNAME__PREFIX"] = ctx.OIDCAuthentication.UsernamePrefix
 }

--- a/pkg/deploy/tls/certificates.go
+++ b/pkg/deploy/tls/certificates.go
@@ -86,7 +86,7 @@ func (c *CertificatesReconciler) Reconcile(ctx *chetypes.DeployContext) (reconci
 		}
 	}
 
-	if ctx.OIDCAuthentication.IssuerCA != "" {
+	if ctx.Authentication.IssuerCA != "" {
 		if done, err := c.syncIssuerCertificate(ctx); !done {
 			return reconcile.Result{}, false, err
 		}
@@ -332,7 +332,7 @@ func (c *CertificatesReconciler) syncIssuerCertificate(ctx *chetypes.DeployConte
 			Labels:    deploy.GetLabels(constants.CheCABundle),
 		},
 		Data: map[string]string{
-			"ca-bundle.crt": ctx.OIDCAuthentication.IssuerCA,
+			"ca-bundle.crt": ctx.Authentication.IssuerCA,
 		},
 	}
 

--- a/pkg/deploy/tls/certificates.go
+++ b/pkg/deploy/tls/certificates.go
@@ -25,6 +25,7 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/diffs"
 	k8sclient "github.com/eclipse-che/che-operator/pkg/common/k8s-client"
 	"github.com/eclipse-che/che-operator/pkg/common/reconciler"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/eclipse-che/che-operator/pkg/common/utils"
 
@@ -47,7 +48,7 @@ const (
 
 	// The ConfigMap name for merged CA bundle certificates
 	CheMergedCABundleCertsCMName = "ca-certs-merged"
-	IssuerCACMName               = "oidc-issuer-ca"
+	OIDCIssuerCACMName           = "oidc-issuer-ca"
 )
 
 type CertificatesReconciler struct {
@@ -87,7 +88,7 @@ func (c *CertificatesReconciler) Reconcile(ctx *chetypes.DeployContext) (reconci
 	}
 
 	if ctx.Authentication.IssuerCA != "" {
-		if done, err := c.syncIssuerCertificate(ctx); !done {
+		if done, err := c.syncOIDCIssuerCertificate(ctx); !done {
 			return reconcile.Result{}, false, err
 		}
 	}
@@ -320,20 +321,24 @@ func (c *CertificatesReconciler) syncKubernetesRootCertificates(ctx *chetypes.De
 	)
 }
 
-func (c *CertificatesReconciler) syncIssuerCertificate(ctx *chetypes.DeployContext) (bool, error) {
+func (c *CertificatesReconciler) syncOIDCIssuerCertificate(ctx *chetypes.DeployContext) (bool, error) {
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      IssuerCACMName,
+			Name:      OIDCIssuerCACMName,
 			Namespace: ctx.CheCluster.Namespace,
 			Labels:    deploy.GetLabels(constants.CheCABundle),
 		},
 		Data: map[string]string{
 			"ca-bundle.crt": ctx.Authentication.IssuerCA,
 		},
+	}
+
+	if err := controllerutil.SetControllerReference(ctx.CheCluster, cm, ctx.ClusterAPI.Scheme); err != nil {
+		return false, err
 	}
 
 	err := ctx.ClusterAPI.ClientWrapper.Sync(context.TODO(), cm, &k8sclient.SyncOptions{DiffOpts: diffs.ConfigMapEnsureLabels})

--- a/pkg/deploy/tls/certificates.go
+++ b/pkg/deploy/tls/certificates.go
@@ -13,6 +13,7 @@
 package tls
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"maps"
@@ -22,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/eclipse-che/che-operator/pkg/common/diffs"
+	k8sclient "github.com/eclipse-che/che-operator/pkg/common/k8s-client"
 	"github.com/eclipse-che/che-operator/pkg/common/reconciler"
 
 	"github.com/eclipse-che/che-operator/pkg/common/utils"
@@ -45,6 +47,7 @@ const (
 
 	// The ConfigMap name for merged CA bundle certificates
 	CheMergedCABundleCertsCMName = "ca-certs-merged"
+	IssuerCACMName               = "issuer-ca"
 )
 
 type CertificatesReconciler struct {
@@ -79,6 +82,12 @@ func (c *CertificatesReconciler) Reconcile(ctx *chetypes.DeployContext) (reconci
 
 	if ctx.IsSelfSignedCertificate {
 		if done, err := c.syncSelfSignedCertificates(ctx); !done {
+			return reconcile.Result{}, false, err
+		}
+	}
+
+	if ctx.OIDCAuthentication.IssuerCA != "" {
+		if done, err := c.syncIssuerCertificate(ctx); !done {
 			return reconcile.Result{}, false, err
 		}
 	}
@@ -309,6 +318,26 @@ func (c *CertificatesReconciler) syncKubernetesRootCertificates(ctx *chetypes.De
 		kubeRootCertsCM,
 		diffs.ConfigMap([]string{constants.KubernetesPartOfLabelKey, constants.KubernetesComponentLabelKey}, nil),
 	)
+}
+
+func (c *CertificatesReconciler) syncIssuerCertificate(ctx *chetypes.DeployContext) (bool, error) {
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      IssuerCACMName,
+			Namespace: ctx.CheCluster.Namespace,
+			Labels:    deploy.GetLabels(constants.CheCABundle),
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": ctx.OIDCAuthentication.IssuerCA,
+		},
+	}
+
+	err := ctx.ClusterAPI.ClientWrapper.Sync(context.TODO(), cm, &k8sclient.SyncOptions{DiffOpts: diffs.ConfigMapEnsureLabels})
+	return err == nil, err
 }
 
 // syncCheCABundleCerts merges all trusted CA certificates into a single ConfigMap `ca-certs-merged`,

--- a/pkg/deploy/tls/certificates.go
+++ b/pkg/deploy/tls/certificates.go
@@ -47,7 +47,7 @@ const (
 
 	// The ConfigMap name for merged CA bundle certificates
 	CheMergedCABundleCertsCMName = "ca-certs-merged"
-	IssuerCACMName               = "issuer-ca"
+	IssuerCACMName               = "oidc-issuer-ca"
 )
 
 type CertificatesReconciler struct {

--- a/pkg/deploy/tls/certificates.go
+++ b/pkg/deploy/tls/certificates.go
@@ -194,7 +194,7 @@ func (c *CertificatesReconciler) syncKubernetesCABundleCertificates(ctx *chetype
 		Data: map[string]string{kubernetesCABundleCertsFile: string(data)},
 	}
 
-	return deploy.Sync(ctx, kubernetesCaBundleCM, diffs.ConfigMapAllLabels)
+	return deploy.Sync(ctx, kubernetesCaBundleCM, diffs.ConfigMapEnsureLabels)
 }
 
 // syncGitTrustedCertificates adds labels to git trusted certificates ConfigMap
@@ -268,7 +268,7 @@ func (c *CertificatesReconciler) syncSelfSignedCertificates(ctx *chetypes.Deploy
 			Data: map[string]string{"ca.crt": string(selfSignedCertSecret.Data["ca.crt"])},
 		}
 
-		return deploy.Sync(ctx, selfSignedCertCM, diffs.ConfigMapAllLabels)
+		return deploy.Sync(ctx, selfSignedCertCM, diffs.ConfigMapEnsureLabels)
 	}
 
 	return true, nil


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
 Adds automatic detection and configuration of OpenShift's external OIDC authentication

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse-che/che/issues/23831

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->
follow the updated doc  from https://github.com/eclipse-che/che-docs/pull/3112


#### Common Test Scenarios
- [x] Deploy Eclipse Che
- [x] Start an empty workspace
- [x] Open terminal and build/run an image
- [x] Stop a workspace
- [x] Check operator logs for reconciliation errors or infinite reconciliation loops

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
