### PR TITLE
fix: Add init container to wait for database before starting OpenVSX server

### DIFF
--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2026-07-24T11:26:36Z"
+    createdAt: "2026-07-24T14:28:09Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     features.operators.openshift.io/cnf: "false"
@@ -108,7 +108,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: eclipse-che.v7.121.0-1043.next
+  name: eclipse-che.v7.121.0-1044.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1173,7 +1173,7 @@ spec:
       name: openvsx
     - image: quay.io/sclorg/postgresql-16-c9s:20260319
       name: openvsx-postgres
-  version: 7.121.0-1043.next
+  version: 7.121.0-1044.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2026-07-21T11:26:48Z"
+    createdAt: "2026-07-24T11:26:36Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     features.operators.openshift.io/cnf: "false"
@@ -108,7 +108,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: eclipse-che.v7.121.0-1042.next
+  name: eclipse-che.v7.121.0-1043.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1173,7 +1173,7 @@ spec:
       name: openvsx
     - image: quay.io/sclorg/postgresql-16-c9s:20260319
       name: openvsx-postgres
-  version: 7.121.0-1042.next
+  version: 7.121.0-1043.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/pkg/deploy/openvsx/openvsx-server/openvsx_server_deployment.go
+++ b/pkg/deploy/openvsx/openvsx-server/openvsx_server_deployment.go
@@ -90,8 +90,18 @@ func (r *OpenVSXServerReconciler) getDeploymentSpec(ctx *chetypes.DeployContext)
 								utils.EnvVarFromSecret("PGUSER", credentialsSecretName, "database-user"),
 								utils.EnvVarFromSecret("PGDATABASE", credentialsSecretName, "database-name"),
 							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							},
 							Command: []string{"sh", "-c",
-								`until pg_isready -q; do echo "Waiting for database..."; sleep 2; done`,
+								`i=0; until pg_isready -q; do echo "Waiting for database... ($i s)"; sleep 2; i=$((i+2)); if [ $i -ge 120 ]; then echo "Timed out waiting for database" >&2; exit 1; fi; done`,
 							},
 						},
 					},

--- a/pkg/deploy/openvsx/openvsx-server/openvsx_server_deployment.go
+++ b/pkg/deploy/openvsx/openvsx-server/openvsx_server_deployment.go
@@ -52,6 +52,9 @@ func (r *OpenVSXServerReconciler) getDeploymentSpec(ctx *chetypes.DeployContext)
 	labels := deploy.GetLabels(constants.OpenVSXServerComponentName)
 	credentialsSecretName := openvsx.GetCredentialsSecretName(ctx)
 
