### PR TITLE
chore: Bump traefik 3.7.10

### DIFF
--- a/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
+++ b/bundle/next/eclipse-che/manifests/che-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:next
-    createdAt: "2026-07-30T08:51:48Z"
+    createdAt: "2026-08-05T10:03:38Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     features.operators.openshift.io/cnf: "false"
@@ -108,7 +108,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: eclipse-che.v7.121.0-1053.next
+  name: eclipse-che.v7.121.0-1054.next
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -987,7 +987,7 @@ spec:
                       - name: RELATED_IMAGE_che_tls_secrets_creation_job
                         value: quay.io/eclipse/che-tls-secret-creator:9f9d4a6
                       - name: RELATED_IMAGE_single_host_gateway
-                        value: quay.io/eclipse/che--traefik:v3.7.5-d6858791f9e74df44ca4014166647c41cdc2abd3bf2a71b832ca4e1c6a91b257
+                        value: quay.io/eclipse/che--traefik:v3.7.10-9c3b91d5fb7770853ca5c1124a23c34bf2d9b47ffaebeab2614cbaf410dcb2ac
                       - name: RELATED_IMAGE_single_host_gateway_config_sidecar
                         value: quay.io/che-incubator/configbump:next
                       - name: RELATED_IMAGE_gateway_authentication_sidecar
@@ -1157,7 +1157,7 @@ spec:
       name: plugin-registry
     - image: quay.io/eclipse/che-tls-secret-creator:9f9d4a6
       name: che-tls-secrets-creation-job
-    - image: quay.io/eclipse/che--traefik:v3.7.5-d6858791f9e74df44ca4014166647c41cdc2abd3bf2a71b832ca4e1c6a91b257
+    - image: quay.io/eclipse/che--traefik:v3.7.10-9c3b91d5fb7770853ca5c1124a23c34bf2d9b47ffaebeab2614cbaf410dcb2ac
       name: single-host-gateway
     - image: quay.io/che-incubator/configbump:next
       name: single-host-gateway-config-sidecar
@@ -1173,7 +1173,7 @@ spec:
       name: openvsx
     - image: quay.io/sclorg/postgresql-16-c9s:20260319
       name: openvsx-postgres
-  version: 7.121.0-1053.next
+  version: 7.121.0-1054.next
   webhookdefinitions:
     - admissionReviewVersions:
         - v1

--- a/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
+++ b/bundle/next/eclipse-che/manifests/org.eclipse.che_checlusters.yaml
@@ -1512,6 +1512,8 @@ spec:
                           type: string
                         nodeSelector:
                           type: string
+                        tolerations:
+                          type: string
                       type: object
                   required:
                     - enable
@@ -4730,7 +4732,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -5920,7 +5921,7 @@ spec:
                                       A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                      The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                      The volume will be mounted read-only (ro).
                                       Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                     properties:
@@ -6094,8 +6095,7 @@ spec:
                                     description: |-
                                       portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                       Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                      are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                      is on.
+                                      are redirected to the pxd.portworx.com CSI driver.
                                     properties:
                                       fsType:
                                         description: |-
@@ -7320,7 +7320,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -8510,7 +8509,7 @@ spec:
                                       A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                      The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                      The volume will be mounted read-only (ro).
                                       Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                     properties:
@@ -8684,8 +8683,7 @@ spec:
                                     description: |-
                                       portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                       Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                      are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                      is on.
+                                      are redirected to the pxd.portworx.com CSI driver.
                                     properties:
                                       fsType:
                                         description: |-
@@ -9876,7 +9874,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -11066,7 +11063,7 @@ spec:
                                       A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                      The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                      The volume will be mounted read-only (ro).
                                       Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                     properties:
@@ -11240,8 +11237,7 @@ spec:
                                     description: |-
                                       portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                       Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                      are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                      is on.
+                                      are redirected to the pxd.portworx.com CSI driver.
                                     properties:
                                       fsType:
                                         description: |-
@@ -12136,6 +12132,8 @@ spec:
                               type: string
                             nodeSelector:
                               type: string
+                            tolerations:
+                              type: string
                           type: object
                       type: object
                     metrics:
@@ -12500,7 +12498,6 @@ spec:
                                               procMount denotes the type of proc mount to use for the containers.
                                               The default value is Default which uses the container runtime defaults for
                                               readonly paths and masked paths.
-                                              This requires the ProcMountType feature flag to be enabled.
                                               Note that this field cannot be set when spec.os.name is windows.
                                             type: string
                                           readOnlyRootFilesystem:
