### PR TITLE
refactor: Consolidate namespace constants into shared constants package

### DIFF
--- a/controllers/namespacecache/namespacecache.go
+++ b/controllers/namespacecache/namespacecache.go
@@ -16,24 +16,13 @@ import (
 	"context"
 	"sync"
 
+	"github.com/eclipse-che/che-operator/pkg/common/constants"
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	projectv1 "github.com/openshift/api/project/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	WorkspaceNamespaceOwnerUidLabel string = "che.eclipse.org/workspace-namespace-owner-uid"
-	CheNameLabel                    string = "che.eclipse.org/che-name"
-	CheNamespaceLabel               string = "che.eclipse.org/che-namespace"
-	ChePartOfLabel                  string = "app.kubernetes.io/part-of"
-	ChePartOfLabelValue             string = "che.eclipse.org"
-	CheComponentLabel               string = "app.kubernetes.io/component"
-	CheComponentLabelValue          string = "workspaces-namespace"
-	CheUsernameAnnotation           string = "che.eclipse.org/username"
 )
 
 type NamespaceCache struct {
@@ -45,7 +34,6 @@ type NamespaceCache struct {
 type NamespaceInfo struct {
 	IsWorkspaceNamespace bool
 	Username             string
-	CheCluster           *types.NamespacedName
 }
 
 func NewNamespaceCache(client client.Client) *NamespaceCache {
@@ -130,20 +118,14 @@ func (c *NamespaceCache) examineNamespaceUnsafe(ctx context.Context, ns string) 
 
 	// ownerUid is the legacy label that we used to use. Let's not break the existing workspace namespaces and still
 	// recognize it
-	ownerUid := labels[WorkspaceNamespaceOwnerUidLabel]
-	cheName := labels[CheNameLabel]
-	cheNamespace := labels[CheNamespaceLabel]
-	partOfLabel := labels[ChePartOfLabel]
-	componentLabel := labels[CheComponentLabel]
-	username := annotations[CheUsernameAnnotation]
+	ownerUid := labels[constants.WorkspaceNamespaceOwnerUidLabelKey]
+	partOfLabel := labels[constants.KubernetesPartOfLabelKey]
+	componentLabel := labels[constants.KubernetesComponentLabelKey]
+	username := annotations[constants.CheEclipseOrgUsername]
 
 	ret := NamespaceInfo{
-		IsWorkspaceNamespace: ownerUid != "" || (partOfLabel == ChePartOfLabelValue && componentLabel == CheComponentLabelValue),
+		IsWorkspaceNamespace: ownerUid != "" || (partOfLabel == constants.CheEclipseOrg && componentLabel == constants.WorkspacesNamespaceComponentName),
 		Username:             username,
-		CheCluster: &types.NamespacedName{
-			Name:      cheName,
-			Namespace: cheNamespace,
-		},
 	}
 
 	c.KnownNamespaces[ns] = ret

--- a/controllers/namespacecache/namespacecache_test.go
+++ b/controllers/namespacecache/namespacecache_test.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/eclipse-che/che-operator/pkg/common/constants"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
 
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
@@ -84,7 +85,7 @@ func TestExamineUpdatesCache(t *testing.T) {
 		assert.NoError(t, cl.Get(context.TODO(), client.ObjectKey{Name: nsName}, ns))
 
 		ns.(metav1.Object).SetLabels(map[string]string{
-			WorkspaceNamespaceOwnerUidLabel: "uid",
+			constants.WorkspaceNamespaceOwnerUidLabelKey: "uid",
 		})
 
 		assert.NoError(t, cl.Update(context.TODO(), ns))
@@ -95,8 +96,8 @@ func TestExamineUpdatesCache(t *testing.T) {
 		assert.True(t, nsi.IsWorkspaceNamespace, "namespace should be found as managed using the legacy user UID label")
 
 		ns.(metav1.Object).SetLabels(map[string]string{
-			ChePartOfLabel:    ChePartOfLabelValue,
-			CheComponentLabel: CheComponentLabelValue,
+			constants.KubernetesPartOfLabelKey:    constants.CheEclipseOrg,
+			constants.KubernetesComponentLabelKey: constants.WorkspacesNamespaceComponentName,
 		})
 
 		assert.NoError(t, cl.Update(context.TODO(), ns))

--- a/controllers/usernamespace/usernamespace_controller_test.go
+++ b/controllers/usernamespace/usernamespace_controller_test.go
@@ -300,7 +300,7 @@ func TestCreatesDataInNamespace(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "ns",
 				Labels: map[string]string{
-					namespacecache.WorkspaceNamespaceOwnerUidLabel: "uid",
+					constants.WorkspaceNamespaceOwnerUidLabelKey: "uid",
 				},
 			},
 		})
@@ -312,7 +312,7 @@ func TestCreatesDataInNamespace(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "prj",
 					Labels: map[string]string{
-						namespacecache.WorkspaceNamespaceOwnerUidLabel: "uid",
+						constants.WorkspaceNamespaceOwnerUidLabelKey: "uid",
 					},
 				},
 			},
@@ -320,7 +320,7 @@ func TestCreatesDataInNamespace(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "prj",
 					Labels: map[string]string{
-						namespacecache.WorkspaceNamespaceOwnerUidLabel: "uid",
+						constants.WorkspaceNamespaceOwnerUidLabelKey: "uid",
 					},
 				},
 			}, &configv1.Proxy{
@@ -344,10 +344,10 @@ func TestUpdateSccClusterRoleBinding(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ns1",
 			Labels: map[string]string{
-				namespacecache.WorkspaceNamespaceOwnerUidLabel: "uid_1",
+				constants.WorkspaceNamespaceOwnerUidLabelKey: "uid_1",
 			},
 			Annotations: map[string]string{
-				namespacecache.CheUsernameAnnotation: "user_1",
+				constants.CheEclipseOrgUsername: "user_1",
 			},
 		},
 	}
@@ -356,10 +356,10 @@ func TestUpdateSccClusterRoleBinding(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ns1",
 			Labels: map[string]string{
-				namespacecache.WorkspaceNamespaceOwnerUidLabel: "uid_1",
+				constants.WorkspaceNamespaceOwnerUidLabelKey: "uid_1",
 			},
 			Annotations: map[string]string{
-				namespacecache.CheUsernameAnnotation: "user_1",
+				constants.CheEclipseOrgUsername: "user_1",
 			},
 		},
 	}