+	dbImage := defaults.GetOpenVSXDatabaseImage(ctx.CheCluster)
+	dbImagePullPolicy := utils.GetPullPolicyFromDockerImage(dbImage)
+
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -74,6 +77,24 @@ func (r *OpenVSXServerReconciler) getDeploymentSpec(ctx *chetypes.DeployContext)
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:            "wait-database",
+							Image:           dbImage,
+							ImagePullPolicy: corev1.PullPolicy(dbImagePullPolicy),
+							Env: []corev1.EnvVar{
+								{
+									Name:  "PGHOST",
+									Value: constants.OpenVSXDatabaseComponentName,
+								},
+								utils.EnvVarFromSecret("PGUSER", credentialsSecretName, "database-user"),
+								utils.EnvVarFromSecret("PGDATABASE", credentialsSecretName, "database-name"),
+							},
+							Command: []string{"sh", "-c",
+								`until pg_isready -q; do echo "Waiting for database..."; sleep 2; done`,
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            constants.OpenVSXServerComponentName,

--- a/pkg/deploy/openvsx/openvsx-server/openvsx_server_test.go
+++ b/pkg/deploy/openvsx/openvsx-server/openvsx_server_test.go
@@ -13,12 +13,15 @@
 package openvsx_server
 
 import (
+	"strings"
 	"testing"
 
 	chev2 "github.com/eclipse-che/che-operator/api/v2"
 	"github.com/eclipse-che/che-operator/pkg/common/constants"
+	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
 	"github.com/eclipse-che/che-operator/pkg/deploy/gateway"
+	"github.com/eclipse-che/che-operator/pkg/deploy/openvsx"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -66,4 +69,54 @@ func TestOpenVSXServerReconciler(t *testing.T) {
 	assert.False(t, test.IsObjectExists(ctx.ClusterAPI.Client, types.NamespacedName{Name: gateway.GatewayConfigMapNamePrefix + constants.OpenVSXServerComponentName, Namespace: ns}, &corev1.ConfigMap{}))
 	assert.False(t, test.IsObjectExists(ctx.ClusterAPI.Client, types.NamespacedName{Name: constants.OpenVSXServerExtensionsConfigMapName, Namespace: ns}, &corev1.ConfigMap{}))
 	assert.False(t, test.IsObjectExists(ctx.ClusterAPI.Client, types.NamespacedName{Name: constants.OpenVSXServerExtensionPublishJobName, Namespace: ns}, &batchv1.Job{}))
+}
+
+func TestDeploymentSpecHasWaitDatabaseInitContainer(t *testing.T) {
+	ctx := test.NewCtxBuilder().WithCheCluster(
+		&chev2.CheCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "eclipse-che",
+				Namespace: "eclipse-che",
+			},
+			Spec: chev2.CheClusterSpec{
+				Components: chev2.CheClusterComponents{
+					OpenVSXRegistry: chev2.OpenVSXRegistry{
+						Enable: true,
+					},
+				},
+			},
+		},
+	).Build()
+
+	reconciler := NewOpenVSXServerReconciler()
+	deployment, err := reconciler.getDeploymentSpec(ctx)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	initContainers := deployment.Spec.Template.Spec.InitContainers
+	if !assert.Len(t, initContainers, 1, "expected exactly one init container") {
+		return
+	}
+
+	ic := initContainers[0]
+	assert.Equal(t, "wait-database", ic.Name)
+	assert.Equal(t, defaults.GetOpenVSXDatabaseImage(ctx.CheCluster), ic.Image)
+
+	expectedSecretName := openvsx.GetCredentialsSecretName(ctx)
+	envMap := make(map[string]corev1.EnvVar, len(ic.Env))
+	for _, e := range ic.Env {
+		envMap[e.Name] = e
+	}
+	assert.Equal(t, constants.OpenVSXDatabaseComponentName, envMap["PGHOST"].Value)
+	assert.Equal(t, expectedSecretName, envMap["PGUSER"].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, expectedSecretName, envMap["PGDATABASE"].ValueFrom.SecretKeyRef.Name)
+
+	if assert.Len(t, ic.Command, 3) {
+		assert.Contains(t, ic.Command[2], "pg_isready")
+		assert.True(t, strings.Contains(ic.Command[2], "120"), "expected timeout of 120 seconds in the command")
+	}
+
+	assert.NotNil(t, ic.Resources.Requests, "init container should have resource requests")
+	assert.NotNil(t, ic.Resources.Limits, "init container should have resource limits")
 }


### PR DESCRIPTION


<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?
Add a wait-database init container that polls with pg_isready until the database is reachable.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
The OpenVSX server pod could crash on first startup with java.net.ConnectException when PostgreSQL was not yet accepting connections.

Related to https://redhat.atlassian.net/browse/CRW-11780

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh
```

or

```bash
build/scripts/docker-run.sh /bin/bash -c "
  oc login \
    --token=<...> \
    --server=<...> \
    --insecure-skip-tls-verify=true && \
  build/scripts/olm/test-catalog-from-sources.sh
"
```

2. Enable openvsx operand:
```yaml
spec:
  components:
    openVSXRegistry:
      enable: true
```

3. Verify that the openvsx-server pod starts successfully on the first attempt.

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh
```

#### Common Test Scenarios
- [ ] Deploy Eclipse Che
- [ ] Start an empty workspace
- [ ] Open terminal and build/run an image
- [ ] Stop a workspace
- [ ] Check operator logs for reconciliation errors or infinite reconciliation loops

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
