### PR TITLE
ci: Skip dependencies-validation when go.mod is unchanged 

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -110,5 +110,17 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check if go.mod changed
+        id: go-mod-check
+        run: |
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^go\.mod$'; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "go.mod has not changed, skipping dependencies validation."
+          fi
       - name: Check dependencies
+        if: steps.go-mod-check.outputs.changed == 'true'
         run: build/scripts/clear-defined-test.sh


### PR DESCRIPTION
### What does this PR do?

Skips the `dependencies-validation` CI job when `go.mod` has not been modified in the PR. The ClearlyDefined license check is expensive and unnecessary when no dependencies changed.

- Adds a step to diff `go.mod` against the base branch
- Conditionally runs `clear-defined-test.sh` only when `go.mod` changed
- Uses `fetch-depth: 0` to ensure full history is available for the diff

### Screenshot/screencast of this PR

N/A — CI-only change.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

1. Open a PR that does **not** modify `go.mod` — verify the `dependencies-validation` job shows the skip message and succeeds without running the license check.
2. Open a PR that **does** modify `go.mod` — verify the `dependencies-validation` job runs `clear-defined-test.sh` as before.

#### Common Test Scenarios
- [x] Check operator logs for reconciliation errors or infinite reconciliation loops

### PR Checklist

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)