@@ -419,7 +419,7 @@ func TestWatchRulesForSecretsInSameNamespace(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ns",
 			Labels: map[string]string{
-				namespacecache.WorkspaceNamespaceOwnerUidLabel: "uid",
+				constants.WorkspaceNamespaceOwnerUidLabelKey: "uid",
 			},
 		},
 	}, secret)
@@ -451,7 +451,7 @@ func TestWatchRulesForConfigMapsInSameNamespace(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ns",
 			Labels: map[string]string{
-				namespacecache.WorkspaceNamespaceOwnerUidLabel: "uid",
+				constants.WorkspaceNamespaceOwnerUidLabelKey: "uid",
 			},
 		},
 	}, cm)
@@ -491,7 +491,7 @@ func TestWatchRulesForSecretsInOtherNamespaces(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "ns1",
 				Labels: map[string]string{
-					namespacecache.WorkspaceNamespaceOwnerUidLabel: "uid1",
+					constants.WorkspaceNamespaceOwnerUidLabelKey: "uid1",
 				},
 			},
 		},
@@ -503,7 +503,7 @@ func TestWatchRulesForSecretsInOtherNamespaces(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "ns2",
 				Labels: map[string]string{
-					namespacecache.WorkspaceNamespaceOwnerUidLabel: "uid2",
+					constants.WorkspaceNamespaceOwnerUidLabelKey: "uid2",
 				},
 			},
 		},
@@ -568,7 +568,7 @@ func TestWatchRulesForConfigMapsInOtherNamespaces(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "ns1",
 				Labels: map[string]string{
-					namespacecache.WorkspaceNamespaceOwnerUidLabel: "uid1",
+					constants.WorkspaceNamespaceOwnerUidLabelKey: "uid1",
 				},
 			},
 		},
@@ -580,7 +580,7 @@ func TestWatchRulesForConfigMapsInOtherNamespaces(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "ns2",
 				Labels: map[string]string{
-					namespacecache.WorkspaceNamespaceOwnerUidLabel: "uid2",
+					constants.WorkspaceNamespaceOwnerUidLabelKey: "uid2",
 				},
 			},
 		},

--- a/controllers/workspaceconfig/configmap2sync_test.go
+++ b/controllers/workspaceconfig/configmap2sync_test.go
@@ -77,7 +77,6 @@ func TestSyncConfigMap(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},
@@ -243,7 +242,6 @@ func TestSyncConfigMapShouldMergeLabelsAndAnnotationsOnUpdate(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},
@@ -360,7 +358,6 @@ func TestSyncConfigMapShouldRespectDWOLabels(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},
@@ -458,7 +455,6 @@ func TestSyncConfigMapShouldRemoveSomeLabels(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},
@@ -509,7 +505,6 @@ func TestSyncConfigMapShouldRetainIfAnnotationSetTrue(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},
@@ -571,7 +566,6 @@ func TestSyncConfigMapShouldNotRetainIfAnnotationSetFalse(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},

--- a/controllers/workspaceconfig/pvc2sync_test.go
+++ b/controllers/workspaceconfig/pvc2sync_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/eclipse-che/che-operator/controllers/namespacecache"
 	"k8s.io/apimachinery/pkg/api/errors"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/eclipse-che/che-operator/pkg/common/constants"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
 	"github.com/eclipse-che/che-operator/pkg/deploy"