@@ -13702,7 +13699,7 @@ spec:
                                           A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                           The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                           The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                          The volume will be mounted read-only (ro).
                                           Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                           The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                         properties:
@@ -13877,8 +13874,7 @@ spec:
                                         description: |-
                                           portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                           Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                          is on.
+                                          are redirected to the pxd.portworx.com CSI driver.
                                         properties:
                                           fsType:
                                             description: |-
@@ -15085,7 +15081,6 @@ spec:
                                               procMount denotes the type of proc mount to use for the containers.
                                               The default value is Default which uses the container runtime defaults for
                                               readonly paths and masked paths.
-                                              This requires the ProcMountType feature flag to be enabled.
                                               Note that this field cannot be set when spec.os.name is windows.
                                             type: string
                                           readOnlyRootFilesystem:
@@ -16287,7 +16282,7 @@ spec:
                                           A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                           The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                           The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                          The volume will be mounted read-only (ro).
                                           Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                           The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                         properties:
@@ -16462,8 +16457,7 @@ spec:
                                         description: |-
                                           portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                           Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                          is on.
+                                          are redirected to the pxd.portworx.com CSI driver.
                                         properties:
                                           fsType:
                                             description: |-
@@ -17660,7 +17654,6 @@ spec:
                                           procMount denotes the type of proc mount to use for the containers.
                                           The default value is Default which uses the container runtime defaults for
                                           readonly paths and masked paths.
-                                          This requires the ProcMountType feature flag to be enabled.
                                           Note that this field cannot be set when spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
@@ -18850,7 +18843,7 @@ spec:
                                       A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                       The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                       The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                      The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                      The volume will be mounted read-only (ro).
                                       Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                       The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                     properties:
@@ -19024,8 +19017,7 @@ spec:
                                     description: |-
                                       portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                       Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                      are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                      is on.
+                                      are redirected to the pxd.portworx.com CSI driver.
                                     properties:
                                       fsType:
                                         description: |-
@@ -20090,7 +20082,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -22143,7 +22134,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -23460,7 +23450,6 @@ spec:
                                   procMount denotes the type of proc mount to use for the containers.
                                   The default value is Default which uses the container runtime defaults for
                                   readonly paths and masked paths.
-                                  This requires the ProcMountType feature flag to be enabled.
                                   Note that this field cannot be set when spec.os.name is windows.
                                 type: string
                               readOnlyRootFilesystem:
@@ -24276,7 +24265,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -24562,7 +24550,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -25628,7 +25615,6 @@ spec:
                                               procMount denotes the type of proc mount to use for the containers.
                                               The default value is Default which uses the container runtime defaults for
                                               readonly paths and masked paths.
-                                              This requires the ProcMountType feature flag to be enabled.
                                               Note that this field cannot be set when spec.os.name is windows.
                                             type: string
                                           readOnlyRootFilesystem:
@@ -26830,7 +26816,7 @@ spec:
                                           A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                           The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                           The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                          The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                          The volume will be mounted read-only (ro).
                                           Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                           The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                         properties:
@@ -27005,8 +26991,7 @@ spec:
                                         description: |-
                                           portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                           Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                          are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                          is on.
+                                          are redirected to the pxd.portworx.com CSI driver.
                                         properties:
                                           fsType:
                                             description: |-

--- a/config/crd/bases/org.eclipse.che_checlusters.yaml
+++ b/config/crd/bases/org.eclipse.che_checlusters.yaml
@@ -1493,6 +1493,8 @@ spec:
                         type: string
                       nodeSelector:
                         type: string
+                      tolerations:
+                        type: string
                     type: object
                 required:
                 - enable
@@ -4694,7 +4696,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -5879,7 +5880,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -6053,8 +6054,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -7273,7 +7273,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -8458,7 +8457,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -8632,8 +8631,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -9818,7 +9816,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -11003,7 +11000,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -11177,8 +11174,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -12069,6 +12065,8 @@ spec:
                             type: string
                           nodeSelector:
                             type: string
+                          tolerations:
+                            type: string
                         type: object
                     type: object
                   metrics:
@@ -12428,7 +12426,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -13624,7 +13621,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -13798,8 +13795,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -15000,7 +14996,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -16196,7 +16191,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -16370,8 +16365,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -17564,7 +17558,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -18749,7 +18742,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -18923,8 +18916,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -19985,7 +19977,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -22033,7 +22024,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -23349,7 +23339,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -24164,7 +24153,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -24450,7 +24438,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -25511,7 +25498,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -26707,7 +26693,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -26881,8 +26867,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,7 +70,7 @@ spec:
             - name: RELATED_IMAGE_che_tls_secrets_creation_job
               value: quay.io/eclipse/che-tls-secret-creator:9f9d4a6
             - name: RELATED_IMAGE_single_host_gateway
