### PR TITLE
refactor: Remove unused image puller constants

### DIFF
--- a/pkg/deploy/image-puller/imagepuller.go
+++ b/pkg/deploy/image-puller/imagepuller.go
@@ -45,12 +45,10 @@ var (
 )
 
 const (
-	resourceName  = "kubernetesimagepullers"
 	finalizerName = "kubernetesimagepullers.finalizers.che.eclipse.org"
 
-	defaultConfigMapName    = "k8s-image-puller"
-	defaultDeploymentName   = "kubernetes-image-puller"
-	defaultImagePullerImage = "quay.io/eclipse/kubernetes-image-puller:next"
+	defaultConfigMapName  = "k8s-image-puller"
+	defaultDeploymentName = "kubernetes-image-puller"
 )
 
 type ImagePuller struct {
@@ -146,7 +144,6 @@ func (ip *ImagePuller) syncKubernetesImagePuller(externalImages []string, ctx *c
 	// See https://github.com/che-incubator/kubernetes-image-puller-operator/blob/main/controllers/kubernetesimagepuller_controller.go
 	imagePuller.Spec.ConfigMapName = utils.GetValue(imagePuller.Spec.ConfigMapName, defaultConfigMapName)
 	imagePuller.Spec.DeploymentName = utils.GetValue(imagePuller.Spec.DeploymentName, defaultDeploymentName)
-	imagePuller.Spec.ImagePullerImage = utils.GetValue(imagePuller.Spec.ImagePullerImage, defaultImagePullerImage)
 	if strings.TrimSpace(imagePuller.Spec.Images) == "" {
 		imagePuller.Spec.Images = convertToSpecField(externalImages)
 	}

--- a/pkg/deploy/image-puller/imagepuller_test.go
+++ b/pkg/deploy/image-puller/imagepuller_test.go
@@ -52,10 +52,9 @@ func TestImagePullerConfiguration(t *testing.T) {
 			}),
 			testCaseFilePath: "image-puller-resources-test/imagepuller_testcase_1.json",
 			expectedImagePuller: InitImagePuller(chev1alpha1.KubernetesImagePullerSpec{
-				DeploymentName:   defaultDeploymentName,
-				ConfigMapName:    defaultConfigMapName,
-				ImagePullerImage: defaultImagePullerImage,
-				Images:           "image-1-0=image_1;image-2-1=image_2;",
+				DeploymentName: defaultDeploymentName,
+				ConfigMapName:  defaultConfigMapName,
+				Images:         "image-1-0=image_1;image-2-1=image_2;",
 			}),
 		},
 		{
@@ -84,16 +83,14 @@ func TestImagePullerConfiguration(t *testing.T) {
 			testCaseFilePath: "image-puller-resources-test/imagepuller_testcase_2.json",
 			initObjects: []client.Object{
 				InitImagePuller(chev1alpha1.KubernetesImagePullerSpec{
-					DeploymentName:   defaultDeploymentName,
-					ConfigMapName:    defaultConfigMapName,
-					ImagePullerImage: defaultImagePullerImage,
+					DeploymentName: defaultDeploymentName,
+					ConfigMapName:  defaultConfigMapName,
 				}),
 			},
 			expectedImagePuller: InitImagePuller(chev1alpha1.KubernetesImagePullerSpec{
-				DeploymentName:   defaultDeploymentName,
-				ConfigMapName:    defaultConfigMapName,
-				ImagePullerImage: defaultImagePullerImage,
-				Images:           "image-1-0=image_1;image-2-1=image_2;image-3-2=image_3;",
+				DeploymentName: defaultDeploymentName,
+				ConfigMapName:  defaultConfigMapName,
+				Images:         "image-1-0=image_1;image-2-1=image_2;image-3-2=image_3;",
 			}),
 		},
 		{
@@ -109,9 +106,8 @@ func TestImagePullerConfiguration(t *testing.T) {
 			testCaseFilePath: "image-puller-resources-test/imagepuller_testcase_1.json",
 			initObjects: []client.Object{
 				InitImagePuller(chev1alpha1.KubernetesImagePullerSpec{
-					DeploymentName:   defaultDeploymentName,
-					ConfigMapName:    defaultConfigMapName,
-					ImagePullerImage: defaultImagePullerImage,
+					DeploymentName: defaultDeploymentName,
+					ConfigMapName:  defaultConfigMapName,
 				}),
 			},
 			expectedImagePuller: InitImagePuller(chev1alpha1.KubernetesImagePullerSpec{
@@ -129,9 +125,8 @@ func TestImagePullerConfiguration(t *testing.T) {
 			testCaseFilePath: "image-puller-resources-test/imagepuller_testcase_1.json",
 			initObjects: []client.Object{
 				InitImagePuller(chev1alpha1.KubernetesImagePullerSpec{
-					DeploymentName:   defaultDeploymentName,
-					ConfigMapName:    defaultConfigMapName,
-					ImagePullerImage: defaultImagePullerImage,
+					DeploymentName: defaultDeploymentName,
+					ConfigMapName:  defaultConfigMapName,
 				}),
 			},
 		},


### PR DESCRIPTION
## Summary
- Remove unused `defaultImagePullerImage` and `resourceName` constants from the image puller reconciler
- Stop overriding `ImagePullerImage` with a hardcoded default, letting the kubernetes-image-puller operator use its own built-in default instead
- Update tests to remove references to the removed constant

## Test plan
- [ ] Verify existing image puller tests pass (`go test ./pkg/deploy/image-puller/...`)
- [ ] Confirm no other references to `defaultImagePullerImage` or `resourceName` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)