### PR TITLE
fix: Skip shared TLS secret creation when external TLS config is enabled 

### DIFF
--- a/controllers/devworkspace/solver/che_routing_external_tls_config_test.go
+++ b/controllers/devworkspace/solver/che_routing_external_tls_config_test.go
@@ -21,8 +21,8 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 )

--- a/controllers/devworkspace/solver/che_routing_external_tls_config_test.go
+++ b/controllers/devworkspace/solver/che_routing_external_tls_config_test.go
@@ -13,6 +13,7 @@
 package solver
 
 import (
+	"context"
 	"testing"
 
 	chev2 "github.com/eclipse-che/che-operator/api/v2"
@@ -21,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 )
 
@@ -57,7 +60,7 @@ func TestExternalTLSConfigForIngresses(t *testing.T) {
 		},
 	}
 
-	_, _, objs := getSpecObjectsForManager(t, mgr, subdomainDevWorkspaceRouting(), userProfileSecret("username"),
+	cli, _, objs := getSpecObjectsForManager(t, mgr, subdomainDevWorkspaceRouting(), userProfileSecret("username"),
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "tlsSecret",
@@ -70,6 +73,11 @@ func TestExternalTLSConfigForIngresses(t *testing.T) {
 		})
 
 	assert.Equal(t, 3, len(objs.Ingresses))
+
+	// shared workspace endpoint TLS secret must NOT be created when external TLS is enabled
+	tlsSecret := &corev1.Secret{}
+	err := cli.Get(context.TODO(), types.NamespacedName{Name: "wsid-endpoints", Namespace: "ws"}, tlsSecret)
+	assert.True(t, errors.IsNotFound(err), "shared workspace endpoint TLS secret should not be created when externalTLSConfig is enabled")
 
 	// secure endpoint with custom TLS secret
 	ingress := objs.Ingresses[0]

--- a/controllers/devworkspace/solver/endpoint_exposer.go
+++ b/controllers/devworkspace/solver/endpoint_exposer.go
@@ -70,7 +70,7 @@ func (e *RouteExposer) initFrom(ctx context.Context, cl client.Client, cluster *
 	e.baseDomain = cluster.Status.WorkspaceBaseDomain
 	e.devWorkspaceID = routing.Spec.DevWorkspaceId
 
-	if cluster.Spec.Networking.TlsSecretName != "" {
+	if cluster.Spec.Networking.TlsSecretName != "" && !cluster.IsDevEnvironmentExternalTLSConfigEnabled() {
 		secret := &corev1.Secret{}
 		err := cl.Get(ctx, client.ObjectKey{Name: cluster.Spec.Networking.TlsSecretName, Namespace: cluster.Namespace}, secret)
 		if err != nil {
@@ -88,7 +88,7 @@ func (e *IngressExposer) initFrom(ctx context.Context, cl client.Client, cluster
 	e.baseDomain = cluster.Status.WorkspaceBaseDomain
 	e.devWorkspaceID = routing.Spec.DevWorkspaceId
 
-	if cluster.Spec.Networking.TlsSecretName != "" {
+	if cluster.Spec.Networking.TlsSecretName != "" && !cluster.IsDevEnvironmentExternalTLSConfigEnabled() {
 		tlsSecretName := routing.Spec.DevWorkspaceId + "-endpoints"
 		e.tlsSecretName = tlsSecretName
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Skip shared TLS secret creation when external TLS config is enabled

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/devfile/devworkspace-operator/issues/1648

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh
```

or

```bash
build/scripts/docker-run.sh /bin/bash -c "
  oc login \
    --token=<...> \
    --server=<...> \
    --insecure-skip-tls-verify=true && \
  build/scripts/olm/test-catalog-from-sources.sh
"
```

2. 

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh
```

#### Common Test Scenarios
- [ ] Deploy Eclipse Che
- [ ] Start an empty workspace
- [ ] Open terminal and build/run an image
- [ ] Stop a workspace
- [ ] Check operator logs for reconciliation errors or infinite reconciliation loops

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