-              value: quay.io/eclipse/che--traefik:v3.7.5-d6858791f9e74df44ca4014166647c41cdc2abd3bf2a71b832ca4e1c6a91b257
+              value: quay.io/eclipse/che--traefik:v3.7.10-9c3b91d5fb7770853ca5c1124a23c34bf2d9b47ffaebeab2614cbaf410dcb2ac
             - name: RELATED_IMAGE_single_host_gateway_config_sidecar
               value: quay.io/che-incubator/configbump:next
             - name: RELATED_IMAGE_gateway_authentication_sidecar

--- a/deploy/deployment/kubernetes/combined.yaml
+++ b/deploy/deployment/kubernetes/combined.yaml
@@ -1514,6 +1514,8 @@ spec:
                         type: string
                       nodeSelector:
                         type: string
+                      tolerations:
+                        type: string
                     type: object
                 required:
                 - enable
@@ -4715,7 +4717,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -5900,7 +5901,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -6074,8 +6075,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -7294,7 +7294,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -8479,7 +8478,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -8653,8 +8652,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -9839,7 +9837,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -11024,7 +11021,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -11198,8 +11195,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -12090,6 +12086,8 @@ spec:
                             type: string
                           nodeSelector:
                             type: string
+                          tolerations:
+                            type: string
                         type: object
                     type: object
                   metrics:
@@ -12449,7 +12447,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -13645,7 +13642,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -13819,8 +13816,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -15021,7 +15017,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -16217,7 +16212,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -16391,8 +16386,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -17585,7 +17579,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -18770,7 +18763,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -18944,8 +18937,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -20006,7 +19998,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -22054,7 +22045,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -23370,7 +23360,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -24185,7 +24174,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -24471,7 +24459,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -25532,7 +25519,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -26728,7 +26714,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -26902,8 +26888,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -28917,7 +28902,7 @@ spec:
         - name: RELATED_IMAGE_che_tls_secrets_creation_job
           value: quay.io/eclipse/che-tls-secret-creator:9f9d4a6
         - name: RELATED_IMAGE_single_host_gateway
-          value: quay.io/eclipse/che--traefik:v3.7.5-d6858791f9e74df44ca4014166647c41cdc2abd3bf2a71b832ca4e1c6a91b257
+          value: quay.io/eclipse/che--traefik:v3.7.10-9c3b91d5fb7770853ca5c1124a23c34bf2d9b47ffaebeab2614cbaf410dcb2ac
         - name: RELATED_IMAGE_single_host_gateway_config_sidecar
           value: quay.io/che-incubator/configbump:next
         - name: RELATED_IMAGE_gateway_authentication_sidecar

--- a/deploy/deployment/kubernetes/objects/che-operator.Deployment.yaml
+++ b/deploy/deployment/kubernetes/objects/che-operator.Deployment.yaml
@@ -64,7 +64,7 @@ spec:
         - name: RELATED_IMAGE_che_tls_secrets_creation_job
           value: quay.io/eclipse/che-tls-secret-creator:9f9d4a6
         - name: RELATED_IMAGE_single_host_gateway
-          value: quay.io/eclipse/che--traefik:v3.7.5-d6858791f9e74df44ca4014166647c41cdc2abd3bf2a71b832ca4e1c6a91b257
+          value: quay.io/eclipse/che--traefik:v3.7.10-9c3b91d5fb7770853ca5c1124a23c34bf2d9b47ffaebeab2614cbaf410dcb2ac
         - name: RELATED_IMAGE_single_host_gateway_config_sidecar
           value: quay.io/che-incubator/configbump:next
         - name: RELATED_IMAGE_gateway_authentication_sidecar

--- a/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/kubernetes/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -1509,6 +1509,8 @@ spec:
                         type: string
                       nodeSelector:
                         type: string
+                      tolerations:
+                        type: string
                     type: object
                 required:
                 - enable
@@ -4710,7 +4712,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -5895,7 +5896,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -6069,8 +6070,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -7289,7 +7289,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -8474,7 +8473,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -8648,8 +8647,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -9834,7 +9832,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -11019,7 +11016,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -11193,8 +11190,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -12085,6 +12081,8 @@ spec:
                             type: string
                           nodeSelector:
                             type: string
+                          tolerations:
+                            type: string
                         type: object
                     type: object
                   metrics:
