### PR TITLE
chore: Set controller UsePriorityQueue to false

### DIFF
--- a/controllers/che/checluster_controller.go
+++ b/controllers/che/checluster_controller.go
@@ -200,6 +200,7 @@ func (r *CheClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return bld.WithOptions(
 		controller.TypedOptions[reconcile.Request]{
 			SkipNameValidation: pointer.Bool(true),
+			UsePriorityQueue:   pointer.Bool(false),
 		}).Complete(r)
 }
 

--- a/controllers/usernamespace/usernamespace_controller.go
+++ b/controllers/usernamespace/usernamespace_controller.go
@@ -106,6 +106,7 @@ func (r *CheUserNamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return bld.WithOptions(
 		controller.TypedOptions[reconcile.Request]{
 			SkipNameValidation: pointer.Bool(true),
+			UsePriorityQueue:   pointer.Bool(false),
 		}).Complete(r)
 }
 

--- a/controllers/workspaceconfig/workspaces_config_controller.go
+++ b/controllers/workspaceconfig/workspaces_config_controller.go
@@ -151,6 +151,7 @@ func (r *WorkspacesConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return bld.WithOptions(
 		controller.TypedOptions[reconcile.Request]{
 			SkipNameValidation: pointer.Bool(true),
+			UsePriorityQueue:   pointer.Bool(false),
 		}).Complete(r)
 }
 


### PR DESCRIPTION
## Summary
- Sets `UsePriorityQueue` to `false` in all controller `SetupWithManager` methods
- The `UsePriorityQueue` field defaults to `true` since controller-runtime v0.23.0
- This reverts the value to match pre-v0.23.0 functionality

Mirrors: https://github.com/devfile/devworkspace-operator/pull/1635

## Test plan
- [ ] Verify the operator builds successfully
- [ ] Verify controllers reconcile as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)