### PR TITLE
chore: convert k8s-helper to singleton pattern 

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -3,5 +3,6 @@
 - Use `test.NewCtxBuilder()` to create test `DeployContext` instances with a fake k8s client.
 - Use `infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)` or `infrastructure.Kubernetes` to set the platform. Use OpenShift when testing OpenShift-specific resources (e.g., network policies with `infrastructure.IsOpenShift()` guards).
 - Use `defaults.InitializeForTesting("../../config/manager/manager.yaml")` in `init_test.go` (adjust relative path) to load operator defaults for `GetCheFlavor()` and other defaults.
+- Use `k8shelper.InitializeForTesting()` in `init_test.go` to initialize helper.
 - Tests are co-located with source files (`*_test.go`). Test helpers live in `pkg/common/test/`.
 - Use `test.EnsureReconcile(t, ctx, reconciler.Reconcile)` to test reconcilers — it loops up to 10 iterations until `done=true` and fails if the reconciler never finishes.

--- a/api/init_test.go
+++ b/api/init_test.go
@@ -14,6 +14,7 @@ package org
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
 )
@@ -21,6 +22,7 @@ import (
 func init() {
 	test.EnableTestMode()
 
+	k8shelper.InitializeForTesting()
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)
 	defaults.InitializeForTesting("../config/manager/manager.yaml")
 }

--- a/api/v1/checluster_conversion_from.go
+++ b/api/v1/checluster_conversion_from.go
@@ -424,9 +424,9 @@ func (dst *CheCluster) convertFrom_Storage(src *chev2.CheCluster) error {
 
 // Finds TrustStore ConfigMap.
 func findTrustStoreConfigMap(namespace string) (string, error) {
-	k8sHelper := k8shelper.New()
+	k8sHelper := k8shelper.GetInstance()
 
-	_, err := k8sHelper.GetClientset().CoreV1().ConfigMaps(namespace).Get(context.TODO(), constants.DefaultCaBundleCertsCMName, metav1.GetOptions{})
+	_, err := k8sHelper.GetClientSet().CoreV1().ConfigMaps(namespace).Get(context.TODO(), constants.DefaultCaBundleCertsCMName, metav1.GetOptions{})
 	if err == nil {
 		// TrustStore ConfigMap with a default name exists
 		return constants.DefaultCaBundleCertsCMName, nil

--- a/api/v1/checluster_conversion_to.go
+++ b/api/v1/checluster_conversion_to.go
@@ -485,9 +485,9 @@ func parseSecurityContext(cheClusterV1 *CheCluster) (*int64, *int64, error) {
 // Create a secret with a user's credentials
 // Username and password are stored in `user` and `password` fields correspondingly.
 func createCredentialsSecret(username string, password string, secretName string, namespace string) error {
-	k8sHelper := k8shelper.New()
+	k8sHelper := k8shelper.GetInstance()
 
-	_, err := k8sHelper.GetClientset().CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	_, err := k8sHelper.GetClientSet().CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err == nil {
 		// Credentials secret already exists, we can't proceed
 		return fmt.Errorf("secret %s already exists", secretName)
@@ -507,7 +507,7 @@ func createCredentialsSecret(username string, password string, secretName string
 		},
 	}
 
-	if _, err := k8sHelper.GetClientset().CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+	if _, err := k8sHelper.GetClientSet().CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 
@@ -524,15 +524,15 @@ func renameTrustStoreConfigMapToDefault(trustStoreConfigMapName string, namespac
 		return nil
 	}
 
-	k8sHelper := k8shelper.New()
+	k8sHelper := k8shelper.GetInstance()
 
-	_, err := k8sHelper.GetClientset().CoreV1().ConfigMaps(namespace).Get(context.TODO(), constants.DefaultCaBundleCertsCMName, metav1.GetOptions{})
+	_, err := k8sHelper.GetClientSet().CoreV1().ConfigMaps(namespace).Get(context.TODO(), constants.DefaultCaBundleCertsCMName, metav1.GetOptions{})
 	if err == nil {
 		// ConfigMap with a default name already exists, we can't proceed
 		return fmt.Errorf("TrustStore ConfigMap %s already exists", constants.DefaultCaBundleCertsCMName)
 	}
 
-	existedTrustStoreConfigMap, err := k8sHelper.GetClientset().CoreV1().ConfigMaps(namespace).Get(context.TODO(), trustStoreConfigMapName, metav1.GetOptions{})
+	existedTrustStoreConfigMap, err := k8sHelper.GetClientSet().CoreV1().ConfigMaps(namespace).Get(context.TODO(), trustStoreConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// ConfigMap not found, nothing to rename
@@ -561,12 +561,12 @@ func renameTrustStoreConfigMapToDefault(trustStoreConfigMapName string, namespac
 	}
 
 	// Create TrustStore ConfigMap with a default name
-	if _, err = k8sHelper.GetClientset().CoreV1().ConfigMaps(namespace).Create(context.TODO(), newTrustStoreConfigMap, metav1.CreateOptions{}); err != nil {
+	if _, err = k8sHelper.GetClientSet().CoreV1().ConfigMaps(namespace).Create(context.TODO(), newTrustStoreConfigMap, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 
 	// Delete legacy TrustStore ConfigMap
-	if err = k8sHelper.GetClientset().CoreV1().ConfigMaps(namespace).Delete(context.TODO(), trustStoreConfigMapName, metav1.DeleteOptions{}); err != nil {
+	if err = k8sHelper.GetClientSet().CoreV1().ConfigMaps(namespace).Delete(context.TODO(), trustStoreConfigMapName, metav1.DeleteOptions{}); err != nil {
 		return err
 	}
 

--- a/api/v2/checluster_webhook.go
+++ b/api/v2/checluster_webhook.go
@@ -124,7 +124,7 @@ func (r *CheClusterValidator) ValidateDelete(_ context.Context, _ *CheCluster) (
 }
 
 func (r *CheClusterValidator) ensureSingletonCheCluster() error {
-	client := k8shelper.New().GetClient()
+	client := k8shelper.GetInstance().GetClient()
 	utilruntime.Must(AddToScheme(client.Scheme()))
 
 	che := &CheClusterList{}
@@ -177,8 +177,8 @@ func (r *CheClusterValidator) validateOAuthSecret(secretName string, scmProvider
 		return nil
 	}
 
-	k8sHelper := k8shelper.New()
-	secret, err := k8sHelper.GetClientset().CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+	k8sHelper := k8shelper.GetInstance()
+	secret, err := k8sHelper.GetClientSet().CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return fmt.Errorf("secret '%s' not found", secretName)
@@ -264,9 +264,9 @@ func (r *CheClusterValidator) ensureScmLabelsAndAnnotations(secret *corev1.Secre
 	}
 
 	patchData, _ := json.Marshal(patch)
-	k8sHelper := k8shelper.New()
+	k8sHelper := k8shelper.GetInstance()
 	if _, err := k8sHelper.
-		GetClientset().
+		GetClientSet().
 		CoreV1().
 		Secrets(secret.Namespace).
 		Patch(context.TODO(), secret.Name, types.MergePatchType, patchData, metav1.PatchOptions{}); err != nil {
@@ -298,9 +298,9 @@ func (r *CheClusterValidator) validateOpenVSXRegistry(checluster *CheCluster) er
 	if checluster.Spec.Components.OpenVSXRegistry.CredentialsSecretName != nil {
 		credentialsSecretName := *checluster.Spec.Components.OpenVSXRegistry.CredentialsSecretName
 
-		k8sHelper := k8shelper.New()
+		k8sHelper := k8shelper.GetInstance()
 		secret, err := k8sHelper.
-			GetClientset().
+			GetClientSet().
 			CoreV1().
 			Secrets(checluster.Namespace).
 			Get(context.TODO(), credentialsSecretName, metav1.GetOptions{})

--- a/api/v2/checluster_webhook_test.go
+++ b/api/v2/checluster_webhook_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestValidateScmSecrets(t *testing.T) {
-	k8sHelper := k8shelper.New()
+	k8sHelper := k8shelper.GetInstance()
 
 	githubSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -36,7 +36,7 @@ func TestValidateScmSecrets(t *testing.T) {
 			"secret": []byte("secret"),
 		},
 	}
-	_, err := k8sHelper.GetClientset().CoreV1().Secrets("eclipse-che").Create(context.TODO(), githubSecret, metav1.CreateOptions{})
+	_, err := k8sHelper.GetClientSet().CoreV1().Secrets("eclipse-che").Create(context.TODO(), githubSecret, metav1.CreateOptions{})
 	assert.Nil(t, err)
 
 	gitlabSecret := &corev1.Secret{
@@ -52,7 +52,7 @@ func TestValidateScmSecrets(t *testing.T) {
 			"secret": []byte("secret"),
 		},
 	}
-	_, err = k8sHelper.GetClientset().CoreV1().Secrets("eclipse-che").Create(context.TODO(), gitlabSecret, metav1.CreateOptions{})
+	_, err = k8sHelper.GetClientSet().CoreV1().Secrets("eclipse-che").Create(context.TODO(), gitlabSecret, metav1.CreateOptions{})
 	assert.Nil(t, err)
 
 	bitbucketSecret := &corev1.Secret{
@@ -65,7 +65,7 @@ func TestValidateScmSecrets(t *testing.T) {
 			"consumer.key": []byte("secret"),
 		},
 	}
-	_, err = k8sHelper.GetClientset().CoreV1().Secrets("eclipse-che").Create(context.TODO(), bitbucketSecret, metav1.CreateOptions{})
+	_, err = k8sHelper.GetClientSet().CoreV1().Secrets("eclipse-che").Create(context.TODO(), bitbucketSecret, metav1.CreateOptions{})
 	assert.Nil(t, err)
 
 	checluster := &CheCluster{
@@ -101,21 +101,21 @@ func TestValidateScmSecrets(t *testing.T) {
 	_, err = cheClusterValidator.ValidateCreate(context.TODO(), checluster)
 	assert.Nil(t, err)
 
-	githubSecret, err = k8sHelper.GetClientset().CoreV1().Secrets("eclipse-che").Get(context.TODO(), "github-scm-secret", metav1.GetOptions{})
+	githubSecret, err = k8sHelper.GetClientSet().CoreV1().Secrets("eclipse-che").Get(context.TODO(), "github-scm-secret", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, "github", githubSecret.Annotations[constants.CheEclipseOrgOAuthScmServer])
 	assert.Equal(t, "github-endpoint", githubSecret.Annotations[constants.CheEclipseOrgScmServerEndpoint])
 	assert.Equal(t, constants.OAuthScmConfiguration, githubSecret.Labels[constants.KubernetesComponentLabelKey])
 	assert.Equal(t, constants.CheEclipseOrg, githubSecret.Labels[constants.KubernetesPartOfLabelKey])
 
-	gitlabSecret, err = k8sHelper.GetClientset().CoreV1().Secrets("eclipse-che").Get(context.TODO(), "gitlab-scm-secret", metav1.GetOptions{})
+	gitlabSecret, err = k8sHelper.GetClientSet().CoreV1().Secrets("eclipse-che").Get(context.TODO(), "gitlab-scm-secret", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, "gitlab", gitlabSecret.Annotations[constants.CheEclipseOrgOAuthScmServer])
 	assert.Equal(t, "gitlab-endpoint-secret", gitlabSecret.Annotations[constants.CheEclipseOrgScmServerEndpoint])
 	assert.Equal(t, constants.OAuthScmConfiguration, gitlabSecret.Labels[constants.KubernetesComponentLabelKey])
 	assert.Equal(t, constants.CheEclipseOrg, gitlabSecret.Labels[constants.KubernetesPartOfLabelKey])
 
-	bitbucketSecret, err = k8sHelper.GetClientset().CoreV1().Secrets("eclipse-che").Get(context.TODO(), "bitbucket-scm-secret", metav1.GetOptions{})
+	bitbucketSecret, err = k8sHelper.GetClientSet().CoreV1().Secrets("eclipse-che").Get(context.TODO(), "bitbucket-scm-secret", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, "bitbucket", bitbucketSecret.Annotations[constants.CheEclipseOrgOAuthScmServer])
 	assert.Empty(t, bitbucketSecret.Annotations[constants.CheEclipseOrgScmServerEndpoint])
@@ -196,7 +196,7 @@ func TestValidateOpenVSXSDatabaseClaimSizeInvalid(t *testing.T) {
 }
 
 func TestValidateOpenVSXCredentialsSecret(t *testing.T) {
-	k8sHelper := k8shelper.New()
+	k8sHelper := k8shelper.GetInstance()
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -213,7 +213,7 @@ func TestValidateOpenVSXCredentialsSecret(t *testing.T) {
 			"openvsx-admin-token":     []byte("admin-token"),
 		},
 	}
-	_, err := k8sHelper.GetClientset().CoreV1().Secrets("eclipse-che").Create(context.TODO(), secret, metav1.CreateOptions{})
+	_, err := k8sHelper.GetClientSet().CoreV1().Secrets("eclipse-che").Create(context.TODO(), secret, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	cheClusterValidator := CheClusterValidator{}
@@ -237,7 +237,7 @@ func TestValidateOpenVSXCredentialsSecret(t *testing.T) {
 }
 
 func TestValidateOpenVSXCredentialsSecretMissingKeys(t *testing.T) {
-	k8sHelper := k8shelper.New()
+	k8sHelper := k8shelper.GetInstance()
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -248,7 +248,7 @@ func TestValidateOpenVSXCredentialsSecretMissingKeys(t *testing.T) {
 			"database-user": []byte("user"),
 		},
 	}
-	_, err := k8sHelper.GetClientset().CoreV1().Secrets("eclipse-che").Create(context.TODO(), secret, metav1.CreateOptions{})
+	_, err := k8sHelper.GetClientSet().CoreV1().Secrets("eclipse-che").Create(context.TODO(), secret, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	cheClusterValidator := CheClusterValidator{}
@@ -300,8 +300,8 @@ func TestValidateScmSecretsShouldThrowError(t *testing.T) {
 		},
 	}
 
-	k8sHelper := k8shelper.New()
-	_, err = k8sHelper.GetClientset().CoreV1().Secrets("eclipse-che").Create(context.TODO(), githubSecret, metav1.CreateOptions{})
+	k8sHelper := k8shelper.GetInstance()
+	_, err = k8sHelper.GetClientSet().CoreV1().Secrets("eclipse-che").Create(context.TODO(), githubSecret, metav1.CreateOptions{})
 	assert.Nil(t, err)
 
 	_, err = cheClusterValidator.ValidateCreate(context.TODO(), checluster)

--- a/api/v2/init_test.go
+++ b/api/v2/init_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019-2023 Red Hat, Inc.
+// Copyright (c) 2019-2026 Red Hat, Inc.
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
 // which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -10,19 +10,12 @@
 //   Red Hat, Inc. - initial API and implementation
 //
 
-package solver
+package v2
 
 import (
-	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
-	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
-	"github.com/eclipse-che/che-operator/pkg/common/test"
 	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
 	k8shelper.InitializeForTesting()
-	test.EnableTestMode()
-
-	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)
-	defaults.InitializeForTesting("../../../config/manager/manager.yaml")
 }

--- a/api/v2/zz_generated.deepcopy.go
+++ b/api/v2/zz_generated.deepcopy.go
@@ -19,7 +19,7 @@ package v2
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/api/v2/zz_generated.deepcopy.go
+++ b/api/v2/zz_generated.deepcopy.go
@@ -19,7 +19,7 @@ package v2
 import (
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/devworkspace-operator/apis/controller/v1alpha1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ import (
 
 	dwInfra "github.com/devfile/devworkspace-operator/pkg/infrastructure"
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	userv1 "github.com/openshift/api/user/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -205,6 +206,11 @@ func getWatchNamespace() (string, error) {
 func main() {
 	if err := dwInfra.Initialize(); err != nil {
 		setupLog.Error(err, "Failed to initialize infrastructure")
+		os.Exit(1)
+	}
+
+	if err := k8shelper.Initialize(); err != nil {
+		setupLog.Error(err, "Failed to initialize Kubernetes helper")
 		os.Exit(1)
 	}
 

--- a/controllers/devworkspace/solver/init_test.go
+++ b/controllers/devworkspace/solver/init_test.go
@@ -14,9 +14,9 @@ package solver
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/controllers/namespacecache/init_test.go
+++ b/controllers/namespacecache/init_test.go
@@ -14,9 +14,9 @@ package namespacecache
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/controllers/namespacecache/init_test.go
+++ b/controllers/namespacecache/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/controllers/usernamespace/init_test.go
+++ b/controllers/usernamespace/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/controllers/usernamespace/init_test.go
+++ b/controllers/usernamespace/init_test.go
@@ -14,9 +14,9 @@ package usernamespace
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/controllers/workspaceconfig/init_test.go
+++ b/controllers/workspaceconfig/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/controllers/workspaceconfig/init_test.go
+++ b/controllers/workspaceconfig/init_test.go
@@ -14,9 +14,9 @@ package workspace_config
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/common/k8s-helper/k8s_helper.go
+++ b/pkg/common/k8s-helper/k8s_helper.go
@@ -18,14 +18,12 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/kubernetes/fake"
-
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 type K8sHelper struct {
@@ -37,62 +35,6 @@ type K8sHelper struct {
 var (
 	k8sHelper *K8sHelper
 )
-
-func GetInstance() *K8sHelper {
-	return k8sHelper
-}
-
-func isInitialized() bool {
-	return k8sHelper != nil
-}
-
-func (k *K8sHelper) GetClientSet() kubernetes.Interface {
-	if !isInitialized() {
-		panic("Kubernetes helper is not initialized")
-	}
-
-	return k.clientSet
-}
-
-func (k *K8sHelper) GetClient() client.Client {
-	if !isInitialized() {
-		panic("Kubernetes helper is not initialized")
-	}
-
-	return k.client
-}
-
-func (k *K8sHelper) GetDiscoveryClient() discovery.DiscoveryInterface {
-	if !isInitialized() {
-		panic("Kubernetes helper is not initialized")
-	}
-
-	return k.discoveryClient
-}
-
-func (k *K8sHelper) GetPodsByComponent(name string, ns string) []string {
-	names := []string{}
-	api := k.clientSet.CoreV1()
-	listOptions := metav1.ListOptions{
-		LabelSelector: "component=" + name,
-	}
-	podList, _ := api.Pods(ns).List(context.TODO(), listOptions)
-	for _, pod := range podList.Items {
-		names = append(names, pod.Name)
-	}
-
-	return names
-}
-
-func InitializeForTesting() {
-	clientSet := fake.NewSimpleClientset()
-
-	k8sHelper = &K8sHelper{
-		clientSet:       clientSet,
-		client:          fakeclient.NewClientBuilder().Build(),
-		discoveryClient: clientSet.Discovery(),
-	}
-}
 
 func Initialize() error {
 	cfg, err := config.GetConfig()
@@ -117,4 +59,52 @@ func Initialize() error {
 	}
 
 	return nil
+}
+
+func InitializeForTesting() {
+	clientSet := fake.NewSimpleClientset()
+
+	k8sHelper = &K8sHelper{
+		clientSet:       clientSet,
+		client:          fakeclient.NewClientBuilder().Build(),
+		discoveryClient: clientSet.Discovery(),
+	}
+}
+
+func GetInstance() *K8sHelper {
+	if !isInitialized() {
+		panic("Kubernetes helper is not initialized")
+	}
+
+	return k8sHelper
+}
+
+func (k *K8sHelper) GetClientSet() kubernetes.Interface {
+	return k.clientSet
+}
+
+func (k *K8sHelper) GetClient() client.Client {
+	return k.client
+}
+
+func (k *K8sHelper) GetDiscoveryClient() discovery.DiscoveryInterface {
+	return k.discoveryClient
+}
+
+func (k *K8sHelper) GetPodsByComponent(name string, ns string) []string {
+	names := []string{}
+	api := k.clientSet.CoreV1()
+	listOptions := metav1.ListOptions{
+		LabelSelector: "component=" + name,
+	}
+	podList, _ := api.Pods(ns).List(context.TODO(), listOptions)
+	for _, pod := range podList.Items {
+		names = append(names, pod.Name)
+	}
+
+	return names
+}
+
+func isInitialized() bool {
+	return k8sHelper != nil
 }

--- a/pkg/common/k8s-helper/k8s_helper.go
+++ b/pkg/common/k8s-helper/k8s_helper.go
@@ -14,52 +14,65 @@ package k8shelper
 
 import (
 	"context"
-	"os"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 type K8sHelper struct {
-	clientset kubernetes.Interface
-	client    client.Client
+	client          client.Client
+	clientSet       kubernetes.Interface
+	discoveryClient discovery.DiscoveryInterface
 }
 
 var (
 	k8sHelper *K8sHelper
 )
 
-func New() *K8sHelper {
-	if k8sHelper != nil {
-		return k8sHelper
+func GetInstance() *K8sHelper {
+	return k8sHelper
+}
+
+func isInitialized() bool {
+	return k8sHelper != nil
+}
+
+func (k *K8sHelper) GetClientSet() kubernetes.Interface {
+	if !isInitialized() {
+		panic("Kubernetes helper is not initialized")
 	}
 
-	if isTestMode() {
-		return initializeForTesting()
+	return k.clientSet
+}
+
+func (k *K8sHelper) GetClient() client.Client {
+	if !isInitialized() {
+		panic("Kubernetes helper is not initialized")
 	}
 
-	return initialize()
+	return k.client
 }
 
-func (cl *K8sHelper) GetClientset() kubernetes.Interface {
-	return cl.clientset
+func (k *K8sHelper) GetDiscoveryClient() discovery.DiscoveryInterface {
+	if !isInitialized() {
+		panic("Kubernetes helper is not initialized")
+	}
+
+	return k.discoveryClient
 }
 
-func (cl *K8sHelper) GetClient() client.Client {
-	return cl.client
-}
-
-func (cl *K8sHelper) GetPodsByComponent(name string, ns string) []string {
+func (k *K8sHelper) GetPodsByComponent(name string, ns string) []string {
 	names := []string{}
-	api := cl.clientset.CoreV1()
+	api := k.clientSet.CoreV1()
 	listOptions := metav1.ListOptions{
 		LabelSelector: "component=" + name,
 	}
@@ -71,38 +84,37 @@ func (cl *K8sHelper) GetPodsByComponent(name string, ns string) []string {
 	return names
 }
 
-func initializeForTesting() *K8sHelper {
-	k8sHelper = &K8sHelper{
-		clientset: fake.NewSimpleClientset(),
-		client:    fakeclient.NewClientBuilder().Build(),
-	}
+func InitializeForTesting() {
+	clientSet := fake.NewSimpleClientset()
 
-	return k8sHelper
+	k8sHelper = &K8sHelper{
+		clientSet:       clientSet,
+		client:          fakeclient.NewClientBuilder().Build(),
+		discoveryClient: clientSet.Discovery(),
+	}
 }
 
-func initialize() *K8sHelper {
+func Initialize() error {
 	cfg, err := config.GetConfig()
 	if err != nil {
-		logrus.Fatalf("Failed to initialized Kubernetes client: %v", err)
+		return fmt.Errorf("failed to get Kubernetes config: %w", err)
 	}
 
 	clientSet, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		logrus.Fatalf("Failed to initialized Kubernetes client: %v", err)
+		return fmt.Errorf("failed to get Kubernetes client: %w", err)
 	}
 
 	client, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
 	if err != nil {
-		logrus.Fatalf("Failed to initialized Kubernetes client: %v", err)
+		return fmt.Errorf("failed to get Kubernetes client: %w", err)
 	}
 
 	k8sHelper = &K8sHelper{
-		clientset: clientSet,
-		client:    client,
+		client:          client,
+		clientSet:       clientSet,
+		discoveryClient: clientSet.Discovery(),
 	}
 
-	return k8sHelper
-}
-func isTestMode() bool {
-	return len(os.Getenv("MOCK_API")) != 0
+	return nil
 }

--- a/pkg/deploy/consolelink/init_test.go
+++ b/pkg/deploy/consolelink/init_test.go
@@ -14,9 +14,9 @@ package consolelink
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/consolelink/init_test.go
+++ b/pkg/deploy/consolelink/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/container-capabilities/init_test.go
+++ b/pkg/deploy/container-capabilities/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/container-capabilities/init_test.go
+++ b/pkg/deploy/container-capabilities/init_test.go
@@ -14,9 +14,9 @@ package containercapabilities
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/dashboard/init_test.go
+++ b/pkg/deploy/dashboard/init_test.go
@@ -14,9 +14,9 @@ package dashboard
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/dashboard/init_test.go
+++ b/pkg/deploy/dashboard/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/deployment.go
+++ b/pkg/deploy/deployment.go
@@ -236,7 +236,7 @@ func OverrideContainer(
 	// See details at https://github.com/eclipse/che/issues/22198
 	if overrideSettings == nil || overrideSettings.Resources == nil || overrideSettings.Resources.Limits == nil || overrideSettings.Resources.Limits.Cpu == nil {
 		// use NonCachedClient to avoid cache LimitRange objects
-		if limitRanges, err := k8shelper.New().GetClientset().CoreV1().LimitRanges(namespace).List(context.TODO(), metav1.ListOptions{}); err != nil {
+		if limitRanges, err := k8shelper.GetInstance().GetClientSet().CoreV1().LimitRanges(namespace).List(context.TODO(), metav1.ListOptions{}); err != nil {
 			return err
 		} else if len(limitRanges.Items) == 0 { // no LimitRange in the namespace
 			delete(container.Resources.Limits, corev1.ResourceCPU)

--- a/pkg/deploy/deployment_test.go
+++ b/pkg/deploy/deployment_test.go
@@ -1285,10 +1285,10 @@ func TestOverrideContainerCpuLimit(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			k8sHelper := k8shelper.New()
+			k8sHelper := k8shelper.GetInstance()
 
 			if testCase.limitRange != nil {
-				_, err := k8sHelper.GetClientset().CoreV1().LimitRanges("eclipse-che").Create(context.TODO(), testCase.limitRange, metav1.CreateOptions{})
+				_, err := k8sHelper.GetClientSet().CoreV1().LimitRanges("eclipse-che").Create(context.TODO(), testCase.limitRange, metav1.CreateOptions{})
 				assert.NoError(t, err)
 			}
 
@@ -1303,7 +1303,7 @@ func TestOverrideContainerCpuLimit(t *testing.T) {
 
 			defer func() {
 				if testCase.limitRange != nil {
-					err := k8sHelper.GetClientset().CoreV1().LimitRanges("eclipse-che").Delete(context.TODO(), testCase.limitRange.Name, metav1.DeleteOptions{})
+					err := k8sHelper.GetClientSet().CoreV1().LimitRanges("eclipse-che").Delete(context.TODO(), testCase.limitRange.Name, metav1.DeleteOptions{})
 					assert.NoError(t, err)
 				}
 			}()

--- a/pkg/deploy/devfileregistry/init_test.go
+++ b/pkg/deploy/devfileregistry/init_test.go
@@ -14,9 +14,9 @@ package devfileregistry
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/devfileregistry/init_test.go
+++ b/pkg/deploy/devfileregistry/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/devworkspace/init_test.go
+++ b/pkg/deploy/devworkspace/init_test.go
@@ -14,9 +14,9 @@ package devworkspace
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/devworkspace/init_test.go
+++ b/pkg/deploy/devworkspace/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/editors-definitions/init_test.go
+++ b/pkg/deploy/editors-definitions/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/editors-definitions/init_test.go
+++ b/pkg/deploy/editors-definitions/init_test.go
@@ -14,9 +14,9 @@ package editorsdefinitions
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/gateway/init_test.go
+++ b/pkg/deploy/gateway/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/gateway/init_test.go
+++ b/pkg/deploy/gateway/init_test.go
@@ -14,9 +14,9 @@ package gateway
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/identity-provider/init_test.go
+++ b/pkg/deploy/identity-provider/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/identity-provider/init_test.go
+++ b/pkg/deploy/identity-provider/init_test.go
@@ -14,9 +14,9 @@ package identityprovider
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/image-puller/init_test.go
+++ b/pkg/deploy/image-puller/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/image-puller/init_test.go
+++ b/pkg/deploy/image-puller/init_test.go
@@ -14,9 +14,9 @@ package imagepuller
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/init_test.go
+++ b/pkg/deploy/init_test.go
@@ -14,9 +14,9 @@ package deploy
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/init_test.go
+++ b/pkg/deploy/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/metrics/init_test.go
+++ b/pkg/deploy/metrics/init_test.go
@@ -14,9 +14,9 @@ package metrics
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/metrics/init_test.go
+++ b/pkg/deploy/metrics/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/migration/init_test.go
+++ b/pkg/deploy/migration/init_test.go
@@ -14,9 +14,9 @@ package migration
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/migration/init_test.go
+++ b/pkg/deploy/migration/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/networkpolicies/init_test.go
+++ b/pkg/deploy/networkpolicies/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/networkpolicies/init_test.go
+++ b/pkg/deploy/networkpolicies/init_test.go
@@ -14,9 +14,9 @@ package networkpolicies
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/openvsx/init_test.go
+++ b/pkg/deploy/openvsx/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/openvsx/init_test.go
+++ b/pkg/deploy/openvsx/init_test.go
@@ -14,9 +14,9 @@ package openvsx
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/openvsx/openvsx-database/init_test.go
+++ b/pkg/deploy/openvsx/openvsx-database/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/openvsx/openvsx-database/init_test.go
+++ b/pkg/deploy/openvsx/openvsx-database/init_test.go
@@ -14,9 +14,9 @@ package openvsx_database
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/openvsx/openvsx-server/init_test.go
+++ b/pkg/deploy/openvsx/openvsx-server/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/openvsx/openvsx-server/init_test.go
+++ b/pkg/deploy/openvsx/openvsx-server/init_test.go
@@ -14,9 +14,9 @@ package openvsx_server
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/pluginregistry/init_test.go
+++ b/pkg/deploy/pluginregistry/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/pluginregistry/init_test.go
+++ b/pkg/deploy/pluginregistry/init_test.go
@@ -14,9 +14,9 @@ package pluginregistry
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/rbac/init_test.go
+++ b/pkg/deploy/rbac/init_test.go
@@ -14,9 +14,9 @@ package rbac
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/rbac/init_test.go
+++ b/pkg/deploy/rbac/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/server/init_test.go
+++ b/pkg/deploy/server/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/server/init_test.go
+++ b/pkg/deploy/server/init_test.go
@@ -14,9 +14,9 @@ package server
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/tls/init_test.go
+++ b/pkg/deploy/tls/init_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {
+	k8shelper.InitializeForTesting()
 	test.EnableTestMode()
 
 	infrastructure.InitializeForTesting(infrastructure.OpenShiftV4)

--- a/pkg/deploy/tls/init_test.go
+++ b/pkg/deploy/tls/init_test.go
@@ -14,9 +14,9 @@ package tls
 
 import (
 	"github.com/eclipse-che/che-operator/pkg/common/infrastructure"
+	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 	defaults "github.com/eclipse-che/che-operator/pkg/common/operator-defaults"
 	"github.com/eclipse-che/che-operator/pkg/common/test"
-	k8shelper "github.com/eclipse-che/che-operator/pkg/common/k8s-helper"
 )
 
 func init() {

--- a/pkg/deploy/tls/tls_utils.go
+++ b/pkg/deploy/tls/tls_utils.go
@@ -494,7 +494,7 @@ func isCheCASecretValid(cheCASelfSignedCertificateSecret *corev1.Secret) bool {
 }
 
 func deleteJob(ctx *chetypes.DeployContext, job *batchv1.Job) {
-	k8sHelper := k8shelper.New()
+	k8sHelper := k8shelper.GetInstance()
 	names := k8sHelper.GetPodsByComponent(CheTLSJobComponentName, ctx.CheCluster.Namespace)
 	for _, podName := range names {
 		pod := &corev1.Pod{}


### PR DESCRIPTION
Refactors the k8s-helper package from factory pattern (`New()`) to singleton pattern (`GetInstance()`) to ensure consistent initialization across the codebase.

Changes:
- Rename `New()` → `GetInstance()`
- Rename `GetClientset()` → `GetClientSet()` (capitalization fix)
- Rename `initializeForTesting()` → `InitializeForTesting()` (export)
- Add `GetDiscoveryClient()` method for discovery API access
- Add initialization checks with panic guards
- Add `k8shelper.InitializeForTesting()` to all test packages
- Update documentation in `.claude/rules/testing.md`

The singleton pattern prevents multiple k8s client instances and ensures proper test initialization order across all packages.

Assisted-by: Claude Sonnet 4.6

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse-che/che-operator/#development
-->

### What does this PR do?


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, docker-desktop, etc)
  - steps to reproduce
 -->

1. Deploy the operator:
 
#### OpenShift
```bash
oc create namespace devworkspace-controller
oc apply --server-side -f https://raw.githubusercontent.com/devfile/devworkspace-operator/refs/heads/main/deploy/deployment/openshift/combined.yaml

OPERATOR_IMAGE=<...>
sed 's|quay.io/eclipse/che-operator:next|'${OPERATOR_IMAGE}'|g' deploy/deployment/openshift/combined.yaml | oc apply --server-side -f  -
oc apply --server-side -f deploy/deployment/openshift/org_v2_checluster.yaml
oc wait checluster eclipse-che -n eclipse-che --for=jsonpath='.status.chePhase'=Active   --timeout=120s
```

#### on Minikube

```bash
./build/scripts/minikube-tests/test-operator-from-sources.sh
```

#### Common Test Scenarios
- [ ] Deploy Eclipse Che
- [ ] Start an empty workspace
- [ ] Open terminal and build/run an image
- [ ] Stop a workspace
- [ ] Check operator logs for reconciliation errors or infinite reconciliation loops

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