@@ -65,7 +63,6 @@ func TestSyncPVC(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},
@@ -169,7 +166,6 @@ func TestSyncPVCShouldRetainIfAnnotationSetTrue(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},
@@ -232,7 +228,6 @@ func TestSyncPVCShouldNotRetainIfAnnotationSetFalse(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},

--- a/controllers/workspaceconfig/secret2sync_test.go
+++ b/controllers/workspaceconfig/secret2sync_test.go
@@ -22,8 +22,6 @@ import (
 
 	dwconstants "github.com/devfile/devworkspace-operator/pkg/constants"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/eclipse-che/che-operator/pkg/common/utils"
 
 	"github.com/eclipse-che/che-operator/pkg/deploy"
@@ -70,7 +68,6 @@ func TestSyncSecrets(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},
@@ -246,7 +243,6 @@ func TestSyncSecretShouldMergeLabelsAndAnnotationsOnUpdate(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},
@@ -353,7 +349,6 @@ func TestSyncSecretShouldRespectDWOLabels(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},
@@ -452,7 +447,6 @@ func TestSyncSecretShouldRemoveSomeLabels(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},

--- a/controllers/workspaceconfig/unstructured2sync_test.go
+++ b/controllers/workspaceconfig/unstructured2sync_test.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/eclipse-che/che-operator/controllers/namespacecache"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/eclipse-che/che-operator/pkg/deploy"
 	templatev1 "github.com/openshift/api/template/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -90,7 +88,6 @@ func TestSyncTemplateWithLimitRange(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},
@@ -283,7 +280,6 @@ func TestSyncUnstructuredShouldRetainIfAnnotationSetTrue(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},
@@ -368,7 +364,6 @@ func TestSyncUnstructuredShouldNotRetainIfAnnotationSetFalse(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},
@@ -451,7 +446,6 @@ func TestSyncUnstructuredShouldNotRetainIfAnnotationIsNotSet(t *testing.T) {
 				userNamespace: {
 					IsWorkspaceNamespace: true,
 					Username:             "user",
-					CheCluster:           &types.NamespacedName{Name: "eclipse-che", Namespace: "eclipse-che"},
 				},
 			},
 			Lock: sync.Mutex{},

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -116,11 +116,12 @@ const (
 	BitbucketOAuth                             = "bitbucket"
 
 	// Labels
-	KubernetesComponentLabelKey = "app.kubernetes.io/component"
-	KubernetesPartOfLabelKey    = "app.kubernetes.io/part-of"
-	KubernetesManagedByLabelKey = "app.kubernetes.io/managed-by"
-	KubernetesInstanceLabelKey  = "app.kubernetes.io/instance"
-	KubernetesNameLabelKey      = "app.kubernetes.io/name"
+	KubernetesComponentLabelKey        = "app.kubernetes.io/component"
+	KubernetesPartOfLabelKey           = "app.kubernetes.io/part-of"
+	KubernetesManagedByLabelKey        = "app.kubernetes.io/managed-by"
+	KubernetesInstanceLabelKey         = "app.kubernetes.io/instance"
+	KubernetesNameLabelKey             = "app.kubernetes.io/name"
+	WorkspaceNamespaceOwnerUidLabelKey = "che.eclipse.org/workspace-namespace-owner-uid"
 
 	// Annotations
 	CheEclipseOrgMountPath                          = "che.eclipse.org/mount-path"
@@ -133,6 +134,7 @@ const (
 	CheEclipseOrgScmGitHubDisableSubdomainIsolation = "che.eclipse.org/scm-github-disable-subdomain-isolation"
 	OpenShiftIOOwningComponent                      = "openshift.io/owning-component"
 	ConfigOpenShiftIOInjectTrustedCaBundle          = "config.openshift.io/inject-trusted-cabundle"
+	CheEclipseOrgUsername                           = "che.eclipse.org/username"
 
 	// DevEnvironments
 	PerUserPVCStorageStrategy           = "per-user"
@@ -160,6 +162,7 @@ const (
 	EditorDefinitionComponentName      = "editor-definition"
 	CheCABundle                        = "ca-bundle"
 	MetricsComponentName               = "metrics"
+	WorkspacesNamespaceComponentName   = "workspaces-namespace"
 
 	// common
 	CheFlavor             = "che"


### PR DESCRIPTION
## Summary
- Move label/annotation constants (`WorkspaceNamespaceOwnerUidLabel`, `ChePartOfLabel`, `CheComponentLabel`, `CheUsernameAnnotation`, etc.) from `controllers/namespacecache` to `pkg/common/constants` for reuse across controllers
- Remove unused `CheCluster` field from `NamespaceInfo` struct and its associated `CheNameLabel`/`CheNamespaceLabel` constants
- Update all references in tests across `namespacecache`, `usernamespace`, and `workspaceconfig` packages

## Test plan
- [ ] Verify existing unit tests pass (`make test`)
- [ ] Verify no remaining references to removed constants

🤖 Generated with [Claude Code](https://claude.com/claude-code)