### PR TITLE
fix: grant workspace users ImageStream read access 

### DIFF
--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2026-07-20T15:40:22Z"
+    createdAt: "2026-07-21T11:26:48Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     features.operators.openshift.io/cnf: "false"
@@ -108,7 +108,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: eclipse-che.v7.121.0-1041.next
+  name: eclipse-che.v7.121.0-1042.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -690,6 +690,13 @@ spec:
               verbs:
                 - create
             - apiGroups:
+                - image.openshift.io
+              resources:
+                - imagestreams
+              verbs:
+                - get
+                - list
+            - apiGroups:
                 - ""
               resources:
                 - events
@@ -1166,7 +1173,7 @@ spec:
       name: openvsx
     - image: quay.io/sclorg/postgresql-16-c9s:20260319
       name: openvsx-postgres
-  version: 7.121.0-1041.next
+  version: 7.121.0-1042.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/config/rbac/cluster_role.yaml
+++ b/config/rbac/cluster_role.yaml
@@ -162,6 +162,13 @@ rules:
     verbs:
       - create
   - apiGroups:
+      - image.openshift.io
+    resources:
+      - imagestreams
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - ''
     resources:
       - events

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -28124,6 +28124,13 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - get
+  - list
+- apiGroups:
   - ""
   resources:
   - events

--- a/deploy/deployment/kubernetes/objects/che-operator.ClusterRole.yaml
+++ b/deploy/deployment/kubernetes/objects/che-operator.ClusterRole.yaml
@@ -162,6 +162,13 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - get
+  - list
+- apiGroups:
   - ""
   resources:
   - events

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -28124,6 +28124,13 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - get
+  - list
+- apiGroups:
   - ""
   resources:
   - events

--- a/deploy/deployment/openshift/objects/che-operator.ClusterRole.yaml
+++ b/deploy/deployment/openshift/objects/che-operator.ClusterRole.yaml
@@ -162,6 +162,13 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - get
+  - list
+- apiGroups:
   - ""
   resources:
   - events

--- a/helmcharts/next/templates/che-operator.ClusterRole.yaml
+++ b/helmcharts/next/templates/che-operator.ClusterRole.yaml
@@ -162,6 +162,13 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - get
+  - list
+- apiGroups:
   - ""
   resources:
   - events

--- a/helmcharts/next/templates/org_v2_checluster.yaml
+++ b/helmcharts/next/templates/org_v2_checluster.yaml
@@ -9,7 +9,6 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 #
-
 apiVersion: org.eclipse.che/v2
 kind: CheCluster
 metadata:

--- a/pkg/deploy/server/rbac.go
+++ b/pkg/deploy/server/rbac.go
@@ -280,6 +280,11 @@ func (s *CheServerReconciler) getUserCommonPolicies() []rbacv1.PolicyRule {
 			Resources: []string{"projects"},
 			Verbs:     []string{"get"},
 		},
+		{
+			APIGroups: []string{"image.openshift.io"},
+			Resources: []string{"imagestreams"},
+			Verbs:     []string{"get", "list"},
+		},
 	}
 
 	if infrastructure.IsOpenShift() {


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?

Adds `image.openshift.io/imagestreams: get, list` to the OpenShift-specific rules in the workspace user ClusterRole (e.g. `openshift-devspaces-cheworkspaces-clusterrole`).

Non-admin Dev Spaces users couldn't list workspace backups stored in the OpenShift internal registry because the ClusterRole lacked ImageStream permissions. The dashboard backup listing failed with 403 Forbidden - the user saw either an empty list (before the companion dashboard fix) or an error notification (after).

This is the server-side companion to eclipse-che/che-dashboard#<!-- PR number -->.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->

resolves https://redhat.atlassian.net/browse/CRW-10984

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Deploy the operator
2. Ensure the DWOC has backup configured with the OpenShift internal registry:
   ```yaml
   config:
     workspace:
       backupCronJob:
         enable: true
         oras:
           extraArgs: '--insecure'
         registry:
           path: image-registry.openshift-image-registry.svc:5000
         schedule: '*/5 * * * *'
   ```
3. Login as a non-admin user, create a workspace
4. Stop the workspace, wait for backup to complete
5. Navigate to the Backups tab on the Workspaces page
6. Verify the backup list loads without errors
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
