### PR TITLE
fix: source nvm in chemuxer postStart to find node binary

### DIFF
--- a/editors-definitions/che-chemuxer-next.yaml
+++ b/editors-definitions/che-chemuxer-next.yaml
@@ -46,10 +46,11 @@ commands:
     exec:
       component: chemuxer-runtime
       commandLine: >-
+        bash -c 'source $HOME/.nvm/nvm.sh &&
         STATIC_DIR=/chemuxer-vol/dist/client
         HOST=0.0.0.0
         nohup node /chemuxer-vol/dist/server/server.js
-        > /chemuxer-vol/chemuxer.log 2>&1 &
+        > /chemuxer-vol/chemuxer.log 2>&1 &'
 events:
   preStart:
     - init-chemuxer-command


### PR DESCRIPTION
### What does this PR do?

Fixes chemuxer editor failing to start when selected from the dashboard. The `start-chemuxer-command` postStart runs `node` to launch the server, but `node` is not in PATH inside UDI's contributed container. Wrapping the command in `bash -c 'source $HOME/.nvm/nvm.sh && ...'` makes the node binary available.

### Root cause

- The chemuxer editor definition uses a `postStart` exec command to start `node /chemuxer-vol/dist/server/server.js`
- When the `chemuxer-runtime` component is merged into UDI via container contribution, the exec runs inside UDI's shell environment
- UDI installs node via nvm, which requires sourcing `$HOME/.nvm/nvm.sh` to add node to PATH
- Without sourcing nvm, the command fails silently: `nohup: failed to run command 'node': No such file or directory`

### How to test this PR

1. Deploy the operator with this change
2. Create a workspace from the dashboard selecting "Chemuxer" as editor
3. Verify the workspace reaches Running and chemuxer UI loads on port 7681

### Validated on

- Dogfooding cluster (`che-dev.x6e0.p1.openshiftapps.com`)
- Patched the DevWorkspaceTemplate directly, workspace started successfully with chemuxer listening on 7681

### PR Checklist

- [x] The Eclipse Contributor Agreement is valid
- [x] Code produced is complete
- [x] Code builds without errors