@@ -12444,7 +12442,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -13640,7 +13637,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -13814,8 +13811,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -15016,7 +15012,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -16212,7 +16207,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -16386,8 +16381,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -17580,7 +17574,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -18765,7 +18758,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -18939,8 +18932,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -20001,7 +19993,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -22049,7 +22040,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -23365,7 +23355,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -24180,7 +24169,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -24466,7 +24454,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -25527,7 +25514,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -26723,7 +26709,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -26897,8 +26883,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-

--- a/deploy/deployment/openshift/combined.yaml
+++ b/deploy/deployment/openshift/combined.yaml
@@ -1514,6 +1514,8 @@ spec:
                         type: string
                       nodeSelector:
                         type: string
+                      tolerations:
+                        type: string
                     type: object
                 required:
                 - enable
@@ -4715,7 +4717,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -5900,7 +5901,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -6074,8 +6075,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -7294,7 +7294,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -8479,7 +8478,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -8653,8 +8652,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -9839,7 +9837,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -11024,7 +11021,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -11198,8 +11195,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -12090,6 +12086,8 @@ spec:
                             type: string
                           nodeSelector:
                             type: string
+                          tolerations:
+                            type: string
                         type: object
                     type: object
                   metrics:
@@ -12449,7 +12447,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -13645,7 +13642,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -13819,8 +13816,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -15021,7 +15017,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -16217,7 +16212,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -16391,8 +16386,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -17585,7 +17579,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -18770,7 +18763,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -18944,8 +18937,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -20006,7 +19998,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -22054,7 +22045,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -23370,7 +23360,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -24185,7 +24174,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -24471,7 +24459,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -25532,7 +25519,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -26728,7 +26714,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -26902,8 +26888,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -28919,7 +28904,7 @@ spec:
         - name: RELATED_IMAGE_che_tls_secrets_creation_job
           value: quay.io/eclipse/che-tls-secret-creator:9f9d4a6
         - name: RELATED_IMAGE_single_host_gateway
-          value: quay.io/eclipse/che--traefik:v3.7.5-d6858791f9e74df44ca4014166647c41cdc2abd3bf2a71b832ca4e1c6a91b257
+          value: quay.io/eclipse/che--traefik:v3.7.10-9c3b91d5fb7770853ca5c1124a23c34bf2d9b47ffaebeab2614cbaf410dcb2ac
         - name: RELATED_IMAGE_single_host_gateway_config_sidecar
           value: quay.io/che-incubator/configbump:next
         - name: RELATED_IMAGE_gateway_authentication_sidecar

--- a/deploy/deployment/openshift/objects/che-operator.Deployment.yaml
+++ b/deploy/deployment/openshift/objects/che-operator.Deployment.yaml
@@ -64,7 +64,7 @@ spec:
         - name: RELATED_IMAGE_che_tls_secrets_creation_job
           value: quay.io/eclipse/che-tls-secret-creator:9f9d4a6
         - name: RELATED_IMAGE_single_host_gateway
-          value: quay.io/eclipse/che--traefik:v3.7.5-d6858791f9e74df44ca4014166647c41cdc2abd3bf2a71b832ca4e1c6a91b257
+          value: quay.io/eclipse/che--traefik:v3.7.10-9c3b91d5fb7770853ca5c1124a23c34bf2d9b47ffaebeab2614cbaf410dcb2ac
         - name: RELATED_IMAGE_single_host_gateway_config_sidecar
           value: quay.io/che-incubator/configbump:next
         - name: RELATED_IMAGE_gateway_authentication_sidecar

--- a/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/deploy/deployment/openshift/objects/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -1509,6 +1509,8 @@ spec:
                         type: string
                       nodeSelector:
                         type: string
+                      tolerations:
+                        type: string
                     type: object
                 required:
                 - enable
@@ -4710,7 +4712,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -5895,7 +5896,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -6069,8 +6070,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -7289,7 +7289,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -8474,7 +8473,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -8648,8 +8647,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -9834,7 +9832,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -11019,7 +11016,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -11193,8 +11190,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -12085,6 +12081,8 @@ spec:
                             type: string
                           nodeSelector:
                             type: string
+                          tolerations:
+                            type: string
                         type: object
                     type: object
                   metrics:
@@ -12444,7 +12442,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -13640,7 +13637,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -13814,8 +13811,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -15016,7 +15012,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -16212,7 +16207,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -16386,8 +16381,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -17580,7 +17574,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -18765,7 +18758,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -18939,8 +18932,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -20001,7 +19993,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -22049,7 +22040,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -23365,7 +23355,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -24180,7 +24169,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -24466,7 +24454,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -25527,7 +25514,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -26723,7 +26709,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -26897,8 +26883,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-

--- a/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
+++ b/helmcharts/next/crds/checlusters.org.eclipse.che.CustomResourceDefinition.yaml
@@ -1509,6 +1509,8 @@ spec:
                         type: string
                       nodeSelector:
                         type: string
+                      tolerations:
+                        type: string
                     type: object
                 required:
                 - enable
@@ -4710,7 +4712,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -5895,7 +5896,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -6069,8 +6070,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -7289,7 +7289,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -8474,7 +8473,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -8648,8 +8647,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -9834,7 +9832,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -11019,7 +11016,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -11193,8 +11190,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -12085,6 +12081,8 @@ spec:
                             type: string
                           nodeSelector:
                             type: string
+                          tolerations:
+                            type: string
                         type: object
                     type: object
                   metrics:
@@ -12444,7 +12442,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -13640,7 +13637,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -13814,8 +13811,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -15016,7 +15012,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -16212,7 +16207,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -16386,8 +16381,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -17580,7 +17574,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -18765,7 +18758,7 @@ spec:
                                     A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                     The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                     The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    The volume will be mounted read-only (ro).
                                     Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                     The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                   properties:
@@ -18939,8 +18932,7 @@ spec:
                                   description: |-
                                     portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                     Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                    is on.
+                                    are redirected to the pxd.portworx.com CSI driver.
                                   properties:
                                     fsType:
                                       description: |-
@@ -20001,7 +19993,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -22049,7 +22040,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -23365,7 +23355,6 @@ spec:
                                 procMount denotes the type of proc mount to use for the containers.
                                 The default value is Default which uses the container runtime defaults for
                                 readonly paths and masked paths.
-                                This requires the ProcMountType feature flag to be enabled.
                                 Note that this field cannot be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
@@ -24180,7 +24169,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -24466,7 +24454,6 @@ spec:
                               procMount denotes the type of proc mount to use for the containers.
                               The default value is Default which uses the container runtime defaults for
                               readonly paths and masked paths.
-                              This requires the ProcMountType feature flag to be enabled.
                               Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
@@ -25527,7 +25514,6 @@ spec:
                                             procMount denotes the type of proc mount to use for the containers.
                                             The default value is Default which uses the container runtime defaults for
                                             readonly paths and masked paths.
-                                            This requires the ProcMountType feature flag to be enabled.
                                             Note that this field cannot be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
@@ -26723,7 +26709,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -26897,8 +26883,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-

--- a/helmcharts/next/templates/che-operator.Deployment.yaml
+++ b/helmcharts/next/templates/che-operator.Deployment.yaml
@@ -64,7 +64,7 @@ spec:
         - name: RELATED_IMAGE_che_tls_secrets_creation_job
           value: quay.io/eclipse/che-tls-secret-creator:9f9d4a6
         - name: RELATED_IMAGE_single_host_gateway
-          value: quay.io/eclipse/che--traefik:v3.7.5-d6858791f9e74df44ca4014166647c41cdc2abd3bf2a71b832ca4e1c6a91b257
+          value: quay.io/eclipse/che--traefik:v3.7.10-9c3b91d5fb7770853ca5c1124a23c34bf2d9b47ffaebeab2614cbaf410dcb2ac
         - name: RELATED_IMAGE_single_host_gateway_config_sidecar
           value: quay.io/che-incubator/configbump:next
         - name: RELATED_IMAGE_gateway_authentication_sidecar


### PR DESCRIPTION
### What does this PR do?

Bumps the Traefik gateway image from v3.7.5 to v3.7.10.

### Screenshot/screencast of this PR

N/A — dependency version bump, no UI changes.

### What issues does this PR fix or reference?

Routine dependency update to pick up the latest Traefik patch release.

### How to test this PR?

1. Deploy the operator:
 
#### OpenShift
```bash
./build/scripts/olm/test-catalog-from-sources.sh
```

or

```bash
build/scripts/docker-run.sh /bin/bash -c "
  oc login \
    --token=<...> \
    --server=<...> \
    --insecure-skip-tls-verify=true && \
  build/scripts/olm/test-catalog-from-sources.sh
"
```

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh
```

#### Common Test Scenarios
- [x] Deploy Eclipse Che
- [x] Start an empty workspace
- [x] Open terminal and build/run an image
- [x] Stop a workspace
- [x] Check operator logs for reconciliation errors or infinite reconciliation loops

